### PR TITLE
Add importer for EUMETSAT SAF Files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,12 +40,14 @@ before_install:
   # Install gcc for MacOSX
   # ----------------------
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      brew install gcc@9 ;
+      brew update-reset
+      brew update
+      brew install gcc@9;
+      which gcc-9 ;
       export CC=gcc-9  ;
       export CXX=g++-9 ;
       export CXX1X=g++-9 ;
-      which gcc-9 ;
-      gcc-9 --version ;
+      gcc-9 --version
     fi
 
   # Install miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,14 +40,14 @@ before_install:
   # Install gcc for MacOSX
   # ----------------------
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      brew update-reset
-      brew update
+      brew update-reset;
+      brew update;
       brew install gcc@9;
       which gcc-9 ;
       export CC=gcc-9  ;
       export CXX=g++-9 ;
       export CXX1X=g++-9 ;
-      gcc-9 --version
+      gcc-9 --version;
     fi
 
   # Install miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
   # Install gcc for MacOSX
   # ----------------------
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      brew install gcc ;
+      brew install gcc@9 ;
       export CC=gcc-9  ;
       export CXX=g++-9 ;
       export CXX1X=g++-9 ;

--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -366,13 +366,12 @@ def _import_crri_eu_geodata(filename):
     ymax = ds_rainfall.getncattr("gdal_ygeo_up_left")
     xpixelsize = abs(geotable[1])
     ypixelsize = abs(geotable[5])
-    factor_scale = 1.0
-    geodata["x1"] = xmin * factor_scale
-    geodata["y1"] = ymin * factor_scale
-    geodata["x2"] = xmax * factor_scale
-    geodata["y2"] = ymax * factor_scale
-    geodata["xpixelsize"] = xpixelsize * factor_scale
-    geodata["ypixelsize"] = ypixelsize * factor_scale
+    geodata["x1"] = xmin
+    geodata["y1"] = ymin
+    geodata["x2"] = xmax
+    geodata["y2"] = ymax
+    geodata["xpixelsize"] = xpixelsize
+    geodata["ypixelsize"] = ypixelsize
     geodata["yorigin"] = "upper"
 
     # get the accumulation period

--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -73,7 +73,7 @@ Available Importers
     :toctree: ../generated/
 
     import_bom_rf3
-    import_crri_eu
+    import_saf_crri
     import_fmi_geotiff
     import_fmi_pgm
     import_mch_gif
@@ -275,7 +275,7 @@ def _import_bom_rf3_geodata(filename):
 
     return geodata
 
-def import_crri_eu(filename, **kwargs):
+def import_saf_crri(filename, **kwargs):
     """Import a NetCDF radar rainfall product from the Convective Rainfall Rate
     Intensity (CRRI) product from the Satellite Application Facilities (SAF).
 
@@ -300,12 +300,12 @@ def import_crri_eu(filename, **kwargs):
             "but it is not installed"
         )
 
-    precip = _import_crri_eu_data(filename)
+    precip = _import_saf_crri_data(filename)
 
-    geodata = _import_crri_eu_geodata(filename)
+    geodata = _import_saf_crri_geodata(filename)
     metadata = geodata
 
-    # TODO(import_crri_eu): Add missing georeferencing data.
+    # TODO(import_saf_crri): Add missing georeferencing data.
 
     metadata["transform"] = None
     metadata["zerovalue"] = np.nanmin(precip)
@@ -336,7 +336,7 @@ def import_crri_eu(filename, **kwargs):
     return precip, None, metadata
 
 
-def _import_crri_eu_data(filename):
+def _import_saf_crri_data(filename):
     ds_rainfall = netCDF4.Dataset(filename)
     if "crr_intensity" in ds_rainfall.variables.keys():
         data = np.array(ds_rainfall.variables["crr_intensity"])
@@ -348,7 +348,7 @@ def _import_crri_eu_data(filename):
     return precipitation
 
 
-def _import_crri_eu_geodata(filename):
+def _import_saf_crri_geodata(filename):
 
     geodata = {}
 

--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -276,7 +276,8 @@ def _import_bom_rf3_geodata(filename):
     return geodata
 
 def import_crri_eu(filename, **kwargs):
-    """Import a NetCDF radar rainfall product from the CRRI SAF.
+    """Import a NetCDF radar rainfall product from the Convective Rainfall Rate
+    Intensity (CRRI) product from the Satellite Application Facilities (SAF).
 
     Parameters
     ----------

--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -280,6 +280,9 @@ def import_saf_crri(filename, **kwargs):
     """Import a NetCDF radar rainfall product from the Convective Rainfall Rate
     Intensity (CRRI) product from the Satellite Application Facilities (SAF).
 
+    Product description available on http://www.nwcsaf.org/crr_description
+    (last visited Jan 26, 2020).
+
     Parameters
     ----------
 

--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -324,10 +324,10 @@ def import_saf_crri(filename, **kwargs):
         idx_y = np.logical_and(ycoord < extent[3], ycoord > extent[2])
 
         # update geodata
-        metadata["x1"] = xcoord[idx_x].min()
-        metadata["x2"] = xcoord[idx_x].max()
-        metadata["y1"] = ycoord[idx_y].min()
-        metadata["y2"] = ycoord[idx_y].max()
+        metadata["x1"] = xcoord[idx_x].min() - metadata["xpixelsize"] / 2
+        metadata["x2"] = xcoord[idx_x].max() + metadata["xpixelsize"] / 2
+        metadata["y1"] = ycoord[idx_y].min() - metadata["ypixelsize"] / 2
+        metadata["y2"] = ycoord[idx_y].max() + metadata["ypixelsize"] / 2
 
     else:
 

--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -239,7 +239,9 @@ def _import_bom_rf3_geodata(filename):
         calendar = "standard"
         if "calendar" in times.ncattrs():
             calendar = times.calendar
-        valid_time = netCDF4.num2date(times[:], units=times.units, calendar=calendar)
+        valid_time = netCDF4.num2date(times[:],
+                                      units=times.units,
+                                      calendar=calendar)
 
     start_time = None
     if "start_time" in ds_rainfall.variables.keys():
@@ -247,7 +249,9 @@ def _import_bom_rf3_geodata(filename):
         calendar = "standard"
         if "calendar" in times.ncattrs():
             calendar = times.calendar
-        start_time = netCDF4.num2date(times[:], units=times.units, calendar=calendar)
+        start_time = netCDF4.num2date(times[:],
+                                      units=times.units,
+                                      calendar=calendar)
 
     time_step = None
 
@@ -282,8 +286,9 @@ def import_fmi_geotiff(filename, **kwargs):
     -------
 
     out : tuple
