### PR TITLE
Reorganize spatial verification scores in the intensity-scale group

### DIFF
--- a/pysteps/verification/plots.py
+++ b/pysteps/verification/plots.py
@@ -5,7 +5,7 @@ from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 import numpy as np
 from . import ensscores, probscores
 
-def plot_intensityscale(iss, fig=None, vmin=-2, vmax=1, kmperpixel=None):
+def plot_intensityscale(iss, fig=None, vmin=-2, vmax=1, kmperpixel=None, unit=None):
     """Plot a intensity-scale verification table with a color bar and axis
     labels.
 
@@ -26,6 +26,8 @@ def plot_intensityscale(iss, fig=None, vmin=-2, vmax=1, kmperpixel=None):
     kmperpixel : float
        Optional conversion factor from pixels to kilometers. If supplied,
        the unit of the shown spatial scales is km instead of pixels.
+    unit : string
+       Optional unit of the intensity thresholds.
 
     """
     if fig is None:
@@ -36,13 +38,16 @@ def plot_intensityscale(iss, fig=None, vmin=-2, vmax=1, kmperpixel=None):
     im = ax.imshow(iss["SS"], vmin=vmin, vmax=vmax, interpolation="nearest",
                    cmap=cm.jet)
     cb = fig.colorbar(im)
-    cb.set_label("Binary MSE skill score")
+    cb.set_label(iss["label"])
 
-    ax.set_xlabel("Intensity threshold (dBZ)")
-    if kmperpixel is None:
-        ax.set_ylabel("Spatial scale (pixels)")
+    if unit is None:
+        ax.set_xlabel("Intensity threshold")
     else:
-        ax.set_ylabel("Spatial scale (km)")
+        ax.set_xlabel("Intensity threshold [%s]" % unit)
+    if kmperpixel is None:
+        ax.set_ylabel("Spatial scale [pixels]")
+    else:
+        ax.set_ylabel("Spatial scale [km]")
 
     ax.set_xticks(np.arange(iss["SS"].shape[1]))
     ax.set_xticklabels(iss["thrs"])

--- a/pysteps/verification/spatialscores.py
+++ b/pysteps/verification/spatialscores.py
@@ -8,6 +8,209 @@ try:
 except ImportError:
   pywt_imported = False
 
