### PR TITLE
Add Z-R parameters (#103)

### DIFF
--- a/doc/source/user_guide/pystepsrc_example.rst
+++ b/doc/source/user_guide/pystepsrc_example.rst
@@ -73,7 +73,9 @@ The lines starting with "//" are comments and they are ignored.
                 "importer": "knmi_hdf5",
                 "timestep": 5,
                 "importer_kwargs": {
-                    "accutime": 5
+                    "accutime": 5,
+                    "qty": "ACRR",
+                    "pixelsize": 1000.0
                 }
             }
         }

--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -16,7 +16,7 @@ precipitation field, the corresponding quality field and a metadata dictionary.
 If the file contains no quality information, the quality field is set to None.
 Pixels containing missing data are set to nan.
 
-The metadata dictionary contains the following mandatory key-value pairs:
+The metadata dictionary contains the following recommended key-value pairs:
 
 .. tabularcolumns:: |p{2cm}|L|
 

--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -16,7 +16,7 @@ precipitation field, the corresponding quality field and a metadata dictionary.
 If the file contains no quality information, the quality field is set to None.
 Pixels containing missing data are set to nan.
 
-The metadata dictionary contains the following recommended key-value pairs:
+The metadata dictionary contains the following mandatory key-value pairs:
 
 .. tabularcolumns:: |p{2cm}|L|
 
@@ -60,10 +60,6 @@ The metadata dictionary contains the following recommended key-value pairs:
 +------------------+----------------------------------------------------------+
 |    zerovalue     | the value assigned to the no rain pixels with the same   |
 |                  | unit, transformation and accutime of the data.           |
-+------------------+----------------------------------------------------------+
-|    zr_a          | the Z-R constant a in Z = a*R**b                         |
-+------------------+----------------------------------------------------------+
-|    zr_b          | the Z-R exponent b in Z = a*R**b                         |
 +------------------+----------------------------------------------------------+
 
 Available Importers
@@ -390,8 +386,6 @@ def import_fmi_pgm(filename, **kwargs):
         metadata["threshold"] = np.nanmin(R[R > np.nanmin(R)])
     else:
         metadata["threshold"] = np.nan
-    metadata["zr_a"] = 223.0
-    metadata["zr_b"] = 1.53
 
     return R, None, metadata
 
@@ -582,8 +576,6 @@ def import_mch_gif(filename, product, unit, accutime):
         metadata["threshold"] = np.nan
     metadata["institution"] = "MeteoSwiss"
     metadata["product"] = product
-    metadata["zr_a"] = 316.0
-    metadata["zr_b"] = 1.5
 
     return R, None, metadata
 
@@ -712,8 +704,6 @@ def import_mch_hdf5(filename, **kwargs):
             "transform": transform,
             "zerovalue": np.nanmin(R),
             "threshold": thr,
-            "zr_a": 316.0,
-            "zr_b": 1.5,
         }
     )
 
@@ -783,8 +773,6 @@ def import_mch_metranet(filename, product, unit, accutime):
         metadata["threshold"] = np.nan
     else:
         metadata["threshold"] = np.nanmin(R[R > metadata["zerovalue"]])
-    metadata["zr_a"] = 316.0
-    metadata["zr_b"] = 1.5
 
     return R, None, metadata
 
@@ -1019,8 +1007,13 @@ def _read_opera_hdf5_what_group(whatgrp):
 
 
 def import_knmi_hdf5(filename, **kwargs):
-    """Import a precipitation field (and optionally the quality field) from a
-    HDF5 file conforming to the KNMI Data Centre specification.
+    """Import a precipitation or reflectivity field (and optionally the quality 
+    field) from a HDF5 file conforming to the KNMI Data Centre specification.
+    Note: don't forget to change the 'pystepsrc'-file in order to be able to 
+    import your data. Every KNMI data type has a slightly different naming 
+    convention. The standard setup is based on the accumulated rainfall product
+    on 1 km2 spatial and 5 min. temporal resolution. 
+    See "https://data.knmi.nl/datasets?q=radar" for all available radar data.
 
     Parameters
     ----------
@@ -1029,6 +1022,10 @@ def import_knmi_hdf5(filename, **kwargs):
 
     Other Parameters
     ----------------
+    qty : {'ACRR', 'DBZH'}
+        The quantity to read from the file. The currently supported identitiers
+        are: 'ACRR'=hourly rainfall accumulation (mm) and 'DBZH'=max-reflectivity 
+        (dBZ). The default value is 'ACRR'.
     accutime : float
         The accumulation time of the dataset in minutes.
     pixelsize: float
@@ -1037,9 +1034,9 @@ def import_knmi_hdf5(filename, **kwargs):
     Returns
     -------
     out : tuple