-        A three-element tuple containing the precipitation field, the associated
-        quality field and metadata. The quality field is currently set to None.
+        A three-element tuple containing the precipitation field,
+        the associated quality field and metadata.
+        The quality field is currently set to None.
     """
     if not GDAL_IMPORTED:
         raise MissingOptionalDependency(
@@ -405,8 +410,8 @@ def _import_fmi_pgm_geodata(metadata):
     projdef += " +lon_0=" + metadata["centrallongitude"][0] + "E"
     projdef += " +lat_0=" + metadata["centrallatitude"][0] + "N"
     projdef += " +lat_ts=" + metadata["truelatitude"][0]
-    # These are hard-coded because the projection definition is missing from the
-    # PGM files.
+    # These are hard-coded because the projection definition 
+    # is missing from the PGM files.
     projdef += " +a=6371288"
     projdef += " +x_0=380886.310"
     projdef += " +y_0=3395677.920"

--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -135,6 +135,119 @@ except ImportError:
     PYPROJ_IMPORTED = False
 
 
+def import_crri_eu(filename, **kwargs):
+    """Import a NetCDF radar rainfall product from the CRRI SAF.
+
+    Parameters
+    ----------
+    filename : str
+        Name of the file to import.
+
+    Returns
+    -------
+    out : tuple
+        A three-element tuple containing the rainfall field in mm/h imported
+        from the CRRI SAF netcdf, the quality field and the metadata. The
+        quality field is currently set to None.
+
+    """
+    if not NETCDF4_IMPORTED:
+        raise MissingOptionalDependency(
+            "netCDF4 package is required to import CRRI SAF products "
+            "but it is not installed"
+        )
+
+    R = _import_crri_eu_data(filename)
+
+    geodata = _import_crri_eu_geodata(filename)
+    metadata = geodata
+
+    # TODO(import_crri_eu): Add missing georeferencing data.
+
+    metadata["transform"] = None
+    metadata["zerovalue"] = np.nanmin(R)
+    if np.any(np.isfinite(R)):
+        metadata["threshold"] = np.nanmin(R[R > np.nanmin(R)])
+    else:
+        metadata["threshold"] = np.nan
+
+    # cut a window, to be defined here and only here
+    if True:
+        ny, nx = R.shape
+        nx1 = 440
+        nx2 = nx - 440
+        ny1 = 250
+        ny2 = ny
+        R = R[ny1:ny2, nx1:nx2]
+        x1, x2 = metadata['x1'], metadata['x2']
+        xpixelsize = metadata['xpixelsize']
+        x1n = x1 + xpixelsize * nx1
+        x2n = x1 + xpixelsize * (nx2 - 1)
+        metadata['x1'], metadata['x2'] = x1n, x2n
+        y1, y2 = metadata['y1'], metadata['y2']
+        ypixelsize = metadata['ypixelsize']
+        y1n = y2 - ypixelsize * (ny2 - 1)
+        y2n = y2 - ypixelsize * ny1
+        metadata['y1'], metadata['y2'] = y1n, y2n
+
+    return R, None, metadata
+
+
+def _import_crri_eu_data(filename):
+    ds_rainfall = netCDF4.Dataset(filename)
+    if "crr_intensity" in ds_rainfall.variables.keys():
+        data = np.array(ds_rainfall.variables["crr_intensity"])
+        precipitation = np.where(data == 65535, np.nan, data)
+    else:
+        precipitation = None
+    ds_rainfall.close()
+
+    return precipitation
+
+
+def _import_crri_eu_geodata(filename):
+
+    geodata = {}
+
+    ds_rainfall = netCDF4.Dataset(filename)
+
+    # get projection
+    projdef = ds_rainfall.getncattr('gdal_projection')
+    geodata["projection"] = projdef
+
+    # get x1, y1, x2, y2, xpixelsize, ypixelsize, yorigin
+    px = ds_rainfall.variables['nx'][:]
+    py = ds_rainfall.variables['ny'][:]
+    geotable = ds_rainfall.getncattr('gdal_geotransform_table')
+    xmin = px.min()
+    xmax = px.max()
+    ymin = py.min()
+    ymax = py.max()
+    xpixelsize = abs(geotable[1])
+    ypixelsize = abs(geotable[5])
+    factor_scale = 1.0
+    geodata["x1"] = xmin * factor_scale
+    geodata["y1"] = ymin * factor_scale
+    geodata["x2"] = xmax * factor_scale
+    geodata["y2"] = ymax * factor_scale
+    geodata["xpixelsize"] = xpixelsize * factor_scale
+    geodata["ypixelsize"] = ypixelsize * factor_scale
+    geodata["yorigin"] = "upper"
+
+    # get the accumulation period
+    geodata["accutime"] = None
+
+    # get the unit of precipitation
+    geodata["unit"] = ds_rainfall.variables['crr_intensity'].units
+
+    # get institution
+    geodata["institution"] = "SAF AEMET"
+
+    ds_rainfall.close()
+
+    return geodata
+
+
 def import_bom_rf3(filename, **kwargs):
     """Import a NetCDF radar rainfall product from the BoM Rainfields3.
 
@@ -216,8 +329,10 @@ def _import_bom_rf3_geodata(filename):
         ymin = min(ds_rainfall.variables["y"])
         ymax = max(ds_rainfall.variables["y"])
 
-    xpixelsize = abs(ds_rainfall.variables["x"][1] - ds_rainfall.variables["x"][0])
-    ypixelsize = abs(ds_rainfall.variables["y"][1] - ds_rainfall.variables["y"][0])
+    xpixelsize = abs(ds_rainfall.variables["x"][1] -
+                     ds_rainfall.variables["x"][0])
+    ypixelsize = abs(ds_rainfall.variables["y"][1] -
+                     ds_rainfall.variables["y"][0])
     factor_scale = 1.0
     if "units" in ds_rainfall.variables["x"].ncattrs():
         if getattr(ds_rainfall.variables["x"], "units") == "km":
@@ -410,7 +525,7 @@ def _import_fmi_pgm_geodata(metadata):
     projdef += " +lon_0=" + metadata["centrallongitude"][0] + "E"
     projdef += " +lat_0=" + metadata["centrallatitude"][0] + "N"
     projdef += " +lat_ts=" + metadata["truelatitude"][0]
-    # These are hard-coded because the projection definition 
+    # These are hard-coded because the projection definition
     # is missing from the PGM files.
     projdef += " +a=6371288"
     projdef += " +x_0=380886.310"

--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -359,13 +359,11 @@ def _import_crri_eu_geodata(filename):
     geodata["projection"] = projdef
 
     # get x1, y1, x2, y2, xpixelsize, ypixelsize, yorigin
-    px = ds_rainfall.variables['nx'][:]
-    py = ds_rainfall.variables['ny'][:]
     geotable = ds_rainfall.getncattr('gdal_geotransform_table')
-    xmin = px.min()
-    xmax = px.max()
-    ymin = py.min()
-    ymax = py.max()
+    xmin = ds_rainfall.getncattr("gdal_xgeo_up_left")
+    xmax = ds_rainfall.getncattr("gdal_xgeo_low_right")
+    ymin = ds_rainfall.getncattr("gdal_ygeo_low_right")
+    ymax = ds_rainfall.getncattr("gdal_ygeo_up_left")
     xpixelsize = abs(geotable[1])
     ypixelsize = abs(geotable[5])
     factor_scale = 1.0

--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -275,6 +275,7 @@ def _import_bom_rf3_geodata(filename):
 
     return geodata
 