+def intensity_scale_init(name, thrs, scales=None, wavelet="Haar"):
+    """Initialize an intensty-scale verification object.
+
+    Parameters
+    ----------
+    score_names : string
+        A string indicating the name of the spatial verification score to be used:
+
+        +------------+--------------------------------------------------------+
+        | Name       | Description                                            |
+        +============+========================================================+
+        |  FSS       | Fractions skill score                                  |
+        +------------+--------------------------------------------------------+
+        |  BMSE      | Binary mean squared error                              |
+        +------------+--------------------------------------------------------+
+
+    thrs : sequence
+        A sequence of intensity thresholds for which to compute the verification.
+    scales : sequence
+        A sequence of spatial scales in pixels to be used in the FSS.
+    wavelet : str
+        The name of the wavelet function to use in the BMSE. Defaults to the Haar
+        wavelet, as described in Casati et al. 2004. See the documentation of
+        PyWavelets for a list of available options.
+
+    Returns
+    -------
+    iss : dict
+        The intensity-scale object.
+
+    """
+
+    iss = {}
+    iss["name"]    = name
+    iss["SS"]      = None
+    iss["thrs"]    = thrs[:]
+    iss["scales"]  = scales
+    iss["wavelet"] = wavelet
+    iss["n"]       = None
+    iss["shape"]   = None
+    if name.lower() == "fss":
+        iss["label"]   = "Fractions skill score"
+        del iss["wavelet"]
+    if name.lower() == "bmse":
+        iss["label"]  = "Binary MSE skill score"
+        iss["scales"] = None
+    if name.lower() == "fss" and scales is None:
+        raise ValueError("a sequence of scales must be provided for the FSS, but %s was passed" % scales)
+
+    return iss
+
+def intensity_scale_accum(iss, X_f, X_o):
+    """Compute and update the intensity-scale verification scores.
+
+    Parameters
+    ----------
+    iss : dict
+        An intensity-scale object created with intensity_scale_init.
+    X_f : array_like
+        Array of shape (n,m) containing the forecast field.
+    X_o : array_like
+        Array of shape (n,m) containing the verification observation field.
+
+    Returns
+    -------
+    iss : dict
+        A dictionary with the following key-value pairs:
+
+        +--------------+------------------------------------------------------+
+        |       Key    |                Value                                 |
+        +==============+======================================================+
+        |  name        | the name of the intensity-scale skill score          |
+        +--------------+------------------------------------------------------+
+        |  SS          | two-dimensional array containing the intensity-scale |
+        |              | skill scores for each spatial scale and intensity    |
+        |              | threshold                                            |
+        +--------------+------------------------------------------------------+
+        |  scales      | the spatial scales,                                  |
+        |              | corresponds to the first index of SS                 |
+        +--------------+------------------------------------------------------+
+        |  thrs        | the used intensity thresholds in increasing order,   |
+        |              | corresponds to the second index of SS                |
+        +--------------+------------------------------------------------------+
+        |  n           | the number of verified fct-obs pairs that were       |
+        |              | averaged                                             |
+        +--------------+------------------------------------------------------+
+        |  shape       | the shape of the fct-obs fields                      |
+        +--------------+------------------------------------------------------+
+    """
+
+    if len(X_f.shape) != 2 or len(X_o.shape) != 2 or X_f.shape != X_o.shape:
+        raise ValueError("X_f and X_o must be two-dimensional arrays having the same shape, but X_f = %s amd X_o = %s" % (str(X_f.shape), str(X_o.shape)))
+
+    if iss["shape"] is not None and X_f.shape != iss["shape"]:
+        raise ValueError("X_f and X_o shapes do not match the shape of the intensity-scale object")
+
+    if iss["shape"] is None:
+        iss["shape"] = X_f.shape
+
+    thrs = iss["thrs"]
+    thr_min = np.min(thrs)
+    n_thrs = len(thrs)
+
+    X_f = X_f.copy()
+    X_f[~np.isfinite(X_f)] = thr_min - 1
+    X_o = X_o.copy()
+    X_o[~np.isfinite(X_o)] = thr_min - 1
+
+    if iss["name"].lower() == "bmse":
+
+        SS = None
+        n_thrs = len(thrs)
+        for i in range(n_thrs):
+            SS_, scales = binary_mse(X_f, X_o, thrs[i], iss["wavelet"])
+            if SS is None:
+                SS = np.empty((SS_.size, n_thrs))
+            SS[:, i] = SS_
+
+        if iss["scales"] is None:
+            iss["scales"] = scales
+
+    elif iss["name"].lower() == "fss":
+        scales = iss["scales"]
+        n_scales = len(scales)
+        SS = np.empty((n_scales, n_thrs))
+        for i in range(n_thrs):
+            for j in range(n_scales):
+                SS[j, i] = fss(X_f, X_o, thrs[i], scales[j])
+
+    else:
+        raise ValueError("unknown method %s" % iss["name"])
+
+    # update scores
+    if iss["n"] is None:
+        iss["n"] = np.ones(SS.shape, dtype=int)
+    iss["n"] += (~np.isnan(SS)).astype(int)
+
+    if iss["SS"] is None:
+        iss["SS"] = SS
+    else:
+        iss["SS"] += np.nansum((SS, -1*iss["SS"]), axis=0)/iss["n"]
+
+    return iss
+
+def binary_mse(X_f, X_o, thr, wavelet="haar"):
+    """Compute an intensity-scale verification as the MSE of the binary error.
+    This method uses PyWavelets for decomposing the error field between the
+    forecasts and observations into multiple spatial scales.
+
+    Parameters
+    ----------
+    X_f : array_like
+        Array of shape (n,m) containing the forecast field.
+    X_o : array_like
+        Array of shape (n,m) containing the verification observation field.
+    thr : sequence
+        The intensity threshold for which to compute the verification.
+    wavelet : str
+        The name of the wavelet function to use. Defaults to the Haar wavelet,
+        as described in Casati et al. 2004. See the documentation of PyWavelets
+        for a list of available options.
+
+    Returns
+    -------
+    SS : array
+        One-dimensional array containing the binary MSE for each spatial scale.
+    spatial_scale : list
+
+    References
+    ----------
+    :cite:`CRS2004`
+
+    """
+    if len(X_f.shape) != 2 or len(X_o.shape) != 2 or X_f.shape != X_o.shape:
+        raise ValueError("X_f and X_o must be two-dimensional arrays having the same shape")
+
+    X_f = X_f.copy()
+    X_f[~np.isfinite(X_f)] = thr - 1
+    X_o = X_o.copy()
+    X_o[~np.isfinite(X_o)] = thr - 1
+
+    w = pywt.Wavelet(wavelet)
+
+    SS = None
+
+    I_f = (X_f >= thr).astype(float)
+    I_o = (X_o >= thr).astype(float)
+
+    E_decomp = _wavelet_decomp(I_f - I_o, w)
+    n_scales = len(E_decomp)
+
+    eps = 1.0*np.sum((X_o >= thr).astype(int)) / np.size(X_o)
+
+    SS = np.empty((n_scales))
+    for j in range(n_scales):
+        mse = np.mean(E_decomp[j]**2)
+        SS[j] = 1 - mse / (2*eps*(1-eps) / n_scales)
+    SS[~np.isfinite(SS)] = np.nan 
+
+    scales = pow(2, np.arange(SS.size))[::-1]
+
+    return SS, scales
+
 def fss(X_f, X_o, thr, scale):
     """Compute the fractions skill score (FSS) for a deterministic forecast
     field and the corresponding observation.
@@ -15,14 +218,14 @@ def fss(X_f, X_o, thr, scale):
     Parameters
     ----------
     X_f : array_like
-        Array of shape (n,m) containing the deterministic forecast field.
+        Array of shape (n,m) containing the forecast field.
     X_o : array_like
-        Array of shape (n,m) containing the observed field.
+        Array of shape (n,m) containing the reference field (observation).
     thr : float
         Intensity threshold.
     scale : int
-        The spatial scale to verify in px. In practice it represents the size of
-        the moving window that it is used to compute the fraction of pixels above
+        The spatial scale  in px. In practice they represent the size of the
+        moving window that it is used to compute the fraction of pixels above
         the threshold.
 
     Returns
@@ -35,104 +238,31 @@ def fss(X_f, X_o, thr, scale):
     :cite:`RL2008`, :cite:`EWWM2013`
 
     """