-        A three-element tuple containing precipitation accumulation of the KNMI
-        product, the associated quality field and metadata. The quality
-        field is currently set to None.
+        A three-element tuple containing precipitation accumulation [mm] / 
+        reflectivity [DBZ] of the KNMI product, the associated quality field 
+        and metadata. The quality field is currently set to None.
 
     """
 
@@ -1047,13 +1044,30 @@ def import_knmi_hdf5(filename, **kwargs):
 
     if not h5py_imported:
         raise Exception("h5py not imported")
+    
+    ###
+    # Options for kwargs.get
+    ###
+    
+    # The unit in the 2D fields: either hourly rainfall accumulation (ACRR) or
+    # reflectivity (DBZH)
+    qty = kwargs.get("qty", "ACRR")
 
-    # Generally, the 5 min. data is used, but also hourly, daily and monthly
-    # accumulations are present.
-    accutime = kwargs.get("accutime", 5.0)
+    if qty not in ["ACRR", "DBZH"]:
+        raise ValueError(
+            "unknown quantity %s: the available options are 'ACRR' and 'DBZH' "
+        )
+
+    # The time step. Generally, the 5 min. data is used, but also hourly, daily 
+    # and monthly accumulations are present.
+    accutime = kwargs.get(
+            "accutime", 5.0
+    )
+    # The pixel size. Recommended is to use KNMI datasets with 1 km grid cell size.
+    # 1.0 or 2.4 km datasets are available - give pixelsize in meters
     pixelsize = kwargs.get(
         "pixelsize", 1000.0
-    )  # 1.0 or 2.4 km datasets are available - give pixelsize in meters
+    )  
 
     ####
     # Precipitation fields
@@ -1062,19 +1076,36 @@ def import_knmi_hdf5(filename, **kwargs):
     f = h5py.File(filename, "r")
     dset = f["image1"]["image_data"]
     R_intermediate = np.copy(dset)  # copy the content
-    R = np.where(R_intermediate == 65535, np.NaN, R_intermediate / 100.0)
-    # R is divided by 100.0, because the data is saved as hundreds of mm (so, as integers)
-    # 65535 is the no data value
-    # Precision of the data is two decimals (0.01 mm).
+    
+    # In case R is a rainfall accumulation (ACRR), R is divided by 100.0, 
+    # because the data is saved as hundreds of mm (so, as integers). 65535 is 
+    # the no data value. The precision of the data is two decimals (0.01 mm).
+    if qty == "ACRR":
+        R = np.where(R_intermediate == 65535, np.NaN, R_intermediate / 100.0)
+
+    # In case reflectivities are imported, the no data value is 255. Values are
+    # saved as integers. The reflectivities are not directly saved in dBZ, but 
+    # as: dBZ = 0.5 * pixel_value - 31.5
+    if qty == "DBZH":
+        R = np.where(R_intermediate == 255, np.NaN, R_intermediate * 0.5 - 31.5)
 
     if R is None:
-        raise IOError("requested quantity [mm] not found")
+        raise IOError("requested quantity not found")
+
+    #TODO: Check if the reflectivity conversion equation is still up to date (unfortunately not well documented)
 
     ####
     # Meta data
     ####
 
     metadata = {}
+
+    if qty == "ACRR":
+        unit = "mm"
+        transform = None
+    elif qty == "DBZH":
+        unit = "dBZ"
+        transform = "dB"
 
     # The 'where' group of mch- and Opera-data, is called 'geographic' in the
     # KNMI data.
@@ -1108,18 +1139,19 @@ def import_knmi_hdf5(filename, **kwargs):
     metadata["y1"] = y1 * 1000.
     metadata["x2"] = x2 * 1000.
     metadata["y2"] = y2 * 1000.
-
     metadata["xpixelsize"] = pixelsize
     metadata["ypixelsize"] = pixelsize
-
     metadata["yorigin"] = "upper"
     metadata["institution"] = "KNMI - Royal Netherlands Meteorological Institute"
     metadata["accutime"] = accutime
-    metadata["unit"] = "mm"
-    metadata["transform"] = None
+    metadata["unit"] = unit
+    metadata["transform"] = transform
     metadata["zerovalue"] = 0.0
     metadata["threshold"] = np.nanmin(R[R > np.nanmin(R)])
+    metadata["zr_a"] = 200.0
+    metadata["zr_b"] = 1.6
 
     f.close()
+
 
     return R, None, metadata

--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -631,7 +631,7 @@ def import_mch_hdf5(filename, **kwargs):
     Q = None
 
     for dsg in f.items():
-        if dsg[0][0:7] == "dataset":
+        if dsg[0].startswith("dataset"):
             what_grp_found = False
             # check if the "what" group is in the "dataset" group
             if "what" in list(dsg[1].keys()):
@@ -869,7 +869,7 @@ def import_opera_hdf5(filename, **kwargs):
     Q = None
 
     for dsg in f.items():
-        if dsg[0][0:7] == "dataset":
+        if dsg[0].startswith("dataset"):
             what_grp_found = False
             # check if the "what" group is in the "dataset" group
             if "what" in list(dsg[1].keys()):

--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -212,16 +212,12 @@ def _import_bom_rf3_geodata(filename):
         ymin = min(ds_rainfall.variables["y"])
         ymax = max(ds_rainfall.variables["y"])
 
-    xpixelsize = (
-        abs(ds_rainfall.variables["x"][1] - ds_rainfall.variables["x"][0])
-    )
-    ypixelsize = (
-        abs(ds_rainfall.variables["y"][1] - ds_rainfall.variables["y"][0])
-    )
+    xpixelsize = abs(ds_rainfall.variables["x"][1] - ds_rainfall.variables["x"][0])
+    ypixelsize = abs(ds_rainfall.variables["y"][1] - ds_rainfall.variables["y"][0])
     factor_scale = 1.0
     if "units" in ds_rainfall.variables["x"].ncattrs():
         if getattr(ds_rainfall.variables["x"], "units") == "km":
-            factor_scale = 1000.
+            factor_scale = 1000.0
 
     geodata["x1"] = xmin * factor_scale
     geodata["y1"] = ymin * factor_scale
@@ -236,24 +232,18 @@ def _import_bom_rf3_geodata(filename):
 
     if "valid_time" in ds_rainfall.variables.keys():
         times = ds_rainfall.variables["valid_time"]
-        calendar = 'standard'
-        if 'calendar' in times.ncattrs():
+        calendar = "standard"
+        if "calendar" in times.ncattrs():
             calendar = times.calendar
-        valid_time = netCDF4.num2date(times[:],
-                                      units=times.units,
-                                      calendar=calendar,
-                                      )
+        valid_time = netCDF4.num2date(times[:], units=times.units, calendar=calendar)
 
     start_time = None
     if "start_time" in ds_rainfall.variables.keys():
         times = ds_rainfall.variables["start_time"]
-        calendar = 'standard'
-        if 'calendar' in times.ncattrs():
+        calendar = "standard"
+        if "calendar" in times.ncattrs():
             calendar = times.calendar
-        start_time = netCDF4.num2date(times[:],
-                                      units=times.units,
-                                      calendar=calendar,
-                                      )
+        start_time = netCDF4.num2date(times[:], units=times.units, calendar=calendar)
 
     time_step = None
 
@@ -319,8 +309,8 @@ def import_fmi_geotiff(filename, **kwargs):
 
     metadata["projection"] = projdef
     metadata["x1"] = gt[0]
-    metadata["y1"] = gt[3] + gt[5]*f.RasterYSize
-    metadata["x2"] = metadata["x1"] + gt[1]*f.RasterXSize
+    metadata["y1"] = gt[3] + gt[5] * f.RasterYSize
+    metadata["x2"] = metadata["x1"] + gt[1] * f.RasterXSize
     metadata["y2"] = gt[3]
     metadata["xpixelsize"] = abs(gt[1])
     metadata["ypixelsize"] = abs(gt[5])
@@ -1069,11 +1059,11 @@ def import_knmi_hdf5(filename, **kwargs):
 
     if not h5py_imported:
         raise Exception("h5py not imported")
-    
+
     ###
     # Options for kwargs.get
     ###
-    
+
     # The unit in the 2D fields: either hourly rainfall accumulation (ACRR) or
     # reflectivity (DBZH)
     qty = kwargs.get("qty", "ACRR")
@@ -1083,16 +1073,12 @@ def import_knmi_hdf5(filename, **kwargs):
             "unknown quantity %s: the available options are 'ACRR' and 'DBZH' "
         )
 
-    # The time step. Generally, the 5 min. data is used, but also hourly, daily 
+    # The time step. Generally, the 5 min. data is used, but also hourly, daily
     # and monthly accumulations are present.
-    accutime = kwargs.get(
-            "accutime", 5.0
-    )
+    accutime = kwargs.get("accutime", 5.0)
     # The pixel size. Recommended is to use KNMI datasets with 1 km grid cell size.
     # 1.0 or 2.4 km datasets are available - give pixelsize in meters
-    pixelsize = kwargs.get(
-        "pixelsize", 1000.0
-    )  
+    pixelsize = kwargs.get("pixelsize", 1000.0)
 
     ####
     # Precipitation fields
@@ -1101,15 +1087,15 @@ def import_knmi_hdf5(filename, **kwargs):
     f = h5py.File(filename, "r")
     dset = f["image1"]["image_data"]
     R_intermediate = np.copy(dset)  # copy the content
-    
-    # In case R is a rainfall accumulation (ACRR), R is divided by 100.0, 
-    # because the data is saved as hundreds of mm (so, as integers). 65535 is 
+
+    # In case R is a rainfall accumulation (ACRR), R is divided by 100.0,
+    # because the data is saved as hundreds of mm (so, as integers). 65535 is
     # the no data value. The precision of the data is two decimals (0.01 mm).
     if qty == "ACRR":
         R = np.where(R_intermediate == 65535, np.NaN, R_intermediate / 100.0)
 
     # In case reflectivities are imported, the no data value is 255. Values are
-    # saved as integers. The reflectivities are not directly saved in dBZ, but 
+    # saved as integers. The reflectivities are not directly saved in dBZ, but
     # as: dBZ = 0.5 * pixel_value - 31.5
     if qty == "DBZH":
         R = np.where(R_intermediate == 255, np.NaN, R_intermediate * 0.5 - 31.5)
@@ -1117,7 +1103,7 @@ def import_knmi_hdf5(filename, **kwargs):
     if R is None:
         raise IOError("requested quantity not found")
 
-    #TODO: Check if the reflectivity conversion equation is still up to date (unfortunately not well documented)
+    # TODO: Check if the reflectivity conversion equation is still up to date (unfortunately not well documented)
 
     ####
     # Meta data
@@ -1160,10 +1146,10 @@ def import_knmi_hdf5(filename, **kwargs):
     y1 = max(UL_y, UR_y)
 
     # Fill in the metadata
-    metadata["x1"] = x1 * 1000.
-    metadata["y1"] = y1 * 1000.
-    metadata["x2"] = x2 * 1000.
-    metadata["y2"] = y2 * 1000.
+    metadata["x1"] = x1 * 1000.0
+    metadata["y1"] = y1 * 1000.0
+    metadata["x2"] = x2 * 1000.0
+    metadata["y2"] = y2 * 1000.0
     metadata["xpixelsize"] = pixelsize
     metadata["ypixelsize"] = pixelsize
     metadata["yorigin"] = "upper"
@@ -1177,6 +1163,5 @@ def import_knmi_hdf5(filename, **kwargs):
     metadata["zr_b"] = 1.6
 
     f.close()
-
 
     return R, None, metadata

--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -390,6 +390,8 @@ def import_fmi_pgm(filename, **kwargs):
         metadata["threshold"] = np.nanmin(R[R > np.nanmin(R)])
     else:
         metadata["threshold"] = np.nan
+    metadata["zr_a"] = 223.0
+    metadata["zr_b"] = 1.53
 
     return R, None, metadata
 

--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -61,6 +61,10 @@ The metadata dictionary contains the following recommended key-value pairs:
 |    zerovalue     | the value assigned to the no rain pixels with the same   |
 |                  | unit, transformation and accutime of the data.           |
 +------------------+----------------------------------------------------------+
+|    zr_a          | the Z-R constant a in Z = a*R**b                         |
++------------------+----------------------------------------------------------+
+|    zr_b          | the Z-R exponent b in Z = a*R**b                         |
++------------------+----------------------------------------------------------+
 
 Available Importers
 -------------------

--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -1019,14 +1019,8 @@ def _read_opera_hdf5_what_group(whatgrp):
 
 
 def import_knmi_hdf5(filename, **kwargs):
-    """Import a precipitation or reflectivity field (and optionally the quality 
+    """Import a precipitation or reflectivity field (and optionally the quality
     field) from a HDF5 file conforming to the KNMI Data Centre specification.
-
-    Note: don't forget to change the 'pystepsrc'-file in order to be able to 
-    import your data. Every KNMI data type has a slightly different naming 
-    convention. The standard setup is based on the accumulated rainfall product
-    on 1 km2 spatial and 5 min. temporal resolution. 
-    See "https://data.knmi.nl/datasets?q=radar" for all available radar data.
 
     Parameters
     ----------
@@ -1038,27 +1032,46 @@ def import_knmi_hdf5(filename, **kwargs):
     ----------------
 
     qty : {'ACRR', 'DBZH'}
-        The quantity to read from the file. The currently supported identitiers
-        are: 'ACRR'=hourly rainfall accumulation (mm) and 'DBZH'=max-reflectivity 
+        The quantity to read from the file. The currently supported identifiers
+        are: 'ACRR'=hourly rainfall accumulation (mm) and 'DBZH'=max-reflectivity
         (dBZ). The default value is 'ACRR'.
+
     accutime : float
-        The accumulation time of the dataset in minutes.
+        The accumulation time of the dataset in minutes. A 5 min accumulation
+        is used as default, but hourly, daily and monthly accumulations
+        are also available.
+
     pixelsize: float
-        The pixelsize of a raster cell in meters.
+        The pixel size of a raster cell in meters. The default value for the KNMI
+        datasets is 1000 m grid cell size, but datasets with 2400 m pixel size
+        are also available.
 
     Returns
     -------
 
     out : tuple
-        A three-element tuple containing precipitation accumulation [mm] / 
-        reflectivity [DBZ] of the KNMI product, the associated quality field 
+        A three-element tuple containing precipitation accumulation [mm] /
+        reflectivity [dBZ] of the KNMI product, the associated quality field
         and metadata. The quality field is currently set to None.
+
+    Notes
+    -----
+
+    Every KNMI data type has a slightly different naming convention. The
+    standard setup is based on the accumulated rainfall product on 1 km2 spatial
+    and 5 min temporal resolution.
+    See https://data.knmi.nl/datasets?q=radar for a list of all available KNMI
+    radar data.
     """
 
     # TODO: Add quality field.
 
     if not h5py_imported:
-        raise Exception("h5py not imported")
+        raise MissingOptionalDependency(
+            "h5py package is required to import "
+            "KNMI's radar datasets "
+            "but it is not installed"
+        )
 
     ###
     # Options for kwargs.get
@@ -1073,7 +1086,7 @@ def import_knmi_hdf5(filename, **kwargs):
             "unknown quantity %s: the available options are 'ACRR' and 'DBZH' "
         )
 