+
 def import_saf_crri(filename, **kwargs):
     """Import a NetCDF radar rainfall product from the Convective Rainfall Rate
     Intensity (CRRI) product from the Satellite Application Facilities (SAF).
@@ -352,8 +353,8 @@ def _import_saf_crri_data(filename, idx_x=None, idx_y=None):
         if idx_x is not None:
             data = np.array(ds_rainfall.variables["crr_intensity"][idx_y, idx_x])
         else:
-            data = np.array(ds_rainfall.variables["crr_intensity"])        precipitation = np.where(data == 65535, np.nan, data)
-            precipitation = np.where(data == 65535, np.nan, data)
+            data = np.array(ds_rainfall.variables["crr_intensity"])
+        precipitation = np.where(data == 65535, np.nan, data)
     else:
         precipitation = None
     ds_rainfall.close()

--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -135,119 +135,6 @@ except ImportError:
     PYPROJ_IMPORTED = False
 
 
-def import_crri_eu(filename, **kwargs):
-    """Import a NetCDF radar rainfall product from the CRRI SAF.
-
-    Parameters
-    ----------
-    filename : str
-        Name of the file to import.
-
-    Returns
-    -------
-    out : tuple
-        A three-element tuple containing the rainfall field in mm/h imported
-        from the CRRI SAF netcdf, the quality field and the metadata. The
-        quality field is currently set to None.
-
-    """
-    if not NETCDF4_IMPORTED:
-        raise MissingOptionalDependency(
-            "netCDF4 package is required to import CRRI SAF products "
-            "but it is not installed"
-        )
-
-    precip = _import_crri_eu_data(filename)
-
-    geodata = _import_crri_eu_geodata(filename)
-    metadata = geodata
-
-    # TODO(import_crri_eu): Add missing georeferencing data.
-
-    metadata["transform"] = None
-    metadata["zerovalue"] = np.nanmin(precip)
-    if np.any(np.isfinite(precip)):
-        metadata["threshold"] = np.nanmin(precip[precip > np.nanmin(precip)])
-    else:
-        metadata["threshold"] = np.nan
-
-    # cut a window, to be defined here and only here
-    if True:
-        ny, nx = precip.shape
-        nx1 = 440
-        nx2 = nx - 440
-        ny1 = 250
-        ny2 = ny
-        precip = precip[ny1:ny2, nx1:nx2]
-        x1, x2 = metadata['x1'], metadata['x2']
-        xpixelsize = metadata['xpixelsize']
-        x1n = x1 + xpixelsize * nx1
-        x2n = x1 + xpixelsize * (nx2 - 1)
-        metadata['x1'], metadata['x2'] = x1n, x2n
-        y1, y2 = metadata['y1'], metadata['y2']
-        ypixelsize = metadata['ypixelsize']
-        y1n = y2 - ypixelsize * (ny2 - 1)
-        y2n = y2 - ypixelsize * ny1
-        metadata['y1'], metadata['y2'] = y1n, y2n
-
-    return precip, None, metadata
-
-
-def _import_crri_eu_data(filename):
-    ds_rainfall = netCDF4.Dataset(filename)
-    if "crr_intensity" in ds_rainfall.variables.keys():
-        data = np.array(ds_rainfall.variables["crr_intensity"])
-        precipitation = np.where(data == 65535, np.nan, data)
-    else:
-        precipitation = None
-    ds_rainfall.close()
-
-    return precipitation
-
-
-def _import_crri_eu_geodata(filename):
-
-    geodata = {}
-
-    ds_rainfall = netCDF4.Dataset(filename)
-
-    # get projection
-    projdef = ds_rainfall.getncattr('gdal_projection')
-    geodata["projection"] = projdef
-
-    # get x1, y1, x2, y2, xpixelsize, ypixelsize, yorigin
-    px = ds_rainfall.variables['nx'][:]
-    py = ds_rainfall.variables['ny'][:]
-    geotable = ds_rainfall.getncattr('gdal_geotransform_table')
-    xmin = px.min()
-    xmax = px.max()
-    ymin = py.min()
-    ymax = py.max()
-    xpixelsize = abs(geotable[1])
-    ypixelsize = abs(geotable[5])
-    factor_scale = 1.0
-    geodata["x1"] = xmin * factor_scale
-    geodata["y1"] = ymin * factor_scale
-    geodata["x2"] = xmax * factor_scale
-    geodata["y2"] = ymax * factor_scale
-    geodata["xpixelsize"] = xpixelsize * factor_scale
-    geodata["ypixelsize"] = ypixelsize * factor_scale
-    geodata["yorigin"] = "upper"
-
-    # get the accumulation period
-    geodata["accutime"] = None
-
-    # get the unit of precipitation
-    geodata["unit"] = ds_rainfall.variables['crr_intensity'].units
-
-    # get institution
-    geodata["institution"] = "SAF AEMET"
-
-    ds_rainfall.close()
-
-    return geodata
-
-
 def import_bom_rf3(filename, **kwargs):
     """Import a NetCDF radar rainfall product from the BoM Rainfields3.
 
@@ -383,6 +270,118 @@ def _import_bom_rf3_geodata(filename):
             geodata["unit"] = "mm"
 
     geodata["institution"] = "Commonwealth of Australia, Bureau of Meteorology"
