### PR TITLE
Fix pysteps.io.archive._generate_path function

### DIFF
--- a/pysteps/io/archive.py
+++ b/pysteps/io/archive.py
@@ -14,6 +14,7 @@ from datetime import datetime, timedelta
 import fnmatch
 import os
 
+
 def find_by_date(date, root_path, path_fmt, fn_pattern, fn_ext, timestep,
                  num_prev_files=0, num_next_files=0):
     """List input files whose timestamp matches the given date.
@@ -51,11 +52,11 @@ def find_by_date(date, root_path, path_fmt, fn_pattern, fn_ext, timestep,
         assigned if a file name corresponding to a given timestamp is not found.
 
     """
-    filenames  = []
+    filenames = []
     timestamps = []
 
-    for i in range(num_prev_files+num_next_files+1):
-        curdate = date + timedelta(minutes=num_next_files*timestep) - timedelta(minutes=i*timestep)
+    for i in range(num_prev_files + num_next_files + 1):
+        curdate = date + timedelta(minutes=num_next_files * timestep) - timedelta(minutes=i * timestep)
         fn = _find_matching_filename(curdate, root_path, path_fmt, fn_pattern, fn_ext)
         filenames.append(fn)
 
@@ -64,10 +65,11 @@ def find_by_date(date, root_path, path_fmt, fn_pattern, fn_ext, timestep,
     if all(filename is None for filename in filenames):
         raise IOError("no input data found in %s" % root_path)
 
-    if (num_prev_files+num_next_files) > 0:
+    if (num_prev_files + num_next_files) > 0:
         return (filenames[::-1], timestamps[::-1])
     else:
         return (filenames, timestamps)
+
 
 def _find_matching_filename(date, root_path, path_fmt, fn_pattern, fn_ext):
     path = _generate_path(date, root_path, path_fmt)
@@ -86,23 +88,25 @@ def _find_matching_filename(date, root_path, path_fmt, fn_pattern, fn_ext):
                         break
 
         fn = os.path.join(path, fn)
-         
+
         if os.path.exists(fn):
             fn = fn
         else:
-            print('filename for date %s not found in %s' % (date,path))
+            print('filename for date %s not found in %s' % (date, path))
             fn = None
     else:
         print('path', path, 'not found.')
-        
+
     return fn
 
-def _generate_path(date, root_path, path_fmt):
-    f = lambda t: datetime.strftime(date, t) if t[0] == '%' else t
-    if path_fmt != "":
-        tokens = [f(t) for t in path_fmt.split('/')]
-        subpath = os.path.join(*tokens)
 
-        return os.path.join(root_path, subpath)
+def _generate_path(date, root_path, path_format):
+    """Generate file path."""
+    if not isinstance(date, datetime):
+        raise TypeError("The input 'date' argument must be a datetime object")
+
+    if path_format != "":
+        sub_path = date.strftime(path_format)
+        return os.path.join(root_path, sub_path)
     else:
         return root_path

--- a/pysteps/tests/test_archive.py
+++ b/pysteps/tests/test_archive.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+# Test the io.archive module
+import os
+from datetime import datetime
+
+import pytest
+
+from pysteps.io.archive import _generate_path
+
+test_argvalues = [
+    ("20190130_1200", "%Y/foo/%m", "./2019/foo/01"),
+    ("20190225_1200", "%Y/foo/%m", "./2019/foo/02"),
+    ("20190122_2222", "%Y/foo/%m", "./2019/foo/01"),
+    ("20190130_1200", "%Y/foo/%m", "./2019/foo/01"),
+    ("20190130_1205", "%Y%m%d/foo/bar/%H%M", "./20190130/foo/bar/1205"),
+    ("20190130_1205", "foo/bar/%H%M", "./foo/bar/1205")]
+
+
+@pytest.mark.parametrize("timestamp, path_fmt, expected_path", test_argvalues)
+def test_generate_path(timestamp, path_fmt, expected_path):
+    date = datetime.strptime(timestamp, "%Y%m%d_%H%M")
+    assert _generate_path(date, "./", path_fmt) == expected_path


### PR DESCRIPTION
**pysteps.io.archive._generate_path** function was not convert paths appropriately.  Only format strings that start with % were formatted using [strftime](https://docs.python.org/3/library/datetime.html#datetime.date.strftime). Otherwise a the same format string was returned.

This PR fix that issue and also add tests for that function.