-    if X_f.shape != X_o.shape:
-        raise ValueError("the shape of X_f does not match the shape of X_o (%d,%d)!=(%d,%d)"
-                            % (X_f.shape[0], X_f.shape[1], X_o.shape[0], X_o.shape[1]))
-
-    # Convert to binary fields with the intensity threshold
-    X_f = (X_f >= thr).astype(float)
-    X_o = (X_o >= thr).astype(float)
-
-    # Compute fractions of pixels above the threshold within a square neighboring
-    # area by applying a 2D moving average to the binary fields
-    X_f = uniform_filter(X_f, size=int(scale), mode="constant", cval=0.0)
-    X_o = uniform_filter(X_o, size=int(scale), mode="constant", cval=0.0)
-
-    n = X_f.size
-    # Compute the numerator
-    N = 1.0*np.sum((X_o - X_f)**2) / n
-    # Compute the denominator
-    D = 1.0*(np.sum(X_o**2) + np.nansum(X_f**2)) / n
-
-    return 1 - N / D
-
-def intensity_scale(X_f, X_o, thrs, wavelet="haar"):
-    """Compute intensity-scale verification. This method uses PyWavelets for
-    decomposing the error field between the forecasts and observations into
-    multiple spatial scales.
-
-    Parameters
-    ----------
-    X_f : array_like
-        Array of shape (n,m) containing the forecast field.
-    X_o : array_like
-        Array of shape (n,m) containing the verification observation field.
-    thrs : sequence
-        A sequence of intensity thresholds for which to compute the verification.
-    wavelet : str
-        The name of the wavelet function to use. Defaults to the Haar wavelet,
-        as described in Casati et al. 2004. See the documentation of PyWavelets
-        for a list of available options.
-
-    Returns
-    -------
-    out : dict
-        A dictionary with the following key-value pairs:
-
-        +--------------+------------------------------------------------------+
-        |       Key    |                Value                                 |
-        +==============+======================================================+
-        |  SS          | two-dimensional array containing the intensity-scale |
-        |              | skill scores for each spatial scale and intensity    |
-        |              | threshold                                            |
-        +--------------+------------------------------------------------------+
-        |  scales      | the spatial scales from largest to smallest,         |
-        |              | corresponds to the first index of SS                 |
-        +--------------+------------------------------------------------------+
-        |  thrs        | the used intensity thresholds in increasing order,   |
-        |              | corresponds to the second index of SS                |
-        +--------------+------------------------------------------------------+
-
-    References
-    ----------
-    :cite:`CRS2004`
-
-    """
     if len(X_f.shape) != 2 or len(X_o.shape) != 2 or X_f.shape != X_o.shape:
         raise ValueError("X_f and X_o must be two-dimensional arrays having the same shape")
 