+    ds_rainfall.close()
+
+    return geodata
+
+def import_crri_eu(filename, **kwargs):
+    """Import a NetCDF radar rainfall product from the CRRI SAF.
+
+    Parameters
+    ----------
+    filename : str
+        Name of the file to import.
+
+    Returns
+    -------
+    out : tuple
+        A three-element tuple containing the rainfall field in mm/h imported
+        from the CRRI SAF netcdf, the quality field and the metadata. The
+        quality field is currently set to None.
+
+    """
+    if not NETCDF4_IMPORTED:
+        raise MissingOptionalDependency(
+            "netCDF4 package is required to import CRRI SAF products "
+            "but it is not installed"
+        )
+
+    precip = _import_crri_eu_data(filename)
+
+    geodata = _import_crri_eu_geodata(filename)
+    metadata = geodata
+
+    # TODO(import_crri_eu): Add missing georeferencing data.
+
+    metadata["transform"] = None
+    metadata["zerovalue"] = np.nanmin(precip)
+    if np.any(np.isfinite(precip)):
+        metadata["threshold"] = np.nanmin(precip[precip > np.nanmin(precip)])
+    else:
+        metadata["threshold"] = np.nan
+
+    # cut a window, to be defined here and only here
+    if True:
+        ny, nx = precip.shape
+        nx1 = 440
+        nx2 = nx - 440
+        ny1 = 250
+        ny2 = ny
+        precip = precip[ny1:ny2, nx1:nx2]
+        x1, x2 = metadata['x1'], metadata['x2']
+        xpixelsize = metadata['xpixelsize']
+        x1n = x1 + xpixelsize * nx1
+        x2n = x1 + xpixelsize * (nx2 - 1)
+        metadata['x1'], metadata['x2'] = x1n, x2n
+        y1, y2 = metadata['y1'], metadata['y2']
+        ypixelsize = metadata['ypixelsize']
+        y1n = y2 - ypixelsize * (ny2 - 1)
+        y2n = y2 - ypixelsize * ny1
+        metadata['y1'], metadata['y2'] = y1n, y2n
+
+    return precip, None, metadata
+
+
+def _import_crri_eu_data(filename):
+    ds_rainfall = netCDF4.Dataset(filename)
+    if "crr_intensity" in ds_rainfall.variables.keys():
+        data = np.array(ds_rainfall.variables["crr_intensity"])
+        precipitation = np.where(data == 65535, np.nan, data)
+    else:
+        precipitation = None
+    ds_rainfall.close()
+
+    return precipitation
+
+
+def _import_crri_eu_geodata(filename):
+
+    geodata = {}
+
+    ds_rainfall = netCDF4.Dataset(filename)
+
+    # get projection
+    projdef = ds_rainfall.getncattr('gdal_projection')
+    geodata["projection"] = projdef
+
+    # get x1, y1, x2, y2, xpixelsize, ypixelsize, yorigin
+    px = ds_rainfall.variables['nx'][:]
+    py = ds_rainfall.variables['ny'][:]
+    geotable = ds_rainfall.getncattr('gdal_geotransform_table')
+    xmin = px.min()
+    xmax = px.max()
+    ymin = py.min()
+    ymax = py.max()
+    xpixelsize = abs(geotable[1])
+    ypixelsize = abs(geotable[5])
+    factor_scale = 1.0
+    geodata["x1"] = xmin * factor_scale
+    geodata["y1"] = ymin * factor_scale
+    geodata["x2"] = xmax * factor_scale
+    geodata["y2"] = ymax * factor_scale
+    geodata["xpixelsize"] = xpixelsize * factor_scale
+    geodata["ypixelsize"] = ypixelsize * factor_scale
+    geodata["yorigin"] = "upper"
+
+    # get the accumulation period
+    geodata["accutime"] = None
+
+    # get the unit of precipitation
+    geodata["unit"] = ds_rainfall.variables['crr_intensity'].units
+
+    # get institution
+    geodata["institution"] = "SAF AEMET"
+
     ds_rainfall.close()
 
     return geodata

--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -281,11 +281,13 @@ def import_crri_eu(filename, **kwargs):
 
     Parameters
     ----------
+
     filename : str
         Name of the file to import.
 
     Returns
     -------
+
     out : tuple
         A three-element tuple containing the rainfall field in mm/h imported
         from the CRRI SAF netcdf, the quality field and the metadata. The

--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -157,7 +157,7 @@ def import_crri_eu(filename, **kwargs):
             "but it is not installed"
         )
 
-    R = _import_crri_eu_data(filename)
+    precip = _import_crri_eu_data(filename)
 
     geodata = _import_crri_eu_geodata(filename)
     metadata = geodata
@@ -165,20 +165,20 @@ def import_crri_eu(filename, **kwargs):
     # TODO(import_crri_eu): Add missing georeferencing data.
 
     metadata["transform"] = None
-    metadata["zerovalue"] = np.nanmin(R)
-    if np.any(np.isfinite(R)):
-        metadata["threshold"] = np.nanmin(R[R > np.nanmin(R)])
+    metadata["zerovalue"] = np.nanmin(precip)
+    if np.any(np.isfinite(precip)):
+        metadata["threshold"] = np.nanmin(precip[precip > np.nanmin(precip)])
     else:
         metadata["threshold"] = np.nan
 
     # cut a window, to be defined here and only here
     if True:
-        ny, nx = R.shape
+        ny, nx = precip.shape
         nx1 = 440
         nx2 = nx - 440
         ny1 = 250
         ny2 = ny
-        R = R[ny1:ny2, nx1:nx2]
+        precip = precip[ny1:ny2, nx1:nx2]
         x1, x2 = metadata['x1'], metadata['x2']
         xpixelsize = metadata['xpixelsize']
         x1n = x1 + xpixelsize * nx1
@@ -190,7 +190,7 @@ def import_crri_eu(filename, **kwargs):
         y2n = y2 - ypixelsize * ny1
         metadata['y1'], metadata['y2'] = y1n, y2n
 
-    return R, None, metadata
+    return precip, None, metadata
 
 
 def _import_crri_eu_data(filename):
@@ -1224,7 +1224,7 @@ def import_knmi_hdf5(filename, **kwargs):
     dset = f["image1"]["image_data"]
     precip_intermediate = np.copy(dset)  # copy the content
 
-    # In case R is a rainfall accumulation (ACRR), R is divided by 100.0,
+    # In case precip is a rainfall accumulation (ACRR), precip is divided by 100.0,
     # because the data is saved as hundreds of mm (so, as integers). 65535 is
     # the no data value. The precision of the data is two decimals (0.01 mm).
     if qty == "ACRR":

--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -355,7 +355,7 @@ def _import_crri_eu_geodata(filename):
     ds_rainfall = netCDF4.Dataset(filename)
 
     # get projection
-    projdef = ds_rainfall.getncattr('gdal_projection')
+    projdef = ds_rainfall.getncattr("gdal_projection")
     geodata["projection"] = projdef
 
     # get x1, y1, x2, y2, xpixelsize, ypixelsize, yorigin
@@ -381,7 +381,7 @@ def _import_crri_eu_geodata(filename):
     geodata["unit"] = ds_rainfall.variables['crr_intensity'].units
 
     # get institution
-    geodata["institution"] = "SAF AEMET"
+    geodata["institution"] = ds_rainfall.getncattr("institution")
 
     ds_rainfall.close()
 

--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -333,7 +333,7 @@ def import_saf_crri(filename, **kwargs):
         idx_x = None
         idx_y = None
 
-    precip = _import_saf_crri_data(filename)
+    precip = _import_saf_crri_data(filename, idx_x, idx_y)
 
     # TODO(import_saf_crri): Add missing georeferencing data.
 

--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -73,6 +73,7 @@ Available Importers
     :toctree: ../generated/
 
     import_bom_rf3
+    import_crri_eu
     import_fmi_geotiff
     import_fmi_pgm
     import_mch_gif

--- a/pysteps/io/interface.py
+++ b/pysteps/io/interface.py
@@ -23,7 +23,7 @@ _importer_methods['mch_hdf5'] = importers.import_mch_hdf5
 _importer_methods['mch_metranet'] = importers.import_mch_metranet
 _importer_methods['opera_hdf5'] = importers.import_opera_hdf5
 _importer_methods['knmi_hdf5'] = importers.import_knmi_hdf5
-_importer_methods['crri_eu'] = importers.import_crri_eu
+_importer_methods['saf_crri'] = importers.import_crri
 
 _exporter_methods = dict()
 _exporter_methods['netcdf'] = exporters.initialize_forecast_exporter_netcdf
@@ -51,7 +51,7 @@ def get_method(name, method_type):
         |              |  archive containing precipitation intensity          |
         |              |  composites.                                         |
         +--------------+------------------------------------------------------+
