### PR TITLE
Add macos env to test on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,15 @@ before_install:
   # -----------------
   # - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update      ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then xcode-select --install  ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CC=gcc-8  ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CXX=g++-8 ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CXX1X=g++-8 ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which gcc-8 ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which gcc ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then gcc-8 --version ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then gcc --version ; fi
-
+xcode-select --install
   # Install miniconda
   # -----------------
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,26 @@
 language: python
 
-env:
-    matrix:
+matrix:
+  include:
+    - os: linux
+      python: 3.6
+      env: 
         - PYTHON_VERSION=3.6
-          PACKAGES="cython numpy attrdict jsmin jsonschema matplotlib netCDF4 opencv pillow pyproj scipy dask"
+        - TOXENV=py36
+        - PACKAGES="cython numpy attrdict jsmin jsonschema matplotlib netCDF4 opencv pillow pyproj scipy dask"
+    # - os: osx
+    #   language: generic
+    #   env: 
+    #     - PYTHON_VERSION=3.6
+    #     - TOXENV=py36
+    #     - PACKAGES="cython numpy attrdict jsmin jsonschema matplotlib netCDF4 opencv pillow pyproj scipy dask"
 
 sudo: false
 
 install:
   # Install miniconda
   # -----------------
-  - travis_retry wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then travis_retry wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
 
@@ -29,16 +39,6 @@ install:
   - PACKAGES="$PACKAGES pytest pytest-cov coveralls codecov";
   - export CYTHON_COVERAGE=1;
   - travis_retry conda install --quiet $PACKAGES
-
-  # Conda debug
-  # -----------
-  # - conda list -n $ENV_NAME
-  # - conda list -n $ENV_NAME --explicit
-  # - conda info -a
-
-  # - MPL_CONFIG_DIR=~/.config/matplotlib
-  # - mkdir -p $MPL_CONFIG_DIR
-  # - echo "backend" ":" "agg" > $MPL_CONFIG_DIR/matplotlibrc
 
   # Install pySTEPS
   # ---------------

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ matrix:
         - PYTHON_VERSION=3.6
         - TOXENV=py36
         - PACKAGES="cython numpy attrdict jsmin jsonschema matplotlib netCDF4 opencv pillow pyproj scipy dask"
-  allow_failures:
     - os: osx
       language: generic
       env: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,12 @@ matrix:
 
 sudo: false
 
-install:
+before_install:
   # Install miniconda
   # -----------------
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then travis_retry wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+    travis_retry wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
 
@@ -40,6 +42,7 @@ install:
   - export CYTHON_COVERAGE=1;
   - travis_retry conda install --quiet $PACKAGES
 
+install:
   # Install pySTEPS
   # ---------------
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,30 +6,27 @@ matrix:
       python: 3.6
       env: 
         - PYTHON_VERSION=3.6
-        - TOXENV=py36
         - PACKAGES="cython numpy attrdict jsmin jsonschema matplotlib netCDF4 opencv pillow pyproj scipy dask"
     - os: osx
       language: generic
+      osx_image: xcode10.1
       env: 
         - PYTHON_VERSION=3.6
-        - TOXENV=py36
         - PACKAGES="cython numpy attrdict jsmin jsonschema matplotlib netCDF4 opencv pillow pyproj scipy dask"
 
 sudo: false
-osx_image: xcode10.1
 
 before_install:
-  # Install gcc for MacOS
+  # Install gcc for MacOSX
   # -----------------
-  # - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update      ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CC=gcc-8  ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CXX=g++-8 ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CXX1X=g++-8 ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which gcc-8 ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which gcc ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then gcc-8 --version ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then gcc --version ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      brew install gcc ;
+      export CC=gcc-8  ;
+      export CXX=g++-8 ;
+      export CXX1X=g++-8 ;
+      which gcc-8 ;
+      gcc-8 --version ;
+    fi
   # Install miniconda
   # -----------------
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
@@ -59,10 +56,6 @@ before_install:
   - travis_retry conda install --quiet $PACKAGES
 
 install:
-  # check GCC installation
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which gcc-8 ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then which gcc ; fi
-
   # Install pySTEPS
   # ---------------
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,13 @@ matrix:
 sudo: false
 
 before_install:
+  # Install gcc for MacOS
+  # -----------------
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update      ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CC=gcc-8  ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CXX=g++-8 ; fi
+
   # Install miniconda
   # -----------------
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
@@ -47,6 +54,9 @@ before_install:
   - travis_retry conda install --quiet $PACKAGES
 
 install:
+  # check GCC installation
+  - which gcc-8
+  - which gcc
   # Install pySTEPS
   # ---------------
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which gcc ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then gcc-8 --version ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then gcc --version ; fi
-xcode-select --install
   # Install miniconda
   # -----------------
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,13 @@ matrix:
         - PACKAGES="cython numpy attrdict jsmin jsonschema matplotlib netCDF4 opencv pillow pyproj scipy dask"
 
 sudo: false
+osx_image: xcode10.1
 
 before_install:
   # Install gcc for MacOS
   # -----------------
   # - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update      ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then xcode-select --install  ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CC=gcc-8  ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CXX=g++-8 ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CXX1X=g++-8 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,13 @@ matrix:
         - PYTHON_VERSION=3.6
         - TOXENV=py36
         - PACKAGES="cython numpy attrdict jsmin jsonschema matplotlib netCDF4 opencv pillow pyproj scipy dask"
-    # - os: osx
-    #   language: generic
-    #   env: 
-    #     - PYTHON_VERSION=3.6
-    #     - TOXENV=py36
-    #     - PACKAGES="cython numpy attrdict jsmin jsonschema matplotlib netCDF4 opencv pillow pyproj scipy dask"
+  allow_failures:
+    - os: osx
+      language: generic
+      env: 
+        - PYTHON_VERSION=3.6
+        - TOXENV=py36
+        - PACKAGES="cython numpy attrdict jsmin jsonschema matplotlib netCDF4 opencv pillow pyproj scipy dask"
 
 sudo: false
 
@@ -23,6 +24,10 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     travis_retry wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
     fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    travis_retry wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
+    fi
+
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,14 @@ sudo: false
 before_install:
   # Install gcc for MacOS
   # -----------------
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update      ; fi
+  # - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update      ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CC=gcc-8  ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CXX=g++-8 ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which gcc-8 ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which gcc ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then gcc-8 --version ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then gcc --version ; fi
 
   # Install miniconda
   # -----------------
@@ -55,8 +59,9 @@ before_install:
 
 install:
   # check GCC installation
-  - which gcc-8
-  - which gcc
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which gcc-8 ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then which gcc ; fi
+
   # Install pySTEPS
   # ---------------
   - python setup.py install

--- a/setup.py
+++ b/setup.py
@@ -12,12 +12,10 @@ except ImportError:
         "Try installing it with:\n" +
         "$> pip install numpy")
 
+extra_link_args = ['-fopenmp']
+
 if sys.platform.startswith('darwin'):
-    extra_link_args = ['-fopenmp']
-else:
-    extra_link_args = ['-fopenmp',
-                       '-Wl,-rpath,/usr/local/opt/gcc/lib/gcc/8/',
-                       ]
+    extra_link_args.append('-Wl,-rpath,/usr/local/opt/gcc/lib/gcc/8/')
 
 _vet_extension_arguments = dict(extra_compile_args=['-fopenmp'],
                                 include_dirs=[numpy.get_include()],

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 
 from setuptools import setup, find_packages
 from setuptools.extension import Extension
+import sys
 
 try:
     import numpy
@@ -11,10 +12,18 @@ except ImportError:
         "Try installing it with:\n" +
         "$> pip install numpy")
 
+if sys.platform.startswith('darwin'):
+    extra_link_args = ['-fopenmp']
+else:
+    extra_link_args = ['-fopenmp',
+                       '-Wl,-rpath,/usr/local/opt/gcc/lib/gcc/8/',
+                       ]
+
 _vet_extension_arguments = dict(extra_compile_args=['-fopenmp'],
                                 include_dirs=[numpy.get_include()],
                                 language='c',
-                                extra_link_args=['-fopenmp'])
+                                extra_link_args=extra_link_args,
+                                )
 
 try:
     from Cython.Build.Dependencies import cythonize


### PR DESCRIPTION
- Add macOS enviroment to TravisCI

- Uses `Homebrew` to install `gcc` with `openMP` support in macOS as per instructions in pySTEPS README file

- Tests passed using Python3.6, xcode10.1 and Mac OS X 10.13.6 (https://travis-ci.org/cvelascof/pysteps/jobs/510283462)

- `setup.py` modified to explicitly link libraries in macOS as recommended here (https://github.com/gprMax/gprMax/issues/134#issuecomment-340467832). This may help to solve issue of @LuigiJR https://github.com/pySTEPS/pysteps/issues/37#issuecomment-467719662