### PR TITLE
Remove import checks for dependencies.

### DIFF
--- a/pysteps/io/exporters.py
+++ b/pysteps/io/exporters.py
@@ -56,16 +56,8 @@ implements the following interface:
 
 import numpy as np
 from datetime import datetime
-try:
-    import netCDF4
-    netcdf4_imported = True
-except ImportError:
-    netcdf4_imported = False
-try:
-    import pyproj
-    pyproj_imported = True
-except ImportError:
-    pyproj_imported = False
+import netCDF4
+import pyproj
 
 # TODO: This is a draft version of the exporter. Revise the variable names and
 # the structure of the file if necessary.
@@ -73,11 +65,6 @@ def initialize_forecast_exporter_netcdf(filename, startdate, timestep,
                                         n_timesteps, shape, n_ens_members,
                                         metadata, incremental=None):
     """Initialize a netCDF forecast exporter."""
-    if not netcdf4_imported:
-        raise Exception("netCDF4 not imported")
-
-    if not pyproj_imported:
-        raise Exception("pyproj not imported")
 
     if incremental not in [None, "timestep", "member"]:
         raise ValueError("unknown option %s: incremental must be 'timestep' or 'member'" % incremental)
@@ -241,10 +228,8 @@ def export_forecast_dataset(F, exporter):
         |    'member'       | (num_timesteps,shape[0],shape[1])                 |
         +-------------------+---------------------------------------------------+
     """
-    if not netcdf4_imported:
-        raise Exception("netCDF4 not imported")
 
-    if exporter["incremental"] == None:
+    if exporter["incremental"] is None:
         shp = (exporter["num_ens_members"], exporter["num_timesteps"],
                exporter["shape"][0], exporter["shape"][1])
         if F.shape != shp:

--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -66,32 +66,21 @@ import gzip
 from matplotlib.pyplot import imread
 import numpy as np
 import os
+import netCDF4
+import pyproj
+import PIL
 try:
     import h5py
     h5py_imported = True
 except ImportError:
     h5py_imported = False
-try:
 
+try:
     import metranet
     metranet_imported = True
 except ImportError:
     metranet_imported = False
-try:
-    import netCDF4
-    netcdf4_imported = True
-except ImportError:
-    netcdf4_imported = False
-try:
-    import PIL
-    pil_imported = True
-except ImportError:
-    pil_imported = False
-try:
-    import pyproj
-    pyproj_imported = True
-except ImportError:
-    pyproj_imported = False
+
 
 def import_bom_rf3(filename, **kwargs):
     """Import a NetCDF radar rainfall product from the BoM Rainfields3.
@@ -109,8 +98,6 @@ def import_bom_rf3(filename, **kwargs):
         quality field is currently set to None.
 
     """
-    if not netcdf4_imported:
-        raise Exception("netCDF4 not imported")
 
     R = _import_bom_rf3_data(filename)
 
@@ -223,8 +210,6 @@ def import_fmi_pgm(filename, **kwargs):
         currently set to None.
 
     """
-    if not pyproj_imported:
-        raise Exception("pyproj not imported")
 
     gzipped = kwargs.get("gzipped", False)
 
@@ -353,8 +338,6 @@ def import_mch_gif(filename, **kwargs):
         The quality field is currently set to None.
 
     """
-    if not pil_imported:
-        raise Exception("PIL not imported")
 
     product     = kwargs.get("product", "AQC")
     unit        = kwargs.get("unit",    "mm")

--- a/pysteps/io/nowcast_importers.py
+++ b/pysteps/io/nowcast_importers.py
@@ -61,17 +61,11 @@ The metadata dictionary contains the following mandatory key-value pairs:
 """
 
 import numpy as np
-try:
-    import netCDF4
-    netcdf4_imported = True
-except ImportError:
-    netcdf4_imported = False
+import netCDF4
 
 def import_netcdf_pysteps(filename, **kwargs):
     """Read a nowcast or a nowcast ensemble from a NetCDF file conforming to the
     CF 1.7 specification."""
-    if not netcdf4_imported:
-        raise Exception("netCDF4 not imported")
 
     ds = netCDF4.Dataset(filename, 'r')
 

--- a/pysteps/motion/lucaskanade.py
+++ b/pysteps/motion/lucaskanade.py
@@ -2,11 +2,7 @@
 vectors for areas with no precipitation."""
 
 import numpy as np
-try:
-    import cv2
-    cv2_imported = True
-except ImportError:
-    cv2_imported = False
+import cv2
 import scipy.spatial
 import time
 
@@ -221,9 +217,7 @@ def _ShiTomasi_features_to_track(R, max_corners_ST, quality_level_ST,
         Output vector of detected corners.
 
     """
-    if not cv2_imported:
-        raise Exception("opencv not imported")
-        
+
     if len(R.shape) != 2:
         raise ValueError("R must be a two-dimensional array")
     if R.dtype != "uint8":
@@ -272,9 +266,6 @@ def _LucasKanade_features_tracking(prvs, next, p0, winsize_LK, nr_levels_LK):
         Output vector of v-components of detected point motions.
 
     """
-    if not cv2_imported:
-        raise Exception("opencv not imported")
-
     # LK parameters
     lk_params = dict( winSize=winsize_LK, maxLevel=nr_levels_LK,
                      criteria=(cv2.TERM_CRITERIA_EPS|cv2.TERM_CRITERIA_COUNT, 10, 0))
@@ -314,9 +305,7 @@ def _clean_image(R, n=3, thr=0):
         Array of shape (m,n) containing the cleaned precipitation field.
 
     """
-    if not cv2_imported:
-        raise Exception("opencv not imported")
-        
+
     # convert to binary image (rain/no rain)
     field_bin = np.ndarray.astype(R > thr,"uint8")
 

--- a/pysteps/visualization/utils.py
+++ b/pysteps/visualization/utils.py
@@ -1,15 +1,12 @@
 """Miscellaneous utility functions."""
 
+import pyproj
+
 try:
     import cartopy.crs as ccrs
     cartopy_imported = True
 except ImportError:
     cartopy_imported = False
-try:
-    import pyproj
-    pyproj_imported = True
-except ImportError:
-    pyproj_imported = False
 
 def parse_proj4_string(proj4str):
     """Construct a dictionary from a PROJ.4 projection string.
@@ -94,8 +91,6 @@ def proj4_to_cartopy(proj4str):
     """
     if not cartopy_imported:
         raise Exception("cartopy not imported")
-    if not pyproj_imported:
-        raise Exception("pyproj not imported")
 
     proj = pyproj.Proj(proj4str)
 


### PR DESCRIPTION
Since several *optional* packages are now listed as **dependencies**. Therefore, several runtime import checks are not needed anymore (following discussion in issue #16). 

This also removes several generic exceptions, which contributes to solve the issue #13.