-        | crri_eu      |  NetCDF SAF CRRI files                               |
+        | saf_crri     |  NetCDF SAF CRRI files                               |
         |              |  containing convective rain rate intensity and other |
         +--------------+------------------------------------------------------+
         | fmi_geotiff  |  GeoTIFF files used in the Finnish Meteorological    |

--- a/pysteps/io/interface.py
+++ b/pysteps/io/interface.py
@@ -37,6 +37,7 @@ def get_method(name, method_type):
     Parameters
     ----------
     name : str
+
         Name of the method. The available options are:\n
 
         Importers:
@@ -89,9 +90,9 @@ def get_method(name, method_type):
         | netcdf      | NetCDF files conforming to the CF 1.7 specification.  |
         +-------------+-------------------------------------------------------+
 
-    method_type : str
-        Type of the method.
-        The available options are 'importer' and 'exporter'.
+    method_type : {'importer', 'exporter'}
+
+        Type of the method (see tables above).
 
     """
 

--- a/pysteps/io/interface.py
+++ b/pysteps/io/interface.py
@@ -50,6 +50,9 @@ def get_method(name, method_type):
         |              |  archive containing precipitation intensity          |
         |              |  composites.                                         |
         +--------------+------------------------------------------------------+
+        | crri_eu      |  NetCDF SAF CRRI files                               |
+        |              |  containing convective rain rate intensity and other |
+        +--------------+------------------------------------------------------+
         | fmi_geotiff  |  GeoTIFF files used in the Finnish Meteorological    |
         |              |  Institute (FMI) archive, containing reflectivity    |
         |              |  composites (dBZ).                                   |
@@ -57,6 +60,8 @@ def get_method(name, method_type):
         | fmi_pgm      |  PGM files used in the Finnish Meteorological        |
         |              |  Institute (FMI) archive, containing reflectivity    |
         |              |  composites (dBZ).                                   |
+        +--------------+------------------------------------------------------+
+        | knmi_hdf5    |  HDF5 file format used by KNMI.                      |
         +--------------+------------------------------------------------------+
         | mch_gif      | GIF files in the MeteoSwiss (MCH) archive containing |
         |              | precipitation composites.                            |
@@ -67,11 +72,6 @@ def get_method(name, method_type):
         |              | containing precipitation composites.                 |
         +--------------+------------------------------------------------------+
         | opera_hdf5   | ODIM HDF5 file format used by Eumetnet/OPERA.        |
-        +--------------+------------------------------------------------------+
-        | knmi_hdf5    |  HDF5 file format used by KNMI.                      |
-        +--------------+------------------------------------------------------+
-        | crri_eu      |  NetCDF SAF CRRI files                               |
-        |              |  containing convective rain rate intensity and other |
         +--------------+------------------------------------------------------+
 
         Exporters:

--- a/pysteps/io/interface.py
+++ b/pysteps/io/interface.py
@@ -51,9 +51,6 @@ def get_method(name, method_type):
         |              |  archive containing precipitation intensity          |
         |              |  composites.                                         |
         +--------------+------------------------------------------------------+
-        | saf_crri     |  NetCDF SAF CRRI files                               |
-        |              |  containing convective rain rate intensity and other |
-        +--------------+------------------------------------------------------+
         | fmi_geotiff  |  GeoTIFF files used in the Finnish Meteorological    |
         |              |  Institute (FMI) archive, containing reflectivity    |
         |              |  composites (dBZ).                                   |
@@ -73,6 +70,9 @@ def get_method(name, method_type):
         |              | containing precipitation composites.                 |
         +--------------+------------------------------------------------------+
         | opera_hdf5   | ODIM HDF5 file format used by Eumetnet/OPERA.        |
+        +--------------+------------------------------------------------------+
+        | saf_crri     |  NetCDF SAF CRRI files                               |
+        |              |  containing convective rain rate intensity and other |
         +--------------+------------------------------------------------------+
 
         Exporters:

--- a/pysteps/io/interface.py
+++ b/pysteps/io/interface.py
@@ -23,6 +23,7 @@ _importer_methods['mch_hdf5'] = importers.import_mch_hdf5
 _importer_methods['mch_metranet'] = importers.import_mch_metranet
 _importer_methods['opera_hdf5'] = importers.import_opera_hdf5
 _importer_methods['knmi_hdf5'] = importers.import_knmi_hdf5
+_importer_methods['crri_eu'] = importers.import_crri_eu
 
 _exporter_methods = dict()
 _exporter_methods['netcdf'] = exporters.initialize_forecast_exporter_netcdf
@@ -30,7 +31,7 @@ _exporter_methods['kineros'] = exporters.initialize_forecast_exporter_kineros
 
 
 def get_method(name, method_type):
-    """Return a callable function for the method corresponding to the given 
+    """Return a callable function for the method corresponding to the given
     name.
 
     Parameters
@@ -42,51 +43,55 @@ def get_method(name, method_type):
 
         .. tabularcolumns:: |p{2cm}|L|
 
-        +--------------+-------------------------------------------------------+
-        |     Name     |              Description                              |
-        +==============+=======================================================+
-        | bom_rf3      |  NefCDF files used in the Boreau of Meterorology      |
-        |              |  archive containing precipitation intensity           |
-        |              |  composites.                                          |
-        +--------------+-------------------------------------------------------+
-        | fmi_geotiff  |  GeoTIFF files used in the Finnish Meteorological     |
-        |              |  Institute (FMI) archive, containing reflectivity     |
-        |              |  composites (dBZ).                                    |
-        +--------------+-------------------------------------------------------+
-        | fmi_pgm      |  PGM files used in the Finnish Meteorological         |
-        |              |  Institute (FMI) archive, containing reflectivity     |
-        |              |  composites (dBZ).                                    |
-        +--------------+-------------------------------------------------------+
-        | mch_gif      | GIF files in the MeteoSwiss (MCH) archive containing  |
-        |              | precipitation composites.                             |
-        +--------------+-------------------------------------------------------+
-        | mch_hdf5     | HDF5 file format used by MeteoSiss (MCH).             |
-        +--------------+-------------------------------------------------------+
-        | mch_metranet | metranet files in the MeteoSwiss (MCH) archive        |
-        |              | containing precipitation composites.                  |
-        +--------------+-------------------------------------------------------+
-        | opera_hdf5   | ODIM HDF5 file format used by Eumetnet/OPERA.         |
-        +--------------+-------------------------------------------------------+
-        | knmi_hdf5    |  HDF5 file format used by KNMI.                       |
-        +--------------+-------------------------------------------------------+
+        +--------------+------------------------------------------------------+
+        |     Name     |              Description                             |
+        +==============+======================================================+
+        | bom_rf3      |  NefCDF files used in the Boreau of Meterorology     |
+        |              |  archive containing precipitation intensity          |
+        |              |  composites.                                         |
+        +--------------+------------------------------------------------------+
+        | fmi_geotiff  |  GeoTIFF files used in the Finnish Meteorological    |
+        |              |  Institute (FMI) archive, containing reflectivity    |
+        |              |  composites (dBZ).                                   |
+        +--------------+------------------------------------------------------+
+        | fmi_pgm      |  PGM files used in the Finnish Meteorological        |
+        |              |  Institute (FMI) archive, containing reflectivity    |
+        |              |  composites (dBZ).                                   |
+        +--------------+------------------------------------------------------+
+        | mch_gif      | GIF files in the MeteoSwiss (MCH) archive containing |
+        |              | precipitation composites.                            |
+        +--------------+------------------------------------------------------+
+        | mch_hdf5     | HDF5 file format used by MeteoSiss (MCH).            |
+        +--------------+------------------------------------------------------+
+        | mch_metranet | metranet files in the MeteoSwiss (MCH) archive       |
+        |              | containing precipitation composites.                 |
+        +--------------+------------------------------------------------------+
+        | opera_hdf5   | ODIM HDF5 file format used by Eumetnet/OPERA.        |
+        +--------------+------------------------------------------------------+
+        | knmi_hdf5    |  HDF5 file format used by KNMI.                      |
+        +--------------+------------------------------------------------------+
+        | crri_eu      |  NetCDF SAF CRRI files                               |
+        |              |  containing convective rain rate intensity and other |
+        +--------------+------------------------------------------------------+
 
         Exporters:
-        
+
         .. tabularcolumns:: |p{2cm}|L|
 
-        +-------------+--------------------------------------------------------+
-        |     Name    |              Description                               |
-        +=============+========================================================+
-        | kineros     | KINEROS2 Rainfall file as specified in                 |
-        |             | https://www.tucson.ars.ag.gov/kineros/.                |
-        |             | Grid points are treated as individual rain gauges.     |
-        |             | A separate file is produced for each ensemble member.  |
-        +-------------+--------------------------------------------------------+
-        | netcdf      | NetCDF files conforming to the CF 1.7 specification.   |
-        +-------------+--------------------------------------------------------+
+        +-------------+-------------------------------------------------------+
+        |     Name    |              Description                              |
+        +=============+=======================================================+
+        | kineros     | KINEROS2 Rainfall file as specified in                |
+        |             | https://www.tucson.ars.ag.gov/kineros/.               |
+        |             | Grid points are treated as individual rain gauges.    |
+        |             | A separate file is produced for each ensemble member. |
+        +-------------+-------------------------------------------------------+
+        | netcdf      | NetCDF files conforming to the CF 1.7 specification.  |
+        +-------------+-------------------------------------------------------+
 
     method_type : str
-        Type of the method. The available options are 'importer' and 'exporter'.
+        Type of the method.
+        The available options are 'importer' and 'exporter'.
 
     """
 

