### PR TITLE
Add more details for minimum python version

### DIFF
--- a/doc/source/user_guide/install_pysteps.rst
+++ b/doc/source/user_guide/install_pysteps.rst
@@ -8,7 +8,7 @@ Dependencies
 
 The pysteps package needs the following dependencies
 
-* `python >=3.6 <http://www.python.org/>`_
+* `python >=3.6 (Need F-string support) <http://www.python.org/>`_
 * `attrdict <https://pypi.org/project/attrdict/>`_
 * `jsmin <https://pypi.org/project/jsmin/>`_
 * `jsonschema <https://pypi.org/project/jsonschema/>`_

--- a/pysteps/nowcasts/utils.py
+++ b/pysteps/nowcasts/utils.py
@@ -122,11 +122,10 @@ def stack_cascades(R_d, n_levels, donorm=True):
             if donorm:
                 mu_ = R_d[j]["means"][i]
                 sigma_ = R_d[j]["stds"][i]
-            if j == n_inputs - 1:
-                mu[i] = mu_
-                sigma[i] = sigma_
             R__ = (R_d[j]["cascade_levels"][i, :, :] - mu_) / sigma_
             R_.append(R__)
+        mu[i] = R_d[n_inputs - 1]["means"][i]
+        sigma[i] = R_d[n_inputs - 1]["stds"][i]
         R_c.append(np.stack(R_))
 
     return np.stack(R_c), mu, sigma

--- a/pysteps/nowcasts/utils.py
+++ b/pysteps/nowcasts/utils.py
@@ -122,10 +122,11 @@ def stack_cascades(R_d, n_levels, donorm=True):
             if donorm:
                 mu_ = R_d[j]["means"][i]
                 sigma_ = R_d[j]["stds"][i]
+            if j == n_inputs - 1:
+                mu[i] = mu_
+                sigma[i] = sigma_
             R__ = (R_d[j]["cascade_levels"][i, :, :] - mu_) / sigma_
             R_.append(R__)
-        mu[i] = R_d[n_inputs - 1]["means"][i]
-        sigma[i] = R_d[n_inputs - 1]["stds"][i]
         R_c.append(np.stack(R_))
 
     return np.stack(R_c), mu, sigma


### PR DESCRIPTION
Python3.6 is the minimum python version to support F-string, which needs attention. 
I tried to use python3.5 and failed very late. It will save time to reinstall python3.6 at the beginning.