-    # The time step. Generally, the 5 min. data is used, but also hourly, daily
+    # The time step. Generally, the 5 min data is used, but also hourly, daily
     # and monthly accumulations are present.
     accutime = kwargs.get("accutime", 5.0)
     # The pixel size. Recommended is to use KNMI datasets with 1 km grid cell size.

--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -580,6 +580,8 @@ def import_mch_gif(filename, product, unit, accutime):
         metadata["threshold"] = np.nan
     metadata["institution"] = "MeteoSwiss"
     metadata["product"] = product
+    metadata["zr_a"] = 316.0
+    metadata["zr_b"] = 1.5
 
     return R, None, metadata
 
@@ -708,6 +710,8 @@ def import_mch_hdf5(filename, **kwargs):
             "transform": transform,
             "zerovalue": np.nanmin(R),
             "threshold": thr,
+            "zr_a": 316.0,
+            "zr_b": 1.5,
         }
     )
 
@@ -777,6 +781,8 @@ def import_mch_metranet(filename, product, unit, accutime):
         metadata["threshold"] = np.nan
     else:
         metadata["threshold"] = np.nanmin(R[R > metadata["zerovalue"]])
+    metadata["zr_a"] = 316.0
+    metadata["zr_b"] = 1.5
 
     return R, None, metadata
 