--- a/pysteps/io/interface.py
+++ b/pysteps/io/interface.py
@@ -23,7 +23,7 @@ _importer_methods['mch_hdf5'] = importers.import_mch_hdf5
 _importer_methods['mch_metranet'] = importers.import_mch_metranet
 _importer_methods['opera_hdf5'] = importers.import_opera_hdf5
 _importer_methods['knmi_hdf5'] = importers.import_knmi_hdf5
-_importer_methods['saf_crri'] = importers.import_crri
+_importer_methods['saf_crri'] = importers.import_saf_crri
 
 _exporter_methods = dict()
 _exporter_methods['netcdf'] = exporters.initialize_forecast_exporter_netcdf

--- a/pysteps/pystepsrc
+++ b/pysteps/pystepsrc
@@ -69,6 +69,17 @@
                 "qty": "ACRR",
                 "pixelsize": 1000.0
 			}
+        },
+        "crri": {
+            "root_path": "./saf",
+            "path_fmt": "%Y%m%d/CRR",
+            "fn_pattern": "S_NWC_CRR_MSG4_Europe-VISIR_%Y%m%dT%H%M00Z",
+            "fn_ext": "nc",
+            "importer": "crri_eu",
+            "timestep": 15,
+            "importer_kwargs": {
+                "gzipped": true
+            }
         }
     }
 }

--- a/pysteps/tests/test_io_bom_rf3.py
+++ b/pysteps/tests/test_io_bom_rf3.py
@@ -9,6 +9,7 @@ from pysteps.tests.helpers import smart_assert
 
 pytest.importorskip('netCDF4')
 
+
 def test_io_import_bom_rf3_shape():
     """Test the importer Bom RF3."""
     root_path = pysteps.rcparams.data_sources["bom"]["root_path"]

--- a/pysteps/tests/test_io_saf_crri.py
+++ b/pysteps/tests/test_io_saf_crri.py
@@ -16,7 +16,7 @@ def test_io_import_saf_crri_shape():
     rel_path = "20180601/CRR"
     filename = os.path.join(root_path, rel_path,
                             "S_NWC_CRR_MSG4_Europe-VISIR_20180601T070000Z.nc")
-    precip, _, _ = pysteps.io._import_crri_eu_data(filename)
+    precip = pysteps.io.importers._import_crri_eu_data(filename)
     assert precip.shape == (2200, 1019)
 
 
@@ -46,5 +46,5 @@ def test_io_import_saf_crri_geodata(variable, expected, tolerance):
     rel_path = "20180601/CRR"
     filename = os.path.join(root_path, rel_path,
                             "S_NWC_CRR_MSG4_Europe-VISIR_20180601T070000Z.nc")
-    geodata = pysteps.io._import_crri_eu_geodata(filename)
+    geodata = pysteps.io.importers._import_crri_eu_geodata(filename)
     smart_assert(geodata[variable], expected, tolerance)

--- a/pysteps/tests/test_io_saf_crri.py
+++ b/pysteps/tests/test_io_saf_crri.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+import os
+
+import pytest
+
+import pysteps
+from pysteps.tests.helpers import smart_assert
+
+pytest.importorskip('netCDF4')
+
+
+def test_io_import_saf_crri_shape():
+    """Test the importer SAF CRRI."""
+    root_path = pysteps.rcparams.data_sources["crri"]["root_path"]
+    rel_path = "20180601/CRR"
+    filename = os.path.join(root_path, rel_path,
+                            "S_NWC_CRR_MSG4_Europe-VISIR_20180601T070000Z.nc")
+    precip, _, _ = pysteps.io._import_crri_eu_data(filename)
+    assert precip.shape == (2200, 1019)
+
+
+expected_proj = ("+proj=geos +a=6378137.000000 +b=6356752.300000 "
+                 "+lon_0=0.000000 +h=35785863.000000")
+
+# test_metadata_crri: list of (variable,expected,tolerance) tuples
+test_metadata_crri = [
+    ('projection', expected_proj, None),
+    ('unit', "mm/h", None),
+    ('accutime', None, None),
+    ('x1', -3300000.0, 0.1),
+    ('x2', 3297000.0, 0.1),
+    ('y1', 2514000.0, 0.1),
+    ('y2', 5568000.0, 0.1),
+    ('xpixelsize', 3000.0, 0.1),
+    ('ypixelsize', 3000.0, 0.1),
+    ('yorigin', 'upper', None),
+    ('institution', "SAF AEMET", None),
+]
+
+
+@pytest.mark.parametrize("variable, expected, tolerance", test_metadata_crri)
+def test_io_import_saf_crri_geodata(variable, expected, tolerance):
+    """Test the importer SAF CRRI."""
+    root_path = pysteps.rcparams.data_sources["crri"]["root_path"]
+    rel_path = "20180601/CRR"
+    filename = os.path.join(root_path, rel_path,
+                            "S_NWC_CRR_MSG4_Europe-VISIR_20180601T070000Z.nc")
+    geodata = pysteps.io._import_crri_eu_geodata(filename)
+    smart_assert(geodata[variable], expected, tolerance)

