### PR TITLE
Simplify the extrapolator and nowcasts interface

### DIFF
--- a/pysteps/extrapolation/__init__.py
+++ b/pysteps/extrapolation/__init__.py
@@ -1,5 +1,6 @@
-"""Methods for advection-based extrapolation of precipitation fields. Currently 
-the module contains an implementation of the semi-Lagrangian method described 
-in :cite:`GZ2002`."""
+"""Methods for advection-based extrapolation of precipitation fields.
+Currently the module contains an implementation of the
+semi-Lagrangian method described in :cite:`GZ2002` and the
+eulerian persistence."""
 
-from .interface import get_method
+from pysteps.extrapolation.interface import get_method

--- a/pysteps/extrapolation/interface.py
+++ b/pysteps/extrapolation/interface.py
@@ -53,10 +53,10 @@ _extrapolation_methods = dict()
 _extrapolation_methods['eulerian'] = eulerian_persistence
 _extrapolation_methods['semilagrangian'] = semilagrangian.extrapolate
 _extrapolation_methods[None] = _do_nothing
-_extrapolation_methods["None"] = _do_nothing
+_extrapolation_methods["none"] = _do_nothing
 
 
-def get_method(name, extrapolator=False):
+def get_method(name):
     """Return two-element tuple for the extrapolation method corresponding to
     the given name. The elements of the tuple are callable functions for the
     initializer of the extrapolator and the extrapolation method, respectively.

--- a/pysteps/extrapolation/interface.py
+++ b/pysteps/extrapolation/interface.py
@@ -19,19 +19,28 @@ extrapolated fields of shape (num_timesteps, m, n)."""
 import numpy as np
 
 from pysteps.extrapolation import semilagrangian
-from pysteps.nowcasts.interface import _eulerian_persistence
 
 
-def eulerian_persistence(extrapolator, R, V, num_timesteps,
-                         outval=np.nan, **kwargs):
-    """ Eulerian persistence extrapolator """
-    del extrapolator  # Unused
-    return _eulerian_persistence(R, V, num_timesteps,
-                                 outval=np.nan, **kwargs)
+def eulerian_persistence(precip, velocity, num_timesteps, outval=np.nan,
+                         **kwargs):
+    """Eulerian persistence."""
+    del velocity, outval  # Unused by _eulerian_persistence
+    return_displacement = kwargs.get("return_displacement", False)
+
+    extrapolated_precip = np.repeat(precip[np.newaxis, :, :, ],
+                                    num_timesteps,
+                                    axis=0)
+
+    if not return_displacement:
+        return extrapolated_precip
+    else:
+        return extrapolated_precip, np.zeros((2,) + extrapolated_precip.shape)
 
 
-def _do_nothing(extrapolator, R, V, num_timesteps, outval=np.nan, **kwargs):
-    del extrapolator, R, V, num_timesteps, outval, kwargs  # Unused
+def _do_nothing(precip, velocity, num_timesteps, outval=np.nan,
+                **kwargs):
+    """Return None."""
+    del precip, velocity, num_timesteps, outval, kwargs  # Unused
     return None
 
 
@@ -41,13 +50,13 @@ def _return_none(**kwargs):
 
 
 _extrapolation_methods = dict()
-_extrapolation_methods['eulerian'] = _return_none, eulerian_persistence
-_extrapolation_methods['semilagrangian'] = \
-    semilagrangian.initialize, semilagrangian.extrapolate
-_extrapolation_methods[None] = _return_none, _do_nothing
+_extrapolation_methods['eulerian'] = eulerian_persistence
+_extrapolation_methods['semilagrangian'] = semilagrangian.extrapolate
+_extrapolation_methods[None] = _do_nothing
+_extrapolation_methods["None"] = _do_nothing
 
 
-def get_method(name):
+def get_method(name, extrapolator=False):
     """Return two-element tuple for the extrapolation method corresponding to
     the given name. The elements of the tuple are callable functions for the
     initializer of the extrapolator and the extrapolation method, respectively.
@@ -71,6 +80,7 @@ def get_method(name):
 
     try:
         return _extrapolation_methods[name]
+
     except KeyError:
         raise ValueError("Unknown method {}\n".format(name)
                          + "The available methods are:"

--- a/pysteps/nowcasts/__init__.py
+++ b/pysteps/nowcasts/__init__.py
@@ -4,4 +4,4 @@ Currently the module contains a
 deterministic advection extrapolation method and STEPS.
 """
 
-from .interface import get_method
+from pysteps.nowcasts.interface import get_method

--- a/pysteps/nowcasts/extrapolation.py
+++ b/pysteps/nowcasts/extrapolation.py
@@ -1,83 +1,86 @@
 """Implementations of deterministic nowcasting methods."""
 
-from .. import extrapolation
 import time
 
+from pysteps import extrapolation
 