--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -1,17 +1,25 @@
 """
 pysteps.io.importers
 ====================
+
 Methods for importing files containing 2d precipitation fields.
+
 The methods in this module implement the following interface::
+
     import_xxx(filename, optional arguments)
+
 where **xxx** is the name (or abbreviation) of the file format and filename
 is the name of the input file.
+
 The output of each method is a three-element tuple containing a two-dimensional
 precipitation field, the corresponding quality field and a metadata dictionary.
 If the file contains no quality information, the quality field is set to None.
 Pixels containing missing data are set to nan.
+
 The metadata dictionary contains the following recommended key-value pairs:
+
 .. tabularcolumns:: |p{2cm}|L|
+
 +------------------+----------------------------------------------------------+
 |       Key        |                Value                                     |
 +==================+==========================================================+
@@ -57,10 +65,13 @@ The metadata dictionary contains the following recommended key-value pairs:
 +------------------+----------------------------------------------------------+
 |    zr_b          | the Z-R exponent b in Z = a*R**b                         |
 +------------------+----------------------------------------------------------+
+
 Available Importers
 -------------------
+
 .. autosummary::
     :toctree: ../generated/
+
     import_bom_rf3
     import_fmi_geotiff
     import_fmi_pgm
@@ -121,12 +132,16 @@ except ImportError:
 
 def import_bom_rf3(filename, **kwargs):
     """Import a NetCDF radar rainfall product from the BoM Rainfields3.
+
     Parameters
     ----------
+
     filename : str
         Name of the file to import.
+
     Returns
     -------
+
     out : tuple
         A three-element tuple containing the rainfall field in mm/h imported
         from the Bureau RF3 netcdf, the quality field and the metadata. The
@@ -262,12 +277,16 @@ def _import_bom_rf3_geodata(filename):
 
 def import_fmi_geotiff(filename, **kwargs):
     """Import a reflectivity field (dBZ) from an FMI GeoTIFF file.
+
     Parameters
     ----------
+
     filename : str
         Name of the file to import.
+
     Returns
     -------
+
     out : tuple
         A three-element tuple containing the precipitation field, the associated
         quality field and metadata. The quality field is currently set to None.
@@ -322,16 +341,22 @@ def import_fmi_geotiff(filename, **kwargs):
 
 def import_fmi_pgm(filename, **kwargs):
     """Import a 8-bit PGM radar reflectivity composite from the FMI archive.