--- a/pysteps/tests/test_io_saf_crri.py
+++ b/pysteps/tests/test_io_saf_crri.py
@@ -57,7 +57,7 @@ def test_io_import_saf_crri_eu_shape():
     filename = os.path.join(root_path, rel_path,
                             "S_NWC_CRR_MSG4_Europe-VISIR_20180601T070000Z.nc")
     precip, _, _ = pysteps.io.import_crri_eu(filename)
-    assert precip.shape == (250, 440)
+    assert precip.shape == (769, 1320)
 
 
 test_metadata_crri_eu = [

--- a/pysteps/tests/test_io_saf_crri.py
+++ b/pysteps/tests/test_io_saf_crri.py
@@ -17,7 +17,7 @@ def test_io_import_saf_crri_shape():
     filename = os.path.join(root_path, rel_path,
                             "S_NWC_CRR_MSG4_Europe-VISIR_20180601T070000Z.nc")
     precip = pysteps.io.importers._import_crri_eu_data(filename)
-    assert precip.shape == (2200, 1019)
+    assert precip.shape == (1019, 2200)
 
 
 expected_proj = ("+proj=geos +a=6378137.000000 +b=6356752.300000 "

--- a/pysteps/tests/test_io_saf_crri.py
+++ b/pysteps/tests/test_io_saf_crri.py
@@ -62,7 +62,7 @@ test_extent_crri = [
 ]
 
 @pytest.mark.parametrize("extent, expected_extent, expected_shape, tolerance",
-                         test_metadata_crri)
+                         test_extent_crri)
 def test_io_import_saf_crri_extent(extent, expected_extent, expected_shape, tolerance):
     """Test the importer SAF CRRI."""
     root_path = pysteps.rcparams.data_sources["crri"]["root_path"]

--- a/pysteps/tests/test_io_saf_crri.py
+++ b/pysteps/tests/test_io_saf_crri.py
@@ -58,7 +58,7 @@ def test_io_import_saf_crri_metadata(variable, expected, tolerance):
 
 test_extent_crri = [
     (None, (-3301500.0, 3298500.0, 2512500.0, 5569500.0), (1019, 2200), None),
-    ((-1980000.0, 1977000.0, 2514000.0, 4818000.0), (-1977000.0, 1974000.0, 2517000.0, 4815000.0), (767, 1318), None),
+    ((-1980000.0, 1977000.0, 2514000.0, 4818000.0), (-1978500.0, 1975500.0, 2515500.0, 4816500.0), (767, 1318), None),
 ]
 
 @pytest.mark.parametrize("extent, expected_extent, expected_shape, tolerance",

--- a/pysteps/tests/test_io_saf_crri.py
+++ b/pysteps/tests/test_io_saf_crri.py
@@ -7,83 +7,85 @@ import pytest
 import pysteps
 from pysteps.tests.helpers import smart_assert
 
-pytest.importorskip('netCDF4')
-
-
-def test_io_import_saf_crri_shape():
-    """Test the importer SAF CRRI."""
-    root_path = pysteps.rcparams.data_sources["crri"]["root_path"]
-    rel_path = "20180601/CRR"
-    filename = os.path.join(root_path, rel_path,
-                            "S_NWC_CRR_MSG4_Europe-VISIR_20180601T070000Z.nc")
-    precip = pysteps.io.importers._import_crri_eu_data(filename)
-    assert precip.shape == (1019, 2200)
+pytest.importorskip("netCDF4")
 
 
 expected_proj = ("+proj=geos +a=6378137.000000 +b=6356752.300000 "
                  "+lon_0=0.000000 +h=35785863.000000")
-
-# test_metadata_crri: list of (variable,expected,tolerance) tuples
-test_metadata_crri = [
-    ('projection', expected_proj, None),
-    ('unit', "mm/h", None),
-    ('accutime', None, None),
-    ('x1', -3300000.0, 0.1),
-    ('x2', 3297000.0, 0.1),
-    ('y1', 2514000.0, 0.1),
-    ('y2', 5568000.0, 0.1),
-    ('xpixelsize', 3000.0, 0.1),
-    ('ypixelsize', 3000.0, 0.1),
-    ('yorigin', 'upper', None),
-    ('institution', "SAF AEMET", None),
+test_geodata_crri = [
+    ("projection", expected_proj, None),
+    ("x1", -3301500.0, 0.1),
+    ("x2", 3298500.0, 0.1),
+    ("y1", 2512500.0, 0.1),
+    ("y2", 5569500.0, 0.1),
+    ("xpixelsize", 3000.0, 0.1),
+    ("ypixelsize", 3000.0, 0.1),
+    ("yorigin", "upper", None),
 ]
 
-
-@pytest.mark.parametrize("variable, expected, tolerance", test_metadata_crri)
+@pytest.mark.parametrize("variable, expected, tolerance", test_geodata_crri)
 def test_io_import_saf_crri_geodata(variable, expected, tolerance):
     """Test the importer SAF CRRI."""
     root_path = pysteps.rcparams.data_sources["crri"]["root_path"]
     rel_path = "20180601/CRR"
     filename = os.path.join(root_path, rel_path,
                             "S_NWC_CRR_MSG4_Europe-VISIR_20180601T070000Z.nc")
-    geodata = pysteps.io.importers._import_crri_eu_geodata(filename)
+    geodata = pysteps.io.importers._import_saf_crri_geodata(filename)
+    print(variable, geodata[variable], expected, tolerance)
     smart_assert(geodata[variable], expected, tolerance)
 
 
-def test_io_import_saf_crri_eu_shape():
-    """Test the importer SAF CRRI for EU."""
-    root_path = pysteps.rcparams.data_sources["crri"]["root_path"]
-    rel_path = "20180601/CRR"
-    filename = os.path.join(root_path, rel_path,
-                            "S_NWC_CRR_MSG4_Europe-VISIR_20180601T070000Z.nc")
-    precip, _, _ = pysteps.io.import_crri_eu(filename)
-    assert precip.shape == (769, 1320)
-
-
-test_metadata_crri_eu = [
-    ('transform', None, None),
-    ('zerovalue', 0.0, 0.1),
-    ('projection', expected_proj, None),
-    ('unit', "mm/h", None),
-    ('accutime', None, None),
-    ('x1', -1980000.0, 0.1),
-    ('x2', 1977000.0, 0.1),
-    ('y1', 2514000.0, 0.1),
-    ('y2', 4818000.0, 0.1),
-    ('xpixelsize', 3000.0, 0.1),
-    ('ypixelsize', 3000.0, 0.1),
-    ('yorigin', 'upper', None),
-    ('institution', "SAF AEMET", None),
+test_metadata_crri = [
+    ("transform", None, None),
+    ("zerovalue", 0.0, 0.1),
+    ("unit", "mm/h", None),
+    ("accutime", None, None),
+    ("institution", "Agencia Estatal de Meteorología (AEMET)", None),
 ]
 
-
 @pytest.mark.parametrize("variable, expected, tolerance",
-                         test_metadata_crri_eu)
-def test_io_import_saf_crri_eu_metadata(variable, expected, tolerance):
+                         test_metadata_crri)
+def test_io_import_saf_crri_metadata(variable, expected, tolerance):
     """Test the importer SAF CRRI."""
     root_path = pysteps.rcparams.data_sources["crri"]["root_path"]
     rel_path = "20180601/CRR"
     filename = os.path.join(root_path, rel_path,
                             "S_NWC_CRR_MSG4_Europe-VISIR_20180601T070000Z.nc")
-    _, _, metadata = pysteps.io.import_crri_eu(filename)
+    _, _, metadata = pysteps.io.import_saf_crri(filename)
+    print(variable, metadata[variable], expected, tolerance)
     smart_assert(metadata[variable], expected, tolerance)
+
+
+test_extent_crri = [
+    (None, (-3301500.0, 3298500.0, 2512500.0, 5569500.0), (1019, 2200), None),
+    ((-1980000.0, 1977000.0, 2514000.0, 4818000.0), (-1977000.0, 1974000.0, 2517000.0, 4815000.0), (767, 1318), None),
+]
+
+@pytest.mark.parametrize("extent, expected_extent, expected_shape, tolerance",
+                         test_metadata_crri)
+def test_io_import_saf_crri_extent(extent, expected_extent, expected_shape, tolerance):
+    """Test the importer SAF CRRI."""
+    root_path = pysteps.rcparams.data_sources["crri"]["root_path"]
+    rel_path = "20180601/CRR"
+    filename = os.path.join(root_path, rel_path,
+                            "S_NWC_CRR_MSG4_Europe-VISIR_20180601T070000Z.nc")
+    precip, _, metadata = pysteps.io.import_saf_crri(filename, extent=extent)
+    extent_out = (metadata["x1"], metadata["x2"], metadata["y1"], metadata["y2"])
+
+    print(extent, extent_out, expected_extent)
+    smart_assert(extent_out, expected_extent, tolerance)
+    print(precip.shape, expected_shape)
+    smart_assert(precip.shape, expected_shape, tolerance)
+
+
+if __name__ == "__main__":
+
+    for i, args in enumerate(test_geodata_crri):
+        test_io_import_saf_crri_geodata(args[0], args[1], args[2])
+
+    for i, args in enumerate(test_metadata_crri):
+        test_io_import_saf_crri_metadata(args[0], args[1], args[2])
+
+    for i, args in enumerate(test_extent_crri):
+        test_io_import_saf_crri_extent(args[0], args[1], args[2], args[3])
+

--- a/pysteps/tests/test_io_saf_crri.py
+++ b/pysteps/tests/test_io_saf_crri.py
@@ -59,6 +59,7 @@ def test_io_import_saf_crri_eu_shape():
     precip, _, _ = pysteps.io.import_crri_eu(filename)
     assert precip.shape == (250, 440)
 
+
 test_metadata_crri_eu = [
     ('transform', None, None),
     ('zerovalue', 0.0, 0.1),
@@ -75,7 +76,9 @@ test_metadata_crri_eu = [
     ('institution', "SAF AEMET", None),
 ]
 
-@pytest.mark.parametrize("variable, expected, tolerance", test_metadata_crri_eu)
+
+@pytest.mark.parametrize("variable, expected, tolerance",
+                         test_metadata_crri_eu)
 def test_io_import_saf_crri_eu_metadata(variable, expected, tolerance):
     """Test the importer SAF CRRI."""
     root_path = pysteps.rcparams.data_sources["crri"]["root_path"]
@@ -84,7 +87,3 @@ def test_io_import_saf_crri_eu_metadata(variable, expected, tolerance):
                             "S_NWC_CRR_MSG4_Europe-VISIR_20180601T070000Z.nc")
     _, _, metadata = pysteps.io.import_crri_eu(filename)
     smart_assert(metadata[variable], expected, tolerance)
-
-
-
-

--- a/pysteps/tests/test_io_saf_crri.py
+++ b/pysteps/tests/test_io_saf_crri.py
@@ -48,3 +48,43 @@ def test_io_import_saf_crri_geodata(variable, expected, tolerance):
                             "S_NWC_CRR_MSG4_Europe-VISIR_20180601T070000Z.nc")
     geodata = pysteps.io.importers._import_crri_eu_geodata(filename)
     smart_assert(geodata[variable], expected, tolerance)
+
+
+def test_io_import_saf_crri_eu_shape():
+    """Test the importer SAF CRRI for EU."""
+    root_path = pysteps.rcparams.data_sources["crri"]["root_path"]
+    rel_path = "20180601/CRR"
+    filename = os.path.join(root_path, rel_path,
+                            "S_NWC_CRR_MSG4_Europe-VISIR_20180601T070000Z.nc")
+    precip, _, _ = pysteps.io.import_crri_eu(filename)
+    assert precip.shape == (250, 440)
+
+test_metadata_crri_eu = [
+    ('transform', None, None),
+    ('zerovalue', 0.0, 0.1),
+    ('projection', expected_proj, None),
+    ('unit', "mm/h", None),
+    ('accutime', None, None),
+    ('x1', -1980000.0, 0.1),
+    ('x2', 1977000.0, 0.1),
+    ('y1', 2514000.0, 0.1),
+    ('y2', 4818000.0, 0.1),
+    ('xpixelsize', 3000.0, 0.1),
+    ('ypixelsize', 3000.0, 0.1),
+    ('yorigin', 'upper', None),
+    ('institution', "SAF AEMET", None),
+]
+
+@pytest.mark.parametrize("variable, expected, tolerance", test_metadata_crri_eu)
+def test_io_import_saf_crri_eu_metadata(variable, expected, tolerance):
+    """Test the importer SAF CRRI."""
+    root_path = pysteps.rcparams.data_sources["crri"]["root_path"]
+    rel_path = "20180601/CRR"
+    filename = os.path.join(root_path, rel_path,
+                            "S_NWC_CRR_MSG4_Europe-VISIR_20180601T070000Z.nc")
+    _, _, metadata = pysteps.io.import_crri_eu(filename)
+    smart_assert(metadata[variable], expected, tolerance)
+
+
+
+


### PR DESCRIPTION
@juanpablosimarro did write an importer for SAF CRRI netcdf files, updated pysteps visualization scripts to display these datasets and create new examples using pySTEPS with Satellite data. 
https://github.com/juanpablosimarro/pysteps/tree/saf
 
This pull request includes only the CRRI importer and an additional test for the CRRI importer.
@juanpablosimarro and I will continue working to add more of his updates into pySTEPS.

This branch passed all tests in Travis for Linux but for some reason MacOS env seems broken at Travis.