-def forecast(R, V, num_timesteps, extrap_method="semilagrangian",
-             extrap_kwargs={},
+
+def forecast(precip, velocity, num_timesteps,
+             extrap_method="semilagrangian", extrap_kwargs=None,
              measure_time=False):
-    """Generate a nowcast by applying a simple advection-based extrapolation.
-
-    Description:
-    Generate a nowcast by applying a simple advection-based extrapolation to
+    """Generate a nowcast by applying a simple advection-based extrapolation to
     the given precipitation field.
 
     Parameters
     ----------
-    R : array-like
+    precip : array-like
       Two-dimensional array of shape (m,n) containing the input precipitation
       field.
-    V : array-like
+    velocity : array-like
       Array of shape (2,m,n) containing the x- and y-components of the
       advection field. The velocities are assumed to represent one time step
       between the inputs.
     num_timesteps : int
       Number of time steps to forecast.
-
-    Other Parameters
-    ----------------
-    extrap_method : {'semilagrangian'}
+    extrap_method : str, optional
       Name of the extrapolation method to use. See the documentation of
       pysteps.extrapolation.interface.
-    extrap_kwargs : dict
+    extrap_kwargs : dict, , optional
       Optional dictionary that is expanded into keyword arguments for the
       extrapolation method.
-    measure_time : bool
-      If set to True, measure, print and return the computation time.
+    measure_time : bool, optional
+      If True, measure, print, and return the computation time.
 
     Returns
     -------
-    out : ndarray
-      Three-dimensional array of shape (num_timesteps,m,n) containing a time
+    out : ndarray_
+      Three-dimensional array of shape (num_timesteps, m, n) containing a time
       series of nowcast precipitation fields. The time series starts from
-      t0+timestep, where timestep is taken from the advection field V. If
-      measure_time is True, the return value is a two-element tuple containing
-      this array and the computation time (seconds).
+      t0 + timestep, where timestep is taken from the advection field velocity.
+      If *measure_time* is True, the return value is a two-element tuple
+      containing this array and the computation time (seconds).
 
     See also
     --------
     pysteps.extrapolation.interface
 
+    .. _ndarray: http://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.html
+
     """
-    _check_inputs(R, V)
+    _check_inputs(precip, velocity)
 
-    print("Computing extrapolation nowcast from a %dx%d input grid... " %
-          (R.shape[0], R.shape[1]), end="")
+    if extrap_kwargs is None:
+        extrap_kwargs = dict()
 
-    if measure_time:
-        starttime = time.time()
-
-    extrap_init, extrap_method = extrapolation.get_method(extrap_method)
-    extrapolator = extrap_init(shape=R.shape)
-    R_f = extrap_method(extrapolator, R, V, num_timesteps, **extrap_kwargs)
+    print("Computing extrapolation nowcast from a "
+          f"{precip.shape[0]:d}x{precip.shape[1]:d} input grid... ", end="")
 
     if measure_time:
-        comptime = time.time() - starttime
-        print("%.2f seconds." % comptime)
+        start_time = time.time()
+
+    extrapolation_method = extrapolation.get_method(extrap_method)
+
+    precip_forecast = extrapolation_method(precip, velocity, num_timesteps,
+                                           **extrap_kwargs)
 
     if measure_time:
-        return R_f, comptime
+        computation_time = time.time() - start_time
+        print(f"{computation_time:.2f} seconds.")
+
+    if measure_time:
+        return precip_forecast, computation_time
     else:
-        return R_f
+        return precip_forecast
 
 
-def _check_inputs(R, V):
-    if len(R.shape) != 2:
-        raise ValueError("R must be a two-dimensional array")
-    if len(V.shape) != 3:
-        raise ValueError("V must be a three-dimensional array")
-    if R.shape != V.shape[1:3]:
-        raise ValueError("dimension mismatch between R and V: " +
-                         "shape(R)=%s, shape(V)=%s" %
-                         (str(R.shape), str(V.shape)))
+def _check_inputs(precip, velocity):
+    if len(precip.shape) != 2:
+        raise ValueError("The input precipitation must be a "
+                         "two-dimensional array")
+    if len(velocity.shape) != 3:
+        raise ValueError("Input velocity must be a three-dimensional array")
+    if precip.shape != velocity.shape[1:3]:
+        raise ValueError("Dimension mismatch between "
+                         "input precipitation and velocity: " +
+                         "shape(precip)=%s, shape(velocity)=%s" %
+                         (str(precip.shape), str(velocity.shape)))

--- a/pysteps/nowcasts/interface.py
+++ b/pysteps/nowcasts/interface.py
@@ -17,34 +17,11 @@ For stochastic methods that produce an ensemble, the output is a
 four-dimensional array of shape (num_ensemble_members,num_timesteps,m,n).
 The time step of the output is taken from the inputs.
 """
-
-
+from pysteps.extrapolation.interface import eulerian_persistence
 from pysteps.nowcasts import steps, sseps, extrapolation
-import numpy as np
-
-
-def _eulerian_persistence(R, V, num_timesteps, outval=np.nan, **kwargs):
-    """ Eulerian persistence """
-    del V, outval  # Unused by _eulerian_persistence
-    return_displacement = kwargs.get("return_displacement", False)
-
-    extrapolated_precip = np.repeat(R[np.newaxis, :, :, ],
-                                    num_timesteps,
-                                    axis=0)
-
-    if not return_displacement:
-        return extrapolated_precip
-    else:
-        return extrapolated_precip, np.zeros((2,) + extrapolated_precip.shape)
-
-
-def _do_nothing(R, V, num_timesteps, outval=np.nan, **kwargs):
-    del R, V, num_timesteps, outval, kwargs  # Unused by _do_nothing
-    return None
-
 
 _nowcast_methods = dict()
-_nowcast_methods["eulerian"] = _eulerian_persistence
+_nowcast_methods["eulerian"] = eulerian_persistence
 _nowcast_methods["lagrangian"] = extrapolation.forecast
 _nowcast_methods["extrapolation"] = extrapolation.forecast
 _nowcast_methods["steps"] = steps.forecast

--- a/pysteps/nowcasts/steps.py
+++ b/pysteps/nowcasts/steps.py
@@ -2,28 +2,36 @@
 
 import sys
 import time
+
 import numpy as np
 import scipy.ndimage
-from .. import extrapolation
-from .. import cascade
-from .. import noise
-from ..postprocessing import probmatching
-from ..timeseries import autoregression, correlation
-from .. import utils
+
+from pysteps import cascade
+from pysteps import extrapolation
+from pysteps import noise
+from pysteps import utils
+from pysteps.postprocessing import probmatching
+from pysteps.timeseries import autoregression, correlation
+
 try:
     import dask
-    dask_imported = True
-except ImportError:
-    dask_imported = False
 
-def forecast(R, V, n_timesteps, n_ens_members=24, n_cascade_levels=6, R_thr=None,
-             kmperpixel=None, timestep=None, extrap_method="semilagrangian",
-             decomp_method="fft", bandpass_filter_method="gaussian",
-             noise_method="nonparametric", noise_stddev_adj=None, ar_order=2,
-             vel_pert_method="bps", conditional=False, probmatching_method="cdf",
+    DASK_IMPORTED = True
+except ImportError:
+    DASK_IMPORTED = False
+
+
+def forecast(R, V, n_timesteps, n_ens_members=24, n_cascade_levels=6,
+             R_thr=None, kmperpixel=None, timestep=None,
+             extrap_method="semilagrangian", decomp_method="fft",
+             bandpass_filter_method="gaussian", noise_method="nonparametric",
+             noise_stddev_adj=None, ar_order=2,
+             vel_pert_method="bps", conditional=False,
+             probmatching_method="cdf",
              mask_method="incremental", callback=None, return_output=True,
-             seed=None, num_workers=1, fft_method="numpy", extrap_kwargs={},
-             filter_kwargs={}, noise_kwargs={}, vel_pert_kwargs={}, mask_kwargs={},
+             seed=None, num_workers=1, fft_method="numpy", extrap_kwargs=None,
+             filter_kwargs=None, noise_kwargs=None, vel_pert_kwargs=None,
+             mask_kwargs=None,
              measure_time=False):
     """Generate a nowcast ensemble by using the Short-Term Ensemble Prediction
     System (STEPS) method.
@@ -40,97 +48,94 @@ def forecast(R, V, n_timesteps, n_ens_members=24, n_cascade_levels=6, R_thr=None
       inputs. All values are required to be finite.
     n_timesteps : int
       Number of time steps to forecast.
-    n_ens_members : int
+    n_ens_members : int, optional
       The number of ensemble members to generate.
-    n_cascade_levels : int
+    n_cascade_levels : int, optional
       The number of cascade levels to use.
-
-    Other Parameters
-    ----------------
-    R_thr : float
+    R_thr : float, optional
       Specifies the threshold value for minimum observable precipitation
       intensity. Required if mask_method is not None or conditional is True.
-    kmperpixel : float
+    kmperpixel : float, optional
       Spatial resolution of the input data (kilometers/pixel). Required if
       vel_pert_method is not None or mask_method is 'incremental'.
-    timestep : float
+    timestep : float, optional
       Time step of the motion vectors (minutes). Required if vel_pert_method is
       not None or mask_method is 'incremental'.
-    extrap_method : {'semilagrangian'}
+    extrap_method : str, optional
       Name of the extrapolation method to use. See the documentation of
       pysteps.extrapolation.interface.
-    decomp_method : {'fft'}
+    decomp_method : {'fft'}, optional
       Name of the cascade decomposition method to use. See the documentation
       of pysteps.cascade.interface.
-    bandpass_filter_method : {'gaussian', 'uniform'}
+    bandpass_filter_method : {'gaussian', 'uniform'}, optional
       Name of the bandpass filter method to use with the cascade decomposition.
       See the documentation of pysteps.cascade.interface.
-    noise_method : {'parametric','nonparametric','ssft','nested',None}
+    noise_method : {'parametric','nonparametric','ssft','nested',None}, optional
       Name of the noise generator to use for perturbating the precipitation
       field. See the documentation of pysteps.noise.interface. If set to None,
       no noise is generated.
-    noise_stddev_adj : {'auto','fixed',None}
+    noise_stddev_adj : {'auto','fixed',None}, optional
       Optional adjustment for the standard deviations of the noise fields added
       to each cascade level. This is done to compensate incorrect std. dev.
       estimates of casace levels due to presence of no-rain areas. 'auto'=use
       the method implemented in pysteps.noise.utils.compute_noise_stddev_adjs.
       'fixed'= use the formula given in :cite:`BPS2006` (eq. 6), None=disable
       noise std. dev adjustment.
-    ar_order : int
+    ar_order : int, optional
       The order of the autoregressive model to use. Must be >= 1.
-    vel_pert_method : {'bps',None}
+    vel_pert_method : {'bps',None}, optional
       Name of the noise generator to use for perturbing the advection field. See
       the documentation of pysteps.noise.interface. If set to None, the advection
       field is not perturbed.
-    conditional : bool
+    conditional : bool, optional
       If set to True, compute the statistics of the precipitation field
       conditionally by excluding pixels where the values are below the threshold
       R_thr.
-    mask_method : {'obs','sprog','incremental',None}
+    mask_method : {'obs','sprog','incremental',None}, optional
       The method to use for masking no precipitation areas in the forecast field.
       The masked pixels are set to the minimum value of the observations.
       'obs' = apply R_thr to the most recently observed precipitation intensity
       field, 'sprog' = use the smoothed forecast field from S-PROG, where the
       AR(p) model has been applied, 'incremental' = iteratively buffer the mask
       with a certain rate (currently it is 1 km/min), None=no masking.
-    probmatching_method : {'cdf','mean',None}
+    probmatching_method : {'cdf','mean',None}, optional
       Method for matching the statistics of the forecast field with those of
       the most recently observed one. 'cdf'=map the forecast CDF to the observed
       one, 'mean'=adjust only the conditional mean value of the forecast field
       in precipitation areas, None=no matching applied. Using 'mean' requires
       that mask_method is not None.
-    callback : function
+    callback : function, optional
       Optional function that is called after computation of each time step of
       the nowcast. The function takes one argument: a three-dimensional array
       of shape (n_ens_members,h,w), where h and w are the height and width
       of the input field R, respectively. This can be used, for instance,
       writing the outputs into files.
-    return_output : bool
+    return_output : bool, optional
       Set to False to disable returning the outputs as numpy arrays. This can
       save memory if the intermediate results are written to output files using
       the callback function.
-    seed : int
+    seed : int, optional
       Optional seed number for the random generators.
-    num_workers : int
+    num_workers : int, optional
       The number of workers to use for parallel computation. Applicable if dask
       is enabled or pyFFTW is used for computing the FFT. When num_workers>1, it
       is advisable to disable OpenMP by setting the environment variable
       OMP_NUM_THREADS to 1. This avoids slowdown caused by too many simultaneous
       threads.
-    fft_method : str
+    fft_method : str, optional
       A string defining the FFT method to use (see utils.fft.get_method).
       Defaults to 'numpy' for compatibility reasons. If pyFFTW is installed,
       the recommended method is 'pyfftw'.
-    extrap_kwargs : dict
+    extrap_kwargs : dict, optional
       Optional dictionary containing keyword arguments for the extrapolation
       method. See the documentation of pysteps.extrapolation.
-    filter_kwargs : dict
+    filter_kwargs : dict, optional
       Optional dictionary containing keyword arguments for the filter method.
       See the documentation of pysteps.cascade.bandpass_filters.py.
-    noise_kwargs : dict
+    noise_kwargs : dict, optional
       Optional dictionary containing keyword arguments for the initializer of
       the noise generator. See the documentation of pysteps.noise.fftgenerators.
-    vel_pert_kwargs : dict
+    vel_pert_kwargs : dict, optional
       Optional dictionary containing keyword arguments 'p_par' and 'p_perp' for
       the initializer of the velocity perturbator. The choice of the optimal
       parameters depends on the domain and the used optical flow method.
@@ -221,6 +226,21 @@ def forecast(R, V, n_timesteps, n_ens_members=24, n_cascade_levels=6, R_thr=None
     """
     _check_inputs(R, V, ar_order)
 
+    if extrap_kwargs is None:
+        extrap_kwargs = dict()
+
+    if filter_kwargs is None:
+        filter_kwargs = dict()
+
+    if noise_kwargs is None:
+        noise_kwargs = dict()
+
+    if vel_pert_kwargs is None:
+        vel_pert_kwargs = dict()
+
+    if mask_kwargs is None:
+        mask_kwargs = dict()
+
     if np.any(~np.isfinite(R)):
         raise ValueError("R contains non-finite values")
 
@@ -262,7 +282,7 @@ def forecast(R, V, n_timesteps, n_ens_members=24, n_cascade_levels=6, R_thr=None
     print("-------")
     print("input dimensions: %dx%d" % (R.shape[1], R.shape[2]))
     if kmperpixel is not None:
-        print("km/pixel:         %g"    % kmperpixel)
+        print("km/pixel:         %g" % kmperpixel)
     if timestep is not None:
         print("time step:        %d minutes" % timestep)
     print("")
@@ -292,15 +312,15 @@ def forecast(R, V, n_timesteps, n_ens_members=24, n_cascade_levels=6, R_thr=None
         vp_par = vel_pert_kwargs.get("p_par", noise.motion.get_default_params_bps_par())
         vp_perp = vel_pert_kwargs.get("p_perp", noise.motion.get_default_params_bps_perp())
         print("velocity perturbations, parallel:      %g,%g,%g" % \
-            (vp_par[0], vp_par[1], vp_par[2]))
+              (vp_par[0], vp_par[1], vp_par[2]))
         print("velocity perturbations, perpendicular: %g,%g,%g" % \
-            (vp_perp[0], vp_perp[1], vp_perp[2]))
+              (vp_perp[0], vp_perp[1], vp_perp[2]))
 
     if conditional or mask_method is not None:
         print("precip. intensity threshold: %g" % R_thr)
 
     num_ensemble_workers = n_ens_members if num_workers > n_ens_members \
-                           else num_workers
+        else num_workers
 
     if measure_time:
         starttime_init = time.time()
@@ -315,8 +335,13 @@ def forecast(R, V, n_timesteps, n_ens_members=24, n_cascade_levels=6, R_thr=None
 
     decomp_method = cascade.get_method(decomp_method)
 
-    extrap_init,extrap_method = extrapolation.get_method(extrap_method)
-    extrapolator = extrap_init(shape=R.shape[1:])
+    extrapolator_method = extrapolation.get_method(extrap_method)
+
+    x_values, y_values = np.meshgrid(np.arange(R.shape[2]),
+                                     np.arange(R.shape[1]))
+
+    xy_coords = np.stack([x_values, y_values])
+
     R = R[-(ar_order + 1):, :, :].copy()
 
     if conditional:
@@ -327,16 +352,21 @@ def forecast(R, V, n_timesteps, n_ens_members=24, n_cascade_levels=6, R_thr=None
     # advect the previous precipitation fields to the same position with the
     # most recent one (i.e. transform them into the Lagrangian coordinates)
     extrap_kwargs = extrap_kwargs.copy()
-    res = []
-    f = lambda R, i: extrap_method(extrapolator, R[i, :, :], V, ar_order-i,
-                                   "min", **extrap_kwargs)[-1]
+    extrap_kwargs['xy_coords'] = xy_coords
+    res = list()
+
+    def f(R, i):
+        return extrapolator_method(R[i, :, :], V, ar_order - i,
+                                   "min",
+                                   **extrap_kwargs)[-1]
+
     for i in range(ar_order):
-        if not dask_imported:
+        if not DASK_IMPORTED:
             R[i, :, :] = f(R, i)
         else:
             res.append(dask.delayed(f)(R, i))
 
-    if dask_imported:
+    if DASK_IMPORTED:
         num_workers_ = len(res) if num_workers > len(res) else num_workers
         R = np.stack(list(dask.compute(*res, num_workers=num_workers_)) + [R[-1, :, :]])
 
@@ -355,16 +385,17 @@ def forecast(R, V, n_timesteps, n_ens_members=24, n_cascade_levels=6, R_thr=None
 
             R_min = np.min(R)
             noise_std_coeffs = noise.utils.compute_noise_stddev_adjs(R[-1, :, :],
-                R_thr, R_min, filter, decomp_method, pp, generate_noise, 20,
-                conditional=True, num_workers=num_workers)
+                                                                     R_thr, R_min, filter, decomp_method, pp,
+                                                                     generate_noise, 20,
+                                                                     conditional=True, num_workers=num_workers)
 
             if measure_time:
                 print("%.2f seconds." % (time.time() - starttime))
             else:
                 print("done.")
         elif noise_stddev_adj == "fixed":
-            f = lambda k: 1.0 / (0.75 + 0.09*k)
-            noise_std_coeffs = [f(k) for k in range(1, n_cascade_levels+1)]
+            f = lambda k: 1.0 / (0.75 + 0.09 * k)
+            noise_std_coeffs = [f(k) for k in range(1, n_cascade_levels + 1)]
         else:
             noise_std_coeffs = np.ones(n_cascade_levels)
 
@@ -373,7 +404,7 @@ def forecast(R, V, n_timesteps, n_ens_members=24, n_cascade_levels=6, R_thr=None
 
     # compute the cascade decompositions of the input precipitation fields
     R_d = []
-    for i in range(ar_order+1):
+    for i in range(ar_order + 1):
         R_ = decomp_method(R[i, :, :], filter, MASK=MASK_thr, fft_method=fft)
         R_d.append(R_)
 
@@ -385,7 +416,7 @@ def forecast(R, V, n_timesteps, n_ens_members=24, n_cascade_levels=6, R_thr=None
     # compute lag-l temporal autocorrelation coefficients for each cascade level
     GAMMA = np.empty((n_cascade_levels, ar_order))
     for i in range(n_cascade_levels):
-        R_c_ = np.stack([R_c[i, j, :, :] for j in range(ar_order+1)])
+        R_c_ = np.stack([R_c[i, j, :, :] for j in range(ar_order + 1)])
         GAMMA[i, :] = correlation.temporal_autocorrelation(R_c_, MASK=MASK_thr)
     R_c_ = None
 
@@ -399,7 +430,7 @@ def forecast(R, V, n_timesteps, n_ens_members=24, n_cascade_levels=6, R_thr=None
 
     # estimate the parameters of the AR(p) model from the autocorrelation
     # coefficients
-    PHI = np.empty((n_cascade_levels, ar_order+1))
+    PHI = np.empty((n_cascade_levels, ar_order + 1))
     for i in range(n_cascade_levels):
         PHI[i, :] = autoregression.estimate_ar_params_yw(GAMMA[i, :])
 
@@ -432,10 +463,10 @@ def forecast(R, V, n_timesteps, n_ens_members=24, n_cascade_levels=6, R_thr=None
         # initialize the perturbation generators for the motion field
         vps = []
         for j in range(n_ens_members):
-            kwargs = {"randstate":randgen_motion[j],
-                      "p_par":vp_par,
-                      "p_perp":vp_perp}
-            vp_ = init_vel_noise(V, 1./kmperpixel, timestep, **kwargs)
+            kwargs = {"randstate": randgen_motion[j],
+                      "p_par": vp_par,
+                      "p_perp": vp_perp}
+            vp_ = init_vel_noise(V, 1. / kmperpixel, timestep, **kwargs)
             vps.append(vp_)
 
     D = [None for j in range(n_ens_members)]
@@ -451,7 +482,7 @@ def forecast(R, V, n_timesteps, n_ens_members=24, n_cascade_levels=6, R_thr=None
             pass
         elif mask_method == "sprog":
             # compute the wet area ratio and the precipitation mask
-            war = 1.0*np.sum(MASK_prec) / (R.shape[1]*R.shape[2])
+            war = 1.0 * np.sum(MASK_prec) / (R.shape[1] * R.shape[2])
             R_m = R_c[0, :, :, :].copy()
         elif mask_method == "incremental":
             # get mask parameters
@@ -460,12 +491,12 @@ def forecast(R, V, n_timesteps, n_ens_members=24, n_cascade_levels=6, R_thr=None
             # initialize the structuring element
             struct = scipy.ndimage.generate_binary_structure(2, 1)
             # iterate it to expand it nxn
-            n = mask_f*timestep/kmperpixel
-            struct = scipy.ndimage.iterate_structure(struct, int((n - 1)/2.))
+            n = mask_f * timestep / kmperpixel
+            struct = scipy.ndimage.iterate_structure(struct, int((n - 1) / 2.))
             # initialize precip mask for each member
             MASK_prec = _compute_incremental_mask(MASK_prec, struct, mask_rim)
             MASK_prec = [MASK_prec.copy() for j in range(n_ens_members)]
-    
+
     if noise_method is None:
         R_m = R_c[0, :, :, :].copy()
 
@@ -485,7 +516,7 @@ def forecast(R, V, n_timesteps, n_ens_members=24, n_cascade_levels=6, R_thr=None
 
     # iterate each time step
     for t in range(n_timesteps):
-        print("Computing nowcast for time step %d... " % (t+1), end="")
+        print("Computing nowcast for time step %d... " % (t + 1), end="")
         sys.stdout.flush()
         if measure_time:
             starttime = time.time()
@@ -546,7 +577,7 @@ def forecast(R, V, n_timesteps, n_ens_members=24, n_cascade_levels=6, R_thr=None
                 if mask_method == "obs":
                     MASK_prec_ = ~MASK_prec
                 elif mask_method == "incremental":
-                    R_c_ = R_cmin + (R_c_ - R_cmin)*MASK_prec[j]
+                    R_c_ = R_cmin + (R_c_ - R_cmin) * MASK_prec[j]
                     MASK_prec_ = R_c_ <= R_cmin
                 elif mask_method == "sprog":
                     MASK_prec_ = MASK_prec
@@ -566,14 +597,14 @@ def forecast(R, V, n_timesteps, n_ens_members=24, n_cascade_levels=6, R_thr=None
 
             # compute the perturbed motion field
             if vel_pert_method is not None:
-                V_ = V + generate_vel_noise(vps[j], (t+1)*timestep)
+                V_ = V + generate_vel_noise(vps[j], (t + 1) * timestep)
             else:
                 V_ = V
 
             # advect the recomposed precipitation field to obtain the forecast
             # for time step t
-            extrap_kwargs.update({"D_prev":D[j], "return_displacement":True})
-            R_f_, D_ = extrap_method(extrapolator, R_c_, V_, 1, **extrap_kwargs)
+            extrap_kwargs.update({"D_prev": D[j], "return_displacement": True})
+            R_f_, D_ = extrapolator_method(R_c_, V_, 1, **extrap_kwargs)
             D[j] = D_
             R_f_ = R_f_[0]
 
@@ -581,13 +612,13 @@ def forecast(R, V, n_timesteps, n_ens_members=24, n_cascade_levels=6, R_thr=None
 
         res = []
         for j in range(n_ens_members):
-            if not dask_imported or n_ens_members == 1:
+            if not DASK_IMPORTED or n_ens_members == 1:
                 res.append(worker(j))
             else:
                 res.append(dask.delayed(worker)(j))
 
         R_f_ = dask.compute(*res, num_workers=num_ensemble_workers) \
-            if dask_imported and n_ens_members > 1 else res
+            if DASK_IMPORTED and n_ens_members > 1 else res
         res = None
 
         if measure_time:
@@ -609,11 +640,12 @@ def forecast(R, V, n_timesteps, n_ens_members=24, n_cascade_levels=6, R_thr=None
     if return_output:
         outarr = np.stack([np.stack(R_f[j]) for j in range(n_ens_members)])
         if measure_time:
-            return outarr,init_time,mainloop_time
+            return outarr, init_time, mainloop_time
         else:
             return outarr
     else:
         return None
+
 
 def _check_inputs(R, V, ar_order):
     if len(R.shape) != 3:
@@ -625,6 +657,7 @@ def _check_inputs(R, V, ar_order):
     if R.shape[1:3] != V.shape[1:3]:
         raise ValueError("dimension mismatch between R and V: shape(R)=%s, shape(V)=%s" % \
                          (str(R.shape), str(V.shape)))
+
 
 def _compute_incremental_mask(Rbin, kr, r):
     # buffer the observation mask Rbin using the kernel kr
@@ -641,7 +674,8 @@ def _compute_incremental_mask(Rbin, kr, r):
         Rd = scipy.ndimage.morphology.binary_dilation(Rd, kr1)
         mask += Rd
     # normalize between 0 and 1
-    return mask/(r + 1)
+    return mask / (r + 1)
+
 
 def _compute_sprog_mask(R, war):
     # obtain the CDF from the non-perturbed forecast that is
@@ -652,7 +686,7 @@ def _compute_sprog_mask(R, war):
     # same fraction of precipitation pixels (forecast values above
     # R_thr) as in the most recently observed precipitation field
     R_s.sort(kind="quicksort")
-    x = 1.0*np.arange(1, len(R_s)+1)[::-1] / len(R_s)
+    x = 1.0 * np.arange(1, len(R_s) + 1)[::-1] / len(R_s)
     i = np.argmin(abs(x - war))
     # handle ties
     if R_s[i] == R_s[i + 1]:
@@ -662,6 +696,7 @@ def _compute_sprog_mask(R, war):
     # determine a mask using the above threshold value to preserve the
     # wet-area ratio
     return R < R_pct_thr
+
 
 def _print_ar_params(PHI, include_perturb_term):
     print("****************************************")
@@ -676,8 +711,8 @@ def _print_ar_params(PHI, include_perturb_term):
 
     print(hline_str)
     title_str = "| Level |"
-    for k in range(n-1):
-        title_str += "    Phi-%d     |" % (k+1)
+    for k in range(n - 1):
+        title_str += "    Phi-%d     |" % (k + 1)
     title_str += "    Phi-0     |"
     print(title_str)
     print(hline_str)
@@ -687,8 +722,9 @@ def _print_ar_params(PHI, include_perturb_term):
         fmt_str += " %-12.6f |"
 
     for k in range(PHI.shape[0]):
-        print(fmt_str % ((k+1,) + tuple(PHI[k, :])))
+        print(fmt_str % ((k + 1,) + tuple(PHI[k, :])))
         print(hline_str)
+
 
 def _print_corrcoefs(GAMMA):
     print("************************************************")
@@ -705,7 +741,7 @@ def _print_corrcoefs(GAMMA):
     print(hline_str)
     title_str = "| Level |"
     for k in range(n):
-        title_str += "     Lag-%d     |" % (k+1)
+        title_str += "     Lag-%d     |" % (k + 1)
     print(title_str)
     print(hline_str)
 
@@ -714,8 +750,9 @@ def _print_corrcoefs(GAMMA):
         fmt_str += " %-13.6f |"
 
     for k in range(m):
-        print(fmt_str % ((k+1,) + tuple(GAMMA[k, :])))
+        print(fmt_str % ((k + 1,) + tuple(GAMMA[k, :])))
         print(hline_str)
+
 
 def _stack_cascades(R_d, n_levels, donorm=True):
     R_c = []
@@ -740,6 +777,7 @@ def _stack_cascades(R_d, n_levels, donorm=True):
         R_c.append(np.stack(R_))
 
     return np.stack(R_c), mu, sigma
+
 
 def _recompose_cascade(R, mu, sigma):
     R_rc = [(R[i, -1, :, :] * sigma[i]) + mu[i] for i in range(len(mu))]

--- a/pysteps/tests/test_interfaces.py
+++ b/pysteps/tests/test_interfaces.py
@@ -1,12 +1,9 @@
 # -*- coding: utf-8 -*-
 
 import numpy
-
 import pytest
 
 import pysteps
-
-from collections.abc import Iterable
 
 
 def _generic_interface_test(method_getter,
@@ -25,7 +22,7 @@ def _generic_interface_test(method_getter,
 
 
 def test_cascade_interface():
-    """ Test the cascade module interface"""
+    """Test the cascade module interface."""
 
     from pysteps.cascade import decomposition, bandpass_filters
 
@@ -40,7 +37,7 @@ def test_cascade_interface():
 
 
 def test_extrapolation_interface():
-    """ Test the extrapolation module interface"""
+    """Test the extrapolation module interface."""
 
     from pysteps import extrapolation
     from pysteps.extrapolation import semilagrangian
@@ -52,10 +49,10 @@ def test_extrapolation_interface():
     method_getter = extrapolation.interface.get_method
 
     valid_returned_objs = dict()
-    valid_returned_objs['semilagrangian'] = (semilagrangian.initialize,
-                                             semilagrangian.extrapolate)
-    valid_returned_objs['eulerian'] = (_return_none, eulerian)
-    valid_returned_objs[None] = (_return_none, do_nothing)
+    valid_returned_objs['semilagrangian'] = semilagrangian.extrapolate
+    valid_returned_objs['eulerian'] = eulerian
+    valid_returned_objs[None] = do_nothing
+    valid_returned_objs['None'] = do_nothing
 
     valid_names_func_pair = list(valid_returned_objs.items())
 
@@ -63,24 +60,21 @@ def test_extrapolation_interface():
     _generic_interface_test(method_getter, valid_names_func_pair, invalid_names)
 
     # Test eulerian persistence method
-    extrapolator = None
     precip = numpy.random.rand(100, 100)
     velocity = numpy.random.rand(100, 100)
     num_timesteps = 10
     for name in ["eulerian", "EULERIAN"]:
-        initialization, forecaster = method_getter(name)
-        assert initialization() is None
-        forecast = forecaster(extrapolator, precip, velocity, num_timesteps)
+        forecaster = method_getter(name)
+        forecast = forecaster(precip, velocity, num_timesteps)
         for i in range(num_timesteps):
             assert numpy.all(forecast[i] == precip)
 
-    initialization, forecaster = method_getter(None)
-    assert initialization() is None
-    assert forecaster(extrapolator, precip, velocity, num_timesteps) is None
+    forecaster = method_getter(None)
+    assert forecaster(precip, velocity, num_timesteps) is None
 
 
 def test_io_interface():
-    """ Test the io module interface"""
+    """Test the io module interface."""
 
     from pysteps.io import import_bom_rf3
     from pysteps.io import import_fmi_pgm
@@ -127,7 +121,7 @@ def test_io_interface():
 
 
 def test_motion_interface():
-    """ Test the motion module interface"""
+    """Test the motion module interface."""
 
     from pysteps.motion.darts import DARTS
     from pysteps.motion.lucaskanade import dense_lucaskanade
@@ -155,7 +149,7 @@ def test_motion_interface():
 
 
 def test_noise_interface():
-    """ Test the noise module interface"""
+    """Test the noise module interface."""
 
     from pysteps.noise.fftgenerators import (initialize_param_2d_fft_filter,
                                              generate_noise_2d_fft_filter,
@@ -185,7 +179,7 @@ def test_noise_interface():
 
 
 def test_nowcasts_interface():
-    """ Test the nowcasts module interface"""
+    """Test the nowcasts module interface."""
 
     from pysteps.nowcasts import steps
     from pysteps.nowcasts import extrapolation
@@ -208,7 +202,7 @@ def test_nowcasts_interface():
 
 
 def test_utils_interface():
-    """ Test utils module interface"""
+    """Test utils module interface."""
 
     from pysteps.utils import conversion
     from pysteps.utils import transformation


### PR DESCRIPTION
This is the simplified version of the extrapolation and the nowcasts interface that do not need the extrapolator object returned by the initializing functions.  

Y run a few comparison and the results of the [run_parallel_scaling_tests.py](https://github.com/pySTEPS/pysteps-publication/blob/master/run_parallel_scaling_tests.py) script are very similar with the master version. The differences are minimal, and can not be distinguished from the differences between two runs of the same script using the master pysteps version. 

This pull request closes issue #45.