### PR TITLE
Improved exporters

### DIFF
--- a/pysteps/io/exporters.py
+++ b/pysteps/io/exporters.py
@@ -60,16 +60,6 @@ table:
 |               |                   | 'member' = write a forecast sequence    |
 |               |                   | for a given ensemble member             |
 +---------------+-------------------+-----------------------------------------+
-| outputfiles   | 'single',         | organization of the output files        |
-|               | 'per_ens_member', | 'single' = write the whole forecast     |
-|               | 'per_timestep'    | into the same file                      |
-|               | 'separate'        | 'per_ens_member' = use one file for     |
-|               |                   | each member of a forecast ensemble      |
-|               |                   | 'per_timestep' = use one file for each  |
-|               |                   | time step                               |
-|               |                   | 'separate' = use a separate file for    |
-|               |                   | each ensemble member and time step      |
-+---------------+-------------------+-----------------------------------------+
 
 Optional exporter-specific arguments are passed with **kwargs. The return value
 is a dictionary containing an exporter object. This can be used with
@@ -155,11 +145,12 @@ def initialize_forecast_exporter_geotiff(outfnprefix, startdate, timestep,
     n_ens_members : int
         Number of ensemble members in the forecast.
 
-    incremental : {None,'timestep','member'}, optional
+    incremental : {None,'timestep'}, optional
         Allow incremental writing of datasets into the GeoTIFF files. Set to
         'timestep' to enable writing forecasts or forecast ensembles separately
         for each time step. If set to None, incremental writing is disabled and
-        the whole forecast is written in a single function call.
+        the whole forecast is written in a single function call. The 'member'
+        option is not currently implemented.
 
     Returns
     -------
@@ -299,6 +290,7 @@ def initialize_forecast_exporter_kineros(outfnprefix, startdate, timestep,
     xr += 0.5 * (xr[1] - xr[0])
     yr = np.linspace(metadata["y1"], metadata["y2"], h + 1)[:-1]
     yr += 0.5 * (yr[1] - yr[0])
+
     xy_coords = np.stack(np.meshgrid(xr, yr))
 
     exporter["method"] = "kineros"

--- a/pysteps/io/exporters.py
+++ b/pysteps/io/exporters.py
@@ -396,6 +396,11 @@ def initialize_forecast_exporter_netcdf(outpath, outfnprefix, startdate,
     elif incremental is not None:
         raise ValueError("unknown argument value incremental='%s': must be 'timestep' or 'member'" % str(incremental))
 
+    n_ens_gt_one = False
+    if n_ens_members is not None:
+        if n_ens_members > 1:
+            n_ens_gt_one = True
+
     exporter = {}
 
     outfn = os.path.join(outpath, outfnprefix + ".nc")
@@ -485,7 +490,7 @@ def initialize_forecast_exporter_netcdf(outpath, outfnprefix, startdate,
         for i in grid_mapping_params.items():
             var_gm.setncattr(i[0], i[1])
 
-    if n_ens_members > 1:
+    if incremental == "member" or n_ens_gt_one:
         var_ens_num = ncf.createVariable("ens_number", np.int,
                                          dimensions=("ens_number",)
                                          )
@@ -501,7 +506,7 @@ def initialize_forecast_exporter_netcdf(outpath, outfnprefix, startdate,
     startdate_str = datetime.strftime(startdate, "%Y-%m-%d %H:%M:%S")
     var_time.units = "seconds since %s" % startdate_str
 
-    if n_ens_members > 1:
+    if incremental == "member" or n_ens_gt_one:
         var_f = ncf.createVariable(var_name, np.float32,
                                    dimensions=("ens_number", "time", "y", "x"),
                                    zlib=True, complevel=9)
@@ -519,7 +524,7 @@ def initialize_forecast_exporter_netcdf(outpath, outfnprefix, startdate,
     exporter["method"] = "netcdf"
     exporter["ncfile"] = ncf
     exporter["var_F"] = var_f
-    if n_ens_members > 1:
+    if incremental == "member" or n_ens_gt_one:
         exporter["var_ens_num"] = var_ens_num
     exporter["var_time"] = var_time
     exporter["var_name"] = var_name

--- a/pysteps/io/exporters.py
+++ b/pysteps/io/exporters.py
@@ -10,7 +10,7 @@ implements the following interface::
 
   initialize_forecast_exporter_xxx(outfnprefix, startdate, timestep,
                                    n_timesteps, shape, n_ens_members,
-                                   metadata, incremental=None)
+                                   metadata, incremental=None, **kwargs)
 
 where xxx specifies the file format.
 
@@ -58,9 +58,10 @@ table:
 |               |                   | for a given ensemble member             |
 +---------------+-------------------+-----------------------------------------+
 
-The return value is a dictionary containing an exporter object. This can be
-used with :py:func:`pysteps.io.exporters.export_forecast_dataset` to write
-datasets in the given file format.
+Optional exporter-specific arguments are passed with **kwargs. The return value
+is a dictionary containing an exporter object. This can be used with
+:py:func:`pysteps.io.exporters.export_forecast_dataset` to write datasets in
+the given file format.
 
 Available Exporters
 -------------------

--- a/pysteps/io/exporters.py
+++ b/pysteps/io/exporters.py
@@ -14,9 +14,11 @@ implements the following interface::
 
 where xxx specifies the file format.
 
-This function creates the output files and writes the metadata. The datasets
-are written by calling :py:func:`pysteps.io.exporters.export_forecast_dataset`,
-and the files are closed by calling :py:func:`pysteps.io.exporters.close_forecast_files`.
+This function creates the output files and writes the metadata. See the
+documentation of the initialization methods for the format of the output files
+and their names. The datasets are written by calling
+:py:func:`pysteps.io.exporters.export_forecast_dataset`, and the files are
+closed by calling :py:func:`pysteps.io.exporters.close_forecast_files`.
 
 The arguments of initialize_forecast_exporter_xxx are described in the following
 table:
@@ -69,30 +71,10 @@ table:
 |               |                   | each ensemble member and time step      |
 +---------------+-------------------+-----------------------------------------+
 
-The output file names depend on the outfnprefix and outputfiles arguments as
-follows:
-
-.. tabularcolumns:: |p{2cm}|L|
-
-+--------------------------------------------------------------------------------+
-|  outputfiles     | File name format                                            |
-+================================================================================+
-| 'single'         | outfnprefix.<ext>                                           |
-+--------------------------------------------------------------------------------+
-| 'per_ens_member' | outfnprefix_i.<ext>, where i is the index of the ensemble   |
-|                  | member starting from one                                    |
-+--------------------------------------------------------------------------------+
-| 'per_timestep'   | <outfnprefix>_ts.<ext>, where ts is the forecast time step  |
-|                  | (minutes)                                                   |
-+--------------------------------------------------------------------------------+
-| 'separate'       | <outfnprefix>_i_ts.<ext>, where i is the index of the       |
-|                  | ensemble member and ts is the time step                     |
-+--------------------------------------------------------------------------------+
-
 Optional exporter-specific arguments are passed with **kwargs. The return value
 is a dictionary containing an exporter object. This can be used with
-:py:func:`pysteps.io.exporters.export_forecast_dataset` to write datasets in
-the given file format.
+:py:func:`pysteps.io.exporters.export_forecast_dataset` to write the datasets to
+the output files.
 
 Available Exporters
 -------------------

--- a/pysteps/io/exporters.py
+++ b/pysteps/io/exporters.py
@@ -208,7 +208,9 @@ def initialize_forecast_exporter_kineros(outfnprefix, startdate, timestep,
     in https://www.tucson.ars.ag.gov/kineros/.
 
     Grid points are treated as individual rain gauges and a separate file is
-    produced for each ensemble member.
+    produced for each ensemble member. The output files are named as
+    <outfnprefix>_N<n>.pre, where <n> is the index of ensemble member starting
+    from zero.
 
     Parameters
     ----------
@@ -255,15 +257,11 @@ def initialize_forecast_exporter_kineros(outfnprefix, startdate, timestep,
 
     exporter = {}
 
-    basefn, extfn = os.path.splitext(outfnprefix)
-    if extfn == "":
-        extfn = ".pre"
-
     # one file for each member
     n_ens_members = np.min((99, n_ens_members))
     fns = []
     for i in range(n_ens_members):
-        fn = "%s_N%02d%s" % (basefn, i, extfn)
+        fn = "%s_N%02d%s" % (outfnprefix, i, ".pre")
         with open(fn, "w") as fd:
             # write header
             fd.writelines("! pysteps-generated nowcast.\n")

--- a/pysteps/io/exporters.py
+++ b/pysteps/io/exporters.py
@@ -115,8 +115,9 @@ def initialize_forecast_exporter_geotiff(outfnprefix, startdate, timestep,
                                          **kwargs):
     """Initialize a GeoTIFF forecast exporter.
 
-    Initialize a GeoTIFF forecast exporter. GDAL needs to be installed to
-    use this exporter.
+    The output files are named as '<outfnprefix>_<startdate>_<t>.tif', where
+    startdate is in YYmmddHHMM format and t is lead time (minutes).  GDAL needs
+    to be installed to use this exporter.
 
     Parameters
     ----------

--- a/pysteps/io/exporters.py
+++ b/pysteps/io/exporters.py
@@ -805,9 +805,10 @@ def _get_geotiff_filename(prefix, startdate, n_timesteps, timestep,
     if n_timesteps * timestep == 0:
         raise ValueError("n_timesteps x timestep can't be 0.")
 
-    timestep_format = f"%0{int(np.floor(np.log10(n_timesteps * timestep))) + 1}d"
+    timestep_format_str = f"{{time_str:0{int(np.floor(np.log10(n_timesteps * timestep))) + 1}d}}"
 
     startdate_str = datetime.strftime(startdate, "%Y%m%d%H%M")
-    timestep_str = timestep_format % ((timestep_index + 1) * timestep)
 
-    return prefix + '_' + startdate_str + '_' + timestep_str + '.tif'
+    timestep_str = timestep_format_str.format(time_str=(timestep_index + 1) * timestep)
+
+    return f"{prefix}_{startdate_str}_{timestep_str}.tif"

--- a/pysteps/io/exporters.py
+++ b/pysteps/io/exporters.py
@@ -131,7 +131,7 @@ except ImportError:
 # Revise the variable names and
 # the structure of the file if necessary.
 
-def initialize_forecast_exporter_kineros(filename, startdate, timestep,
+def initialize_forecast_exporter_kineros(outfnprefix, startdate, timestep,
                                          n_timesteps, shape, metadata,
                                          n_ens_members=1, incremental=None):
     """Initialize a KINEROS2 Rainfall .pre file as specified
@@ -142,8 +142,8 @@ def initialize_forecast_exporter_kineros(filename, startdate, timestep,
 
     Parameters
     ----------
-    filename : str
-        Name of the output file.
+    outfnprefix : str
+        Prefix for output file names.
 
     startdate : datetime.datetime
         Start date of the forecast as datetime object.
@@ -185,7 +185,7 @@ def initialize_forecast_exporter_kineros(filename, startdate, timestep,
 
     exporter = {}
 
-    basefn, extfn = os.path.splitext(filename)
+    basefn, extfn = os.path.splitext(outfnprefix)
     if extfn == "":
         extfn = ".pre"
 
@@ -245,15 +245,15 @@ def initialize_forecast_exporter_kineros(filename, startdate, timestep,
 # Revise the variable names and
 # the structure of the file if necessary.
 
-def initialize_forecast_exporter_netcdf(filename, startdate, timestep,
+def initialize_forecast_exporter_netcdf(outfnprefix, startdate, timestep,
                                         n_timesteps, shape, metadata,
                                         n_ens_members=1, incremental=None):
     """Initialize a netCDF forecast exporter.
 
     Parameters
     ----------
-    filename : str
-        Name of the output file.
+    outfnprefix : str
+        Prefix for output file names.
 
     startdate : datetime.datetime
         Start date of the forecast.
@@ -279,7 +279,7 @@ def initialize_forecast_exporter_netcdf(filename, startdate, timestep,
         incremental is set to 'member'.
 
     incremental : {None,'timestep','member'}, optional
-        Allow incremental writing of datasets into the netCDF file.\n
+        Allow incremental writing of datasets into the netCDF files.\n
         The available options are: 'timestep' = write a forecast or a forecast
         ensemble for  a given time step; 'member' = write a forecast sequence
         for a given ensemble member. If set to None, incremental writing is
@@ -315,7 +315,7 @@ def initialize_forecast_exporter_netcdf(filename, startdate, timestep,
 
     exporter = {}
 
-    ncf = netCDF4.Dataset(filename, 'w', format="NETCDF4")
+    ncf = netCDF4.Dataset(outfnprefix, 'w', format="NETCDF4")
 
     ncf.Conventions = "CF-1.7"
     ncf.title = "pysteps-generated nowcast"

--- a/pysteps/io/exporters.py
+++ b/pysteps/io/exporters.py
@@ -30,7 +30,8 @@ table:
 +---------------+-------------------+-----------------------------------------+
 | startdate     | datetime.datetime | start date of the forecast              |
 +---------------+-------------------+-----------------------------------------+
-| timestep      | int               | time step of the forecast (minutes)     |
+| timestep      | int               | length of the forecast time step        |
+|               |                   | (minutes)                               |
 +---------------+-------------------+-----------------------------------------+
 | n_timesteps   | int               | number of time steps in the forecast    |
 |               |                   | this argument is ignored if             |

--- a/pysteps/io/exporters.py
+++ b/pysteps/io/exporters.py
@@ -49,7 +49,7 @@ table:
 |               |                   | this argument is ignored if incremental |
 |               |                   | is set to 'member'                      |
 +---------------+-------------------+-----------------------------------------+
-| incremental   | {None, 'timestep',| Allow incremental writing of datasets   |
+| incremental   | {None, 'timestep',| allow incremental writing of datasets   |
 |               | 'member'}         | the available options are:              |
 |               |                   | 'timestep' = write a forecast or a      |
 |               |                   | forecast ensemble for a given           |
@@ -59,13 +59,13 @@ table:
 +---------------+-------------------+-----------------------------------------+
 | outputfiles   | 'single',         | organization of the output files        |
 |               | 'per_ens_member', | 'single' = write the whole forecast     |
-|               | 'per_leadtime'    | into the same file                      |
+|               | 'per_timestep'    | into the same file                      |
 |               | 'separate'        | 'per_ens_member' = use one file for     |
 |               |                   | each member of a forecast ensemble      |
 |               |                   | 'per_timestep' = use one file for each  |
-|               |                   | lead time                               |
+|               |                   | time step                               |
 |               |                   | 'separate' = use a separate file for    |
-|               |                   | each ensemble member and lead time      |
+|               |                   | each ensemble member and time step      |
 +---------------+-------------------+-----------------------------------------+
 
 The output file names depend on the outfnprefix and outputfiles arguments as
@@ -81,11 +81,11 @@ follows:
 | 'per_ens_member' | outfnprefix_i.<ext>, where i is the index of the ensemble   |
 |                  | member starting from one                                    |
 +--------------------------------------------------------------------------------+
-| 'per_leadtime'   | <outfnprefix>_lt.<ext>, where lt is the lead time           |
+| 'per_timestep'   | <outfnprefix>_ts.<ext>, where ts is the forecast time step  |
 |                  | (minutes)                                                   |
 +--------------------------------------------------------------------------------+
-| 'separate'       | <outfnprefix>_i_lt.<ext>, where i is the index of the       |
-|                  | ensemble member and lt is the lead time                     |
+| 'separate'       | <outfnprefix>_i_ts.<ext>, where i is the index of the       |
+|                  | ensemble member and ts is the time step                     |
 +--------------------------------------------------------------------------------+
 
 Optional exporter-specific arguments are passed with **kwargs. The return value

--- a/pysteps/io/exporters.py
+++ b/pysteps/io/exporters.py
@@ -125,8 +125,14 @@ def initialize_forecast_exporter_geotiff(outfnprefix, startdate, timestep,
             "gdal package is required for GeoTIFF "
             "exporters but it is not installed")
 
+    if incremental == "member":
+        raise ValueError("incremental writing of GeoTIFF files with the 'member' option is not supported")
+
     exporter = {}
     exporter["method"] = "geotiff"
+    exporter["outfnprefix"] = outfnprefix
+    exporter["startdate"] = startdate
+    exporter["timestep"] = timestep
     exporter["num_timesteps"] = n_timesteps
     exporter["shape"] = shape
     exporter["metadata"] = metadata
@@ -135,21 +141,16 @@ def initialize_forecast_exporter_geotiff(outfnprefix, startdate, timestep,
     exporter["dst"] = []
 
     driver = gdal.GetDriverByName("GTiff")
-    for i in range(n_timesteps):
-        outfn = _get_geotiff_filename(outfnprefix, startdate, n_timesteps,
-                                      timestep, i)
-        dst = driver.Create(outfn, shape[1], shape[0], 1, gdal.GDT_Float32,
-                            ["COMPRESS=DEFLATE", "PREDICTOR=3"])
+    exporter["driver"] = driver
 
-        exporter["dst"].append(dst)
-
-        sx = (metadata["x2"] - metadata["x1"]) / shape[1]
-        sy = (metadata["y2"] - metadata["y1"]) / shape[0]
-        dst.SetGeoTransform([metadata["x1"], sx, 0.0, metadata["y2"], 0.0, -sy])
-
-        sr = osr.SpatialReference()
-        sr.ImportFromProj4(metadata["projection"])
-        dst.SetProjection(sr.ExportToWkt())
+    if incremental != "timestep":
+        for i in range(n_timesteps):
+            outfn = _get_geotiff_filename(outfnprefix, startdate, n_timesteps,
+                                          timestep, i)
+            dst = _create_geotiff_file(outfn, driver, shape, metadata, n_ens_members)
+            exporter["dst"].append(dst)
+    else:
+        exporter["num_files_written"] = 0
 
     return exporter
 
@@ -572,17 +573,52 @@ def close_forecast_files(exporter):
         exporter["ncfile"].close()
 
 def _export_geotiff(F, exporter):
-    for i in range(F.shape[0]):
-        if exporter["incremental"] is None:
-            band = exporter["dst"][i].GetRasterBand(1)
-        else:
-            exporter["dst"][i].AddBand(gdal.GDT_Float32)
-            band = exporter["dst"][i].GetRasterBand(exporter["dst"][i].RasterCount)
+    def init_band(band):
         band.SetScale(1.0)
         band.SetOffset(0.0)
         band.SetUnitType(exporter["metadata"]["unit"])
 
-        band.WriteArray(F[i, :, :])
+    if exporter["incremental"] is None:
+        for i in range(exporter["num_timesteps"]):
+            if exporter["num_ens_members"] == 1:
+                band = exporter["dst"][i].GetRasterBand(1)
+                init_band(band)
+                band.WriteArray(F[i, :, :])
+            else:
+                for j in range(exporter["num_ens_members"]):
+                    band = exporter["dst"][i].GetRasterBand(j+1)
+                    init_band(band)
+                    band.WriteArray(F[j, i, :, :])
+    elif exporter["incremental"] == "timestep":
+        i = exporter["num_files_written"]
+
+        outfn = _get_geotiff_filename(exporter["outfnprefix"],
+                                      exporter["startdate"],
+                                      exporter["num_timesteps"],
+                                      exporter["timestep"], i)
+        dst = _create_geotiff_file(outfn, exporter["driver"],
+                                   exporter["shape"],
+                                   exporter["metadata"],
+                                   exporter["num_ens_members"])
+
+        for j in range(exporter["num_ens_members"]):
+            band = dst.GetRasterBand(j+1)
+            init_band(band)
+            if exporter["num_ens_members"] > 1:
+                band.WriteArray(F[j, :, :])
+            else:
+                band.WriteArray(F)
+
+        exporter["num_files_written"] += 1
+    elif exporter["incremental"] == "member":
+        for i in range(exporter["num_timesteps"]):
+            # NOTE: This does not work because the GeoTIFF driver does not
+            # support adding bands. An alternative solution needs to be
+            # implemented.
+            exporter["dst"][i].AddBand(gdal.GDT_Float32)
+            band = exporter["dst"][i].GetRasterBand(exporter["dst"][i].RasterCount)
+            init_band(band)
+            band.WriteArray(F[i, :, :])
 
 def _export_kineros(F, exporter):
 
@@ -678,6 +714,20 @@ def _convert_proj4_to_grid_mapping(proj4str):
         return None, None, None
 
     return grid_mapping_var_name, grid_mapping_name, params
+
+def _create_geotiff_file(outfn, driver, shape, metadata, num_bands):
+    dst = driver.Create(outfn, shape[1], shape[0], num_bands, gdal.GDT_Float32,
+                        ["COMPRESS=DEFLATE", "PREDICTOR=3"])
+
+    sx = (metadata["x2"] - metadata["x1"]) / shape[1]
+    sy = (metadata["y2"] - metadata["y1"]) / shape[0]
+    dst.SetGeoTransform([metadata["x1"], sx, 0.0, metadata["y2"], 0.0, -sy])
+
+    sr = osr.SpatialReference()
+    sr.ImportFromProj4(metadata["projection"])
+    dst.SetProjection(sr.ExportToWkt())
+
+    return dst
 
 def _get_geotiff_filename(prefix, startdate, n_timesteps, timestep,
                           timestep_index):

--- a/pysteps/io/exporters.py
+++ b/pysteps/io/exporters.py
@@ -318,7 +318,8 @@ def initialize_forecast_exporter_netcdf(outfnprefix, startdate, timestep,
                                         n_timesteps, shape, metadata,
                                         n_ens_members=1, incremental=None,
                                         **kwargs):
-    """Initialize a netCDF forecast exporter.
+    """Initialize a netCDF forecast exporter. All outputs are written to a
+    single file named as outfnprefix+'.nc'.
 
     Parameters
     ----------
@@ -385,7 +386,7 @@ def initialize_forecast_exporter_netcdf(outfnprefix, startdate, timestep,
 
     exporter = {}
 
-    ncf = netCDF4.Dataset(outfnprefix, 'w', format="NETCDF4")
+    ncf = netCDF4.Dataset(outfnprefix + ".nc", 'w', format="NETCDF4")
 
     ncf.Conventions = "CF-1.7"
     ncf.title = "pysteps-generated nowcast"

--- a/pysteps/io/exporters.py
+++ b/pysteps/io/exporters.py
@@ -82,6 +82,7 @@ Available Exporters
 .. autosummary::
     :toctree: ../generated/
 
+    initialize_forecast_exporter_geotiff
     initialize_forecast_exporter_kineros
     initialize_forecast_exporter_netcdf
 
@@ -92,7 +93,7 @@ Generic functions
     :toctree: ../generated/
 
     export_forecast_dataset
-    close_forecast_file
+    close_forecast_files
 """
 
 from datetime import datetime

--- a/pysteps/io/exporters.py
+++ b/pysteps/io/exporters.py
@@ -57,6 +57,36 @@ table:
 |               |                   | 'member' = write a forecast sequence    |
 |               |                   | for a given ensemble member             |
 +---------------+-------------------+-----------------------------------------+
+| outputfiles   | 'single',         | organization of the output files        |
+|               | 'per_ens_member', | 'single' = write the whole forecast     |
+|               | 'per_leadtime'    | into the same file                      |
+|               | 'separate'        | 'per_ens_member' = use one file for     |
+|               |                   | each member of a forecast ensemble      |
+|               |                   | 'per_timestep' = use one file for each  |
+|               |                   | lead time                               |
+|               |                   | 'separate' = use a separate file for    |
+|               |                   | each ensemble member and lead time      |
++---------------+-------------------+-----------------------------------------+
+
+The output file names depend on the outfnprefix and outputfiles arguments as
+follows:
+
+.. tabularcolumns:: |p{2cm}|L|
+
++--------------------------------------------------------------------------------+
+|  outputfiles     | File name format                                            |
++================================================================================+
+| 'single'         | outfnprefix.<ext>                                           |
++--------------------------------------------------------------------------------+
+| 'per_ens_member' | outfnprefix_i.<ext>, where i is the index of the ensemble   |
+|                  | member starting from one                                    |
++--------------------------------------------------------------------------------+
+| 'per_leadtime'   | <outfnprefix>_lt.<ext>, where lt is the lead time           |
+|                  | (minutes)                                                   |
++--------------------------------------------------------------------------------+
+| 'separate'       | <outfnprefix>_i_lt.<ext>, where lt is the lead time         |
+|                  | (minutes)                                                   |
++--------------------------------------------------------------------------------+
 
 Optional exporter-specific arguments are passed with **kwargs. The return value
 is a dictionary containing an exporter object. This can be used with

--- a/pysteps/io/exporters.py
+++ b/pysteps/io/exporters.py
@@ -8,24 +8,25 @@ formats.
 Each exporter method in this module has its own initialization function that
 implements the following interface::
 
-  initialize_forecast_exporter_xxx(filename, startdate, timestep,
+  initialize_forecast_exporter_xxx(outfnprefix, startdate, timestep,
                                    n_timesteps, shape, n_ens_members,
                                    metadata, incremental=None)
 
-where xxx is the name (or abbreviation) of the file format.
+where xxx specifies the file format.
 
-This function creates the file and writes the metadata. The datasets are written
-by calling :py:func:`pysteps.io.exporters.export_forecast_dataset`, and
-the file is closed by calling :py:func:`pysteps.io.exporters.close_forecast_file`.
+This function creates the output files and writes the metadata. The datasets
+are written by calling :py:func:`pysteps.io.exporters.export_forecast_dataset`,
+and the files are closed by calling :py:func:`pysteps.io.exporters.close_forecast_files`.
 
-The arguments in the above are defined as follows:
+The arguments of initialize_forecast_exporter_xxx are described in the following
+table:
 
 .. tabularcolumns:: |p{2cm}|p{2cm}|L|
 
 +---------------+-------------------+-----------------------------------------+
 |   Argument    | Type/values       |             Description                 |
 +===============+===================+=========================================+
-| filename      | str               | name of the output file                 |
+| outfnprefix   | str               | prefix of output file names             |
 +---------------+-------------------+-----------------------------------------+
 | startdate     | datetime.datetime | start date of the forecast              |
 +---------------+-------------------+-----------------------------------------+
@@ -469,10 +470,10 @@ def export_forecast_dataset(F, exporter):
         raise ValueError("unknown exporter method %s" % exporter["method"])
 
 
-def close_forecast_file(exporter):
-    """Close the file associated with a forecast exporter.
+def close_forecast_files(exporter):
+    """Close the files associated with a forecast exporter.
 
-    Finish writing forecasts and close the file associated with a forecast
+    Finish writing forecasts and close the output files opened by a forecast
     exporter.
 
     Parameters

--- a/pysteps/io/exporters.py
+++ b/pysteps/io/exporters.py
@@ -401,13 +401,14 @@ def initialize_forecast_exporter_netcdf(filename, startdate, timestep,
         for i in grid_mapping_params.items():
             var_gm.setncattr(i[0], i[1])
 
-    var_ens_num = ncf.createVariable("ens_number", np.int,
-                                     dimensions=("ens_number",)
-                                     )
-    if incremental != "member":
-        var_ens_num[:] = list(range(1, n_ens_members+1))
-    var_ens_num.long_name = "ensemble member"
-    var_ens_num.units = ""
+    if n_ens_members > 1:
+        var_ens_num = ncf.createVariable("ens_number", np.int,
+                                         dimensions=("ens_number",)
+                                         )
+        if incremental != "member":
+            var_ens_num[:] = list(range(1, n_ens_members+1))
+        var_ens_num.long_name = "ensemble member"
+        var_ens_num.units = ""
 
     var_time = ncf.createVariable("time", np.int, dimensions=("time",))
     if incremental != "timestep":
@@ -429,7 +430,8 @@ def initialize_forecast_exporter_netcdf(filename, startdate, timestep,
     exporter["method"] = "netcdf"
     exporter["ncfile"] = ncf
     exporter["var_F"] = var_F
-    exporter["var_ens_num"] = var_ens_num
+    if n_ens_members > 1:
+        exporter["var_ens_num"] = var_ens_num
     exporter["var_time"] = var_time
     exporter["var_name"] = var_name
     exporter["startdate"] = startdate

--- a/pysteps/io/exporters.py
+++ b/pysteps/io/exporters.py
@@ -563,7 +563,7 @@ def _export_netcdf(F, exporter):
         var_time[len(var_time)-1] = len(var_time) * exporter["timestep"] * 60
     else:
         var_F[var_F.shape[0], :, :, :] = F
-        var_ens_num = exporter["var_time"]
+        var_ens_num = exporter["var_ens_num"]
         var_ens_num[len(var_ens_num)-1] = len(var_ens_num)
 
 

--- a/pysteps/io/exporters.py
+++ b/pysteps/io/exporters.py
@@ -614,3 +614,31 @@ def _convert_proj4_to_grid_mapping(proj4str):
         return None, None, None
 
     return grid_mapping_var_name, grid_mapping_name, params
+
+def _get_output_file_name(prefix, scheme, ext, num_ens_members, ens_member,
+                          num_timesteps, timestep):
+    if num_ens_members < 10:
+        ens_member_format = "%01d"
+    elif num_ens_members < 100:
+        ens_member_format = "%02d"
+    else:
+        ens_member_format = "%03d"
+
+    if num_timesteps < 10:
+        timestep_format = "%01d"
+    elif num_timesteps < 100:
+        timestep_format = "%02d"
+    else:
+        timestep_format = "%03d"
+
+    if scheme == "single":
+        return "%s.%s" % (prefix, ext)
+    elif scheme == "per_ens_member":
+        return ("%s_" + ens_member_format + ".%s") % (prefix, ens_member, ext)
+    elif scheme == "per_timestep":
+        return ("%s_" + timestep_format + ".%s") % (prefix, timestep, ext)
+    elif scheme == "separate":
+        return ("%s_" + ens_member_format + '_' + timestep_format + ".%s") % \
+               (prefix, ens_member, timestep, ext)
+    else:
+        raise ValueError("unsupported output file name scheme %s" % scheme)

--- a/pysteps/io/exporters.py
+++ b/pysteps/io/exporters.py
@@ -84,8 +84,8 @@ follows:
 | 'per_leadtime'   | <outfnprefix>_lt.<ext>, where lt is the lead time           |
 |                  | (minutes)                                                   |
 +--------------------------------------------------------------------------------+
-| 'separate'       | <outfnprefix>_i_lt.<ext>, where lt is the lead time         |
-|                  | (minutes)                                                   |
+| 'separate'       | <outfnprefix>_i_lt.<ext>, where i is the index of the       |
+|                  | ensemble member and lt is the lead time                     |
 +--------------------------------------------------------------------------------+
 
 Optional exporter-specific arguments are passed with **kwargs. The return value

--- a/pysteps/io/exporters.py
+++ b/pysteps/io/exporters.py
@@ -119,7 +119,53 @@ def initialize_forecast_exporter_geotiff(outfnprefix, startdate, timestep,
                                          n_timesteps, shape, metadata,
                                          n_ens_members=1, incremental=None,
                                          **kwargs):
-    """"""
+    """Initialize a GeoTIFF forecast exporter.
+
+    Initialize a GeoTIFF forecast exporter. GDAL needs to be installed to
+    use this exporter.
+
+    Parameters
+    ----------
+    outfnprefix : str
+        Prefix for output file names.
+
+    startdate : datetime.datetime
+        Start date of the forecast.
+
+    timestep : int
+        Time step of the forecast (minutes).
+
+    n_timesteps : int
+        Number of time steps in the forecast. This argument is ignored if
+        incremental is set to 'timestep'.
+
+    shape : tuple of int
+        Two-element tuple defining the shape (height,width) of the forecast
+        grids.
+
+    metadata: dict
+        Metadata dictionary containing the projection,x1,x2,y1,y2 and unit
+        attributes described in the documentation of
+        :py:mod:`pysteps.io.importers`.
+
+    n_ens_members : int
+        Number of ensemble members in the forecast.
+
+    incremental : {None,'timestep','member'}, optional
+        Allow incremental writing of datasets into the GeoTIFF files. Set to
+        'timestep' to enable writing forecasts or forecast ensembles separately
+        for each time step. If set to None, incremental writing is disabled and
+        the whole forecast is written in a single function call.
+
+    Returns
+    -------
+    exporter : dict
+        The return value is a dictionary containing an exporter object. This
+        can be used with :py:func:`pysteps.io.exporters.export_forecast_dataset`
+        to write the datasets.
+
+    """
+
     if not GDAL_IMPORTED:
         raise MissingOptionalDependency(
             "gdal package is required for GeoTIFF "
@@ -174,7 +220,7 @@ def initialize_forecast_exporter_kineros(outfnprefix, startdate, timestep,
         Prefix for output file names.
 
     startdate : datetime.datetime
-        Start date of the forecast as datetime object.
+        Start date of the forecast.
 
     timestep : int
         Time step of the forecast (minutes).

--- a/pysteps/io/exporters.py
+++ b/pysteps/io/exporters.py
@@ -134,7 +134,8 @@ except ImportError:
 
 def initialize_forecast_exporter_kineros(outfnprefix, startdate, timestep,
                                          n_timesteps, shape, metadata,
-                                         n_ens_members=1, incremental=None):
+                                         n_ens_members=1, incremental=None,
+                                         **kwargs):
     """Initialize a KINEROS2 Rainfall .pre file as specified
     in https://www.tucson.ars.ag.gov/kineros/.
 
@@ -248,7 +249,8 @@ def initialize_forecast_exporter_kineros(outfnprefix, startdate, timestep,
 
 def initialize_forecast_exporter_netcdf(outfnprefix, startdate, timestep,
                                         n_timesteps, shape, metadata,
-                                        n_ens_members=1, incremental=None):
+                                        n_ens_members=1, incremental=None,
+                                        **kwargs):
     """Initialize a netCDF forecast exporter.
 
     Parameters

--- a/pysteps/io/exporters.py
+++ b/pysteps/io/exporters.py
@@ -623,31 +623,3 @@ def _convert_proj4_to_grid_mapping(proj4str):
         return None, None, None
 
     return grid_mapping_var_name, grid_mapping_name, params
-
-def get_output_file_name(prefix, scheme, ext, num_ens_members, ens_member,
-                         num_timesteps, timestep):
-    if num_ens_members < 10:
-        ens_member_format = "%01d"
-    elif num_ens_members < 100:
-        ens_member_format = "%02d"
-    else:
-        ens_member_format = "%03d"
-
-    if num_timesteps < 10:
-        timestep_format = "%01d"
-    elif num_timesteps < 100:
-        timestep_format = "%02d"
-    else:
-        timestep_format = "%03d"
-
-    if scheme == "single":
-        return "%s.%s" % (prefix, ext)
-    elif scheme == "per_ens_member":
-        return ("%s_" + ens_member_format + ".%s") % (prefix, ens_member, ext)
-    elif scheme == "per_timestep":
-        return ("%s_" + timestep_format + ".%s") % (prefix, timestep, ext)
-    elif scheme == "separate":
-        return ("%s_" + ens_member_format + '_' + timestep_format + ".%s") % \
-               (prefix, ens_member, timestep, ext)
-    else:
-        raise ValueError("unsupported output file name scheme %s" % scheme)

--- a/pysteps/tests/test_exporters.py
+++ b/pysteps/tests/test_exporters.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+from datetime import datetime
+
+from pysteps.io.exporters import _get_geotiff_filename
+
+
+def test_get_geotiff_filename():
+    """Test the geotif name generator."""
+
+    start_date = datetime.strptime("201909082022", "%Y%m%d%H%M")
+
+    n_timesteps = 50
+    timestep = 5
+
+    for timestep_index in range(n_timesteps):
+        file_name = _get_geotiff_filename("test/path", start_date, n_timesteps, timestep,
+                                          timestep_index)
+
+        assert f"test/path_201909082022_{(timestep_index + 1) * timestep:03d}.tif" == file_name


### PR DESCRIPTION
Several improvements to the exporters module:
- A more general interface that allows saving forecasts into multiple files instead of just one.
- Use output path and output file prefix instead of just output file name.
- Implement a GeoTIFF exporter.
- Modify the NetCDF exporter so that for deterministic forecasts, a three-dimensional array is written and the ens_number dimension is dropped.
- Add documentation about the names of the output files.
- Set n_ens_members to 1 by default (i.e. a deterministic forecast).