+
     Parameters
     ----------
+
     filename : str
         Name of the file to import.
+
     Other Parameters
     ----------------
+
     gzipped : bool
         If True, the input file is treated as a compressed gzip file.
+
     Returns
     -------
+
     out : tuple
         A three-element tuple containing the reflectivity composite in dBZ
         and the associated quality field and metadata. The quality field is
@@ -447,13 +472,17 @@ def _import_fmi_pgm_metadata(filename, gzipped=False):
 def import_mch_gif(filename, product, unit, accutime):
     """Import a 8-bit gif radar reflectivity composite from the MeteoSwiss
     archive.
+
     Parameters
     ----------
+
     filename : str
         Name of the file to import.
+
     product : {"AQC", "CPC", "RZC", "AZC"}
         The name of the MeteoSwiss QPE product.\n
         Currently supported prducts:
+
         +------+----------------------------+
         | Name |          Product           |
         +======+============================+
@@ -465,12 +494,16 @@ def import_mch_gif(filename, product, unit, accutime):
         +------+----------------------------+
         | AZC  |     RZC accumulation       |
         +------+----------------------------+
+
     unit : {"mm/h", "mm", "dBZ"}
         the physical unit of the data
+
     accutime : float
         the accumulation time in minutes of the data
+
     Returns
     -------
+
     out : tuple
         A three-element tuple containing the precipitation field in mm/h imported
         from a MeteoSwiss gif file and the associated quality field and metadata.
@@ -563,19 +596,25 @@ def import_mch_gif(filename, product, unit, accutime):
 def import_mch_hdf5(filename, **kwargs):
     """Import a precipitation field (and optionally the quality field) from a
     MeteoSwiss HDF5 file conforming to the ODIM specification.
+
     Parameters
     ----------
+
     filename : str
         Name of the file to import.
+
     Other Parameters
     ----------------
+
     qty : {'RATE', 'ACRR', 'DBZH'}
         The quantity to read from the file. The currently supported identitiers
         are: 'RATE'=instantaneous rain rate (mm/h), 'ACRR'=hourly rainfall
         accumulation (mm) and 'DBZH'=max-reflectivity (dBZ). The default value
         is 'RATE'.
+
     Returns
     -------
+
     out : tuple
         A three-element tuple containing the OPERA product for the requested
         quantity and the associated quality field and metadata. The quality
@@ -693,13 +732,17 @@ def import_mch_hdf5(filename, **kwargs):
 def import_mch_metranet(filename, product, unit, accutime):
     """Import a 8-bit bin radar reflectivity composite from the MeteoSwiss
     archive.
+
     Parameters
     ----------
+
     filename : str
         Name of the file to import.
+
     product : {"AQC", "CPC", "RZC", "AZC"}
         The name of the MeteoSwiss QPE product.\n
         Currently supported prducts:
+
         +------+----------------------------+
         | Name |          Product           |
         +======+============================+
@@ -711,12 +754,16 @@ def import_mch_metranet(filename, product, unit, accutime):
         +------+----------------------------+
         | AZC  |     RZC accumulation       |
         +------+----------------------------+
+
     unit : {"mm/h", "mm", "dBZ"}
         the physical unit of the data
+
     accutime : float
         the accumulation time in minutes of the data
+
     Returns
     -------
+
     out : tuple
         A three-element tuple containing the precipitation field in mm/h imported
         from a MeteoSwiss gif file and the associated quality field and metadata.
@@ -787,19 +834,25 @@ def _import_mch_geodata():
 def import_opera_hdf5(filename, **kwargs):
     """Import a precipitation field (and optionally the quality field) from an
     OPERA HDF5 file conforming to the ODIM specification.
+
     Parameters
     ----------
+
     filename : str
         Name of the file to import.
+
     Other Parameters
     ----------------
+
     qty : {'RATE', 'ACRR', 'DBZH'}
         The quantity to read from the file. The currently supported identitiers
         are: 'RATE'=instantaneous rain rate (mm/h), 'ACRR'=hourly rainfall
         accumulation (mm) and 'DBZH'=max-reflectivity (dBZ). The default value
         is 'RATE'.
+
     Returns
     -------
+
     out : tuple
         A three-element tuple containing the OPERA product for the requested
         quantity and the associated quality field and metadata. The quality
@@ -978,6 +1031,7 @@ def _read_opera_hdf5_what_group(whatgrp):
 def import_knmi_hdf5(filename, **kwargs):
     """Import a precipitation or reflectivity field (and optionally the quality 
     field) from a HDF5 file conforming to the KNMI Data Centre specification.
+
     Note: don't forget to change the 'pystepsrc'-file in order to be able to 
     import your data. Every KNMI data type has a slightly different naming 
     convention. The standard setup is based on the accumulated rainfall product
@@ -986,11 +1040,13 @@ def import_knmi_hdf5(filename, **kwargs):
 
     Parameters
     ----------
+
     filename : str
         Name of the file to import.
 
     Other Parameters
     ----------------
+
     qty : {'ACRR', 'DBZH'}
         The quantity to read from the file. The currently supported identitiers
         are: 'ACRR'=hourly rainfall accumulation (mm) and 'DBZH'=max-reflectivity 
@@ -1002,11 +1058,11 @@ def import_knmi_hdf5(filename, **kwargs):
 
     Returns
     -------
+
     out : tuple
         A three-element tuple containing precipitation accumulation [mm] / 
         reflectivity [DBZ] of the KNMI product, the associated quality field 
         and metadata. The quality field is currently set to None.
-
     """
 
     # TODO: Add quality field.