-    thr_min = np.min(thrs)
     X_f = X_f.copy()
-    X_f[~np.isfinite(X_f)] = thr_min - 1
+    X_f[~np.isfinite(X_f)] = thr - 1
     X_o = X_o.copy()
-    X_o[~np.isfinite(X_o)] = thr_min - 1
+    X_o[~np.isfinite(X_o)] = thr - 1
+    X_f.size
 
-    w = pywt.Wavelet(wavelet)
+    # Convert to binary fields with the intensity threshold
+    I_f = (X_f >= thr).astype(float)
+    I_o = (X_o >= thr).astype(float)
 
-    SS = None
-    n_thrs = len(thrs)
-    for i in range(n_thrs):
-        I_f = (X_f >= thrs[i]).astype(float)
-        I_o = (X_o >= thrs[i]).astype(float)
+    # Compute fractions of pixels above the threshold within a square neighboring
+    # area by applying a 2D moving average to the binary fields
+    S_f = uniform_filter(I_f, size=int(scale), mode="constant", cval=0.0)
+    S_o = uniform_filter(I_o, size=int(scale), mode="constant", cval=0.0)
 
-        E_decomp = _wavelet_decomp(I_f - I_o, w)
-        n_scales = len(E_decomp)
+    # Compute the numerator
+    n = X_f.size
+    N = 1.0*np.sum((S_o - S_f)**2) / n
+    # Compute the denominator
+    D = 1.0*(np.sum(S_o**2) + np.nansum(S_f**2)) / n
 
-        eps = 1.0*np.sum((X_o >= thrs[i]).astype(int)) / np.size(X_o)
-
-        if SS is None:
-            SS = np.empty((n_scales, n_thrs))
-
-        for j in range(n_scales):
-            mse = np.mean(E_decomp[j]**2)
-            SS[j, i] = 1 - mse / (2*eps*(1-eps) / n_scales)
-
-    out = {}
-    out["SS"]     = SS
-    out["scales"] = pow(2, np.arange(SS.shape[0]))[::-1]
-    out["thrs"]   = thrs[:]
-
-    return out
+    return 1 - N / D
 
 def _wavelet_decomp(X, w):
     c = pywt.wavedec2(X, w)


### PR DESCRIPTION
@pulkkins  please review this pull request. I used your original intensity_scale() method to generate a dictionary where different skill scores can be used, currently either the fractions skill score or the binary MSE skill score. 
I have also adapted the plot_intensityscale function and included two methods to initiate and accumulate the intensity-scale object.