--- a/pysteps/pystepsrc
+++ b/pysteps/pystepsrc
@@ -65,7 +65,9 @@
             "importer": "knmi_hdf5",
             "timestep": 5,
             "importer_kwargs": {
-                "accutime": 5
+                "accutime": 5,
+                "qty": "ACRR",
+                "pixelsize": 1000.0
 			}
         }
     }

--- a/pysteps/tests/test_io_knmi_hdf5.py
+++ b/pysteps/tests/test_io_knmi_hdf5.py
@@ -44,7 +44,7 @@ test_metadata = [
     ('zerovalue', 0.0, 1e-10),
     ('threshold', 0.01, 1e-10),
     ('zr_a',200.0,None),
-    ('zr_b',1.5,None)
+    ('zr_b',1.6,None)
 ]
 
 

--- a/pysteps/tests/test_io_knmi_hdf5.py
+++ b/pysteps/tests/test_io_knmi_hdf5.py
@@ -43,6 +43,8 @@ test_metadata = [
     ('transform', None, None),
     ('zerovalue', 0.0, 1e-10),
     ('threshold', 0.01, 1e-10),
+    ('zr_a',200.0,None),
+    ('zr_b',1.5,None)
 ]
 
 

--- a/pysteps/tests/test_io_mch_gif.py
+++ b/pysteps/tests/test_io_mch_gif.py
@@ -40,6 +40,8 @@ test_metadata = [
     ("threshold", 0.0009628129986471908, 1e-19),
     ("institution", "MeteoSwiss", None),
     ("product", "AQC", None),
+    ("zr_a", 316.0, None),
+    ("zr_b", 1.5, None),
 ]
 
 

--- a/pysteps/tests/test_utils.py
+++ b/pysteps/tests/test_utils.py
@@ -83,7 +83,7 @@ test_data = [
             "threshold": 0,
             "zerovalue": 0,
         },
-        np.array([0.02513093]),
+        np.array([0.04210719]),
     ),
     (
         np.array([1]),
@@ -193,7 +193,7 @@ test_data = [
             "threshold": 0,
             "zerovalue": 0,
         },
-        np.array([0.00209424]),
+        np.array([0.00350893]),
     ),
     (
         np.array([1]),
@@ -259,7 +259,7 @@ test_data = [
             "threshold": 0,
             "zerovalue": 0,
         },
-        np.array([24.99687083]),
+        np.array([23.01029996]),
     ),
     (
         np.array([1]),
@@ -270,7 +270,7 @@ test_data = [
             "threshold": 0,
             "zerovalue": 0,
         },
-        np.array([41.18458952]),
+        np.array([40.27719989]),
     ),
     (
         np.array([1]),
@@ -281,7 +281,7 @@ test_data = [
             "threshold": 0,
             "zerovalue": 0,
         },
-        np.array([26.49687083]),
+        np.array([24.61029996]),
     ),
     (
         np.array([1]),
@@ -292,7 +292,7 @@ test_data = [
             "threshold": 0,
             "zerovalue": 0,
         },
-        np.array([42.68458952]),
+        np.array([41.87719989]),
     ),
     (
         np.array([1]),
@@ -314,7 +314,7 @@ test_data = [
             "threshold": 0,
             "zerovalue": 0,
         },
-        np.array([31.51128805]),
+        np.array([29.95901167]),
     ),
     (
         np.array([1.0]),
@@ -325,7 +325,7 @@ test_data = [
             "threshold": 0,
             "zerovalue": 0,
         },
-        np.array([47.69900675]),
+        np.array([47.2259116]),
     ),
     (
         np.array([1]),
@@ -336,7 +336,7 @@ test_data = [
             "threshold": 0,
             "zerovalue": 0,
         },
-        np.array([24.99687083]),
+        np.array([23.01029996]),
     ),
     (
         np.array([1.0]),
@@ -347,7 +347,7 @@ test_data = [
             "threshold": 0,
             "zerovalue": 0,
         },
-        np.array([41.18458952]),
+        np.array([40.27719989]),
     ),
 ]
 

--- a/pysteps/utils/conversion.py
+++ b/pysteps/utils/conversion.py
@@ -36,7 +36,9 @@ def to_rainrate(R, metadata, a=None, b=None):
         :py:mod:`pysteps.io.importers`.
 
         Additionally, in case of conversion to/from reflectivity units, the
-        zr_a and zr_b attributes are also required, but only if a=b=None.
+        zr_a and zr_b attributes are also required, but only if a = b = None.
+        If missing, it defaults to Marshall–Palmer relation, that is, zr_a = 200.0
+        and zr_b = 1.6.
     a,b : float, optional
         The a and b coefficients of the Z-R relationship (Z = a*R^b).
 
@@ -97,9 +99,9 @@ def to_rainrate(R, metadata, a=None, b=None):
 
         # Z to R
         if a is None:
-            a = metadata.get("zr_a", 316.0)
+            a = metadata.get("zr_a", 200.0) # default to Marshall–Palmer
         if b is None:
-            b = metadata.get("zr_b", 1.5)
+            b = metadata.get("zr_b", 1.6) # default to Marshall–Palmer
         R = (R / a) ** (1.0 / b)
         threshold = (threshold / a) ** (1.0 / b)
         zerovalue = (zerovalue / a) ** (1.0 / b)
@@ -133,7 +135,9 @@ def to_raindepth(R, metadata, a=None, b=None):
         :py:mod:`pysteps.io.importers`.
 
         Additionally, in case of conversion to/from reflectivity units, the
-        zr_a and zr_b attributes are also required, but only if a=b=None.
+        zr_a and zr_b attributes are also required, but only if a = b = None.
+        If missing, it defaults to Marshall–Palmer relation, that is, zr_a = 200.0
+        and zr_b = 1.6.
     a,b : float, optional
         The a and b coefficients of the Z-R relationship (Z = a*R^b).
 
@@ -193,9 +197,9 @@ def to_raindepth(R, metadata, a=None, b=None):
 
         # Z to R
         if a is None:
-            a = metadata.get("zr_a", 316.0)
+            a = metadata.get("zr_a", 200.0) # Default to Marshall–Palmer
         if b is None:
-            b = metadata.get("zr_b", 1.5)
+            b = metadata.get("zr_b", 1.6) # Default to Marshall–Palmer
         R = (R / a) ** (1.0 / b) / 60.0 * metadata["accutime"]
         threshold = (threshold / a) ** (1.0 / b) / 60.0 * metadata["accutime"]
         zerovalue = (zerovalue / a) ** (1.0 / b) / 60.0 * metadata["accutime"]
@@ -229,7 +233,9 @@ def to_reflectivity(R, metadata, a=None, b=None):
         :py:mod:`pysteps.io.importers`.
 
         Additionally, in case of conversion to/from reflectivity units, the
-        zr_a and zr_b attributes are also required, but only if a=b=None.
+        zr_a and zr_b attributes are also required, but only if a = b = None.
+        If missing, it defaults to Marshall–Palmer relation, that is, zr_a = 200.0
+        and zr_b = 1.6.
     a,b : float, optional
         The a and b coefficients of the Z-R relationship (Z = a*R^b).
 
@@ -269,15 +275,17 @@ def to_reflectivity(R, metadata, a=None, b=None):
 
     if metadata["unit"] == "mm/h":
 
-        # R to Z
+        # Z to R
         if a is None:
-            a = metadata.get("zr_a", 316.0)
+            a = metadata.get("zr_a", 200.0) # Default to Marshall–Palmer
         if b is None:
-            b = metadata.get("zr_b", 1.5)
+            b = metadata.get("zr_b", 1.6) # Default to Marshall–Palmer
 
         R = a * R ** b
         metadata["threshold"] = a * metadata["threshold"] ** b
         metadata["zerovalue"] = a * metadata["zerovalue"] ** b
+        metadata["zr_a"] = a
+        metadata["zr_b"] = b
 
         # Z to dBZ
         R, metadata = transformation.dB_transform(R, metadata)
@@ -287,14 +295,16 @@ def to_reflectivity(R, metadata, a=None, b=None):
         # depth to rate
         R, metadata = to_rainrate(R, metadata)
 
-        # R to Z
+        # Z to R
         if a is None:
-            a = metadata.get("zr_a", 316.0)
+            a = metadata.get("zr_a", 200.0) # Default to Marshall-Palmer
         if b is None:
-            b = metadata.get("zr_b", 1.5)
+            b = metadata.get("zr_b", 1.6) # Default to Marshall-Palmer
         R = a * R ** b
         metadata["threshold"] = a * metadata["threshold"] ** b
         metadata["zerovalue"] = a * metadata["zerovalue"] ** b
+        metadata["zr_a"] = a
+        metadata["zr_b"] = b
 
         # Z to dBZ
         R, metadata = transformation.dB_transform(R, metadata)

--- a/pysteps/utils/conversion.py
+++ b/pysteps/utils/conversion.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 pysteps.utils.conversion
 ========================

--- a/pysteps/utils/conversion.py
+++ b/pysteps/utils/conversion.py
@@ -24,7 +24,7 @@ warnings.filterwarnings("ignore", category=RuntimeWarning)
 from . import transformation
 
 
-def to_rainrate(R, metadata, a=None, b=None):
+def to_rainrate(R, metadata, zr_a=None, zr_b=None):
     """Convert to rain rate [mm/h].
 
     Parameters
@@ -37,10 +37,10 @@ def to_rainrate(R, metadata, a=None, b=None):
         :py:mod:`pysteps.io.importers`.
 
         Additionally, in case of conversion to/from reflectivity units, the
-        zr_a and zr_b attributes are also required, but only if a = b = None.
+        zr_a and zr_b attributes are also required, but only if zr_a = zr_b = None.
         If missing, it defaults to Marshall–Palmer relation, that is, zr_a = 200.0
         and zr_b = 1.6.
-    a,b : float, optional
+    zr_a, zr_b : float, optional
         The a and b coefficients of the Z-R relationship (Z = a*R^b).
 
     Returns
@@ -99,16 +99,16 @@ def to_rainrate(R, metadata, a=None, b=None):
         zerovalue = metadata["zerovalue"]  # convert the zerovalue, too
 
         # Z to R
-        if a is None:
-            a = metadata.get("zr_a", 200.0) # default to Marshall–Palmer
-        if b is None:
-            b = metadata.get("zr_b", 1.6) # default to Marshall–Palmer
-        R = (R / a) ** (1.0 / b)
-        threshold = (threshold / a) ** (1.0 / b)
-        zerovalue = (zerovalue / a) ** (1.0 / b)
+        if zr_a is None:
+            zr_a = metadata.get("zr_a", 200.0)  # default to Marshall–Palmer
+        if zr_b is None:
+            zr_b = metadata.get("zr_b", 1.6)  # default to Marshall–Palmer
+        R = (R / zr_a) ** (1.0 / zr_b)
+        threshold = (threshold / zr_a) ** (1.0 / zr_b)
+        zerovalue = (zerovalue / zr_a) ** (1.0 / zr_b)
 
-        metadata["zr_a"] = a
-        metadata["zr_b"] = b
+        metadata["zr_a"] = zr_a
+        metadata["zr_b"] = zr_b
         metadata["threshold"] = threshold
         metadata["zerovalue"] = zerovalue
 
@@ -123,7 +123,7 @@ def to_rainrate(R, metadata, a=None, b=None):
     return R, metadata
 
 
-def to_raindepth(R, metadata, a=None, b=None):
+def to_raindepth(R, metadata, zr_a=None, zr_b=None):
     """Convert to rain depth [mm].
 
     Parameters
@@ -136,10 +136,10 @@ def to_raindepth(R, metadata, a=None, b=None):
         :py:mod:`pysteps.io.importers`.
 
         Additionally, in case of conversion to/from reflectivity units, the
-        zr_a and zr_b attributes are also required, but only if a = b = None.
+        zr_a and zr_b attributes are also required, but only if zr_a = zr_b = None.
         If missing, it defaults to Marshall–Palmer relation, that is, zr_a = 200.0
         and zr_b = 1.6.
-    a,b : float, optional
+    zr_a, zr_b : float, optional
         The a and b coefficients of the Z-R relationship (Z = a*R^b).
 
     Returns
@@ -197,16 +197,16 @@ def to_raindepth(R, metadata, a=None, b=None):
         zerovalue = metadata["zerovalue"]  # convert the zerovalue, too
 
         # Z to R
-        if a is None:
-            a = metadata.get("zr_a", 200.0) # Default to Marshall–Palmer
-        if b is None:
-            b = metadata.get("zr_b", 1.6) # Default to Marshall–Palmer
-        R = (R / a) ** (1.0 / b) / 60.0 * metadata["accutime"]
-        threshold = (threshold / a) ** (1.0 / b) / 60.0 * metadata["accutime"]
-        zerovalue = (zerovalue / a) ** (1.0 / b) / 60.0 * metadata["accutime"]
+        if zr_a is None:
+            zr_a = metadata.get("zr_a", 200.0)  # Default to Marshall–Palmer
+        if zr_b is None:
+            zr_b = metadata.get("zr_b", 1.6)  # Default to Marshall–Palmer
+        R = (R / zr_a) ** (1.0 / zr_b) / 60.0 * metadata["accutime"]
+        threshold = (threshold / zr_a) ** (1.0 / zr_b) / 60.0 * metadata["accutime"]
+        zerovalue = (zerovalue / zr_a) ** (1.0 / zr_b) / 60.0 * metadata["accutime"]
 
-        metadata["zr_a"] = a
-        metadata["zr_b"] = b
+        metadata["zr_a"] = zr_a
+        metadata["zr_b"] = zr_b
         metadata["threshold"] = threshold
         metadata["zerovalue"] = zerovalue
 
@@ -221,7 +221,7 @@ def to_raindepth(R, metadata, a=None, b=None):
     return R, metadata
 
 
-def to_reflectivity(R, metadata, a=None, b=None):
+def to_reflectivity(R, metadata, zr_a=None, zr_b=None):
     """Convert to reflectivity [dBZ].
 
     Parameters
@@ -234,10 +234,10 @@ def to_reflectivity(R, metadata, a=None, b=None):
         :py:mod:`pysteps.io.importers`.
 
         Additionally, in case of conversion to/from reflectivity units, the
-        zr_a and zr_b attributes are also required, but only if a = b = None.
+        zr_a and zr_b attributes are also required, but only if zr_a = zr_b = None.
         If missing, it defaults to Marshall–Palmer relation, that is, zr_a = 200.0
         and zr_b = 1.6.
-    a,b : float, optional
+    zr_a, zr_b : float, optional
         The a and b coefficients of the Z-R relationship (Z = a*R^b).
 
     Returns
@@ -277,16 +277,16 @@ def to_reflectivity(R, metadata, a=None, b=None):
     if metadata["unit"] == "mm/h":
 
         # Z to R
-        if a is None:
-            a = metadata.get("zr_a", 200.0) # Default to Marshall–Palmer
-        if b is None:
-            b = metadata.get("zr_b", 1.6) # Default to Marshall–Palmer
+        if zr_a is None:
+            zr_a = metadata.get("zr_a", 200.0)  # Default to Marshall–Palmer
+        if zr_b is None:
+            zr_b = metadata.get("zr_b", 1.6)  # Default to Marshall–Palmer
 
-        R = a * R ** b
-        metadata["threshold"] = a * metadata["threshold"] ** b
-        metadata["zerovalue"] = a * metadata["zerovalue"] ** b
-        metadata["zr_a"] = a
-        metadata["zr_b"] = b
+        R = zr_a * R ** zr_b
+        metadata["threshold"] = zr_a * metadata["threshold"] ** zr_b
+        metadata["zerovalue"] = zr_a * metadata["zerovalue"] ** zr_b
+        metadata["zr_a"] = zr_a
+        metadata["zr_b"] = zr_b
 
         # Z to dBZ
         R, metadata = transformation.dB_transform(R, metadata)
@@ -297,15 +297,15 @@ def to_reflectivity(R, metadata, a=None, b=None):
         R, metadata = to_rainrate(R, metadata)
 
         # Z to R
-        if a is None:
-            a = metadata.get("zr_a", 200.0) # Default to Marshall-Palmer
-        if b is None:
-            b = metadata.get("zr_b", 1.6) # Default to Marshall-Palmer
-        R = a * R ** b
-        metadata["threshold"] = a * metadata["threshold"] ** b
-        metadata["zerovalue"] = a * metadata["zerovalue"] ** b
-        metadata["zr_a"] = a
-        metadata["zr_b"] = b
+        if zr_a is None:
+            zr_a = metadata.get("zr_a", 200.0)  # Default to Marshall-Palmer
+        if zr_b is None:
+            zr_b = metadata.get("zr_b", 1.6)  # Default to Marshall-Palmer
+        R = zr_a * R ** zr_b
+        metadata["threshold"] = zr_a * metadata["threshold"] ** zr_b
+        metadata["zerovalue"] = zr_a * metadata["zerovalue"] ** zr_b
+        metadata["zr_a"] = zr_a
+        metadata["zr_b"] = zr_b
 
         # Z to dBZ
         R, metadata = transformation.dB_transform(R, metadata)


### PR DESCRIPTION
Include `zr_a` and `zr_b` parameters in the metadata where available.

TO DO:
- @pulkkins can you take care of the FMI importers (since the data are stored as reflectivities)?
- @cvelascof can you double-check with the BOM data?
- @RubenImhoff is the information available for the KNMI composite?
- OPERA importer

**Under development, please do not merge.**