### PR TITLE
Make use of linspace compatible with NumPy 1.18

### DIFF
--- a/pysteps/noise/fftgenerators.py
+++ b/pysteps/noise/fftgenerators.py
@@ -806,7 +806,7 @@ def build_2D_tapering_function(win_size, win_type="flat-hanning"):
 
         T = win_size[0] / 4.0
         W = win_size[0] / 2.0
-        B = np.linspace(-W, W, 2 * W)
+        B = np.linspace(-W, W, int(2 * W))
         R = np.abs(B) - T
         R[R < 0] = 0.0
         A = 0.5 * (1.0 + np.cos(np.pi * R / T))
@@ -815,7 +815,7 @@ def build_2D_tapering_function(win_size, win_type="flat-hanning"):
 
         T = win_size[1] / 4.0
         W = win_size[1] / 2.0
-        B = np.linspace(-W, W, 2 * W)
+        B = np.linspace(-W, W, int(2 * W))
         R = np.abs(B) - T
         R[R < 0] = 0.0
         A = 0.5 * (1.0 + np.cos(np.pi * R / T))

--- a/pysteps/nowcasts/sseps.py
+++ b/pysteps/nowcasts/sseps.py
@@ -850,7 +850,7 @@ def _build_2D_tapering_function(win_size, win_type="flat-hanning"):
 
         T = win_size[0] / 4.0
         W = win_size[0] / 2.0
-        B = np.linspace(-W, W, 2 * W)
+        B = np.linspace(-W, W, int(2 * W))
         R = np.abs(B) - T
         R[R < 0] = 0.0
         A = 0.5 * (1.0 + np.cos(np.pi * R / T))
@@ -859,7 +859,7 @@ def _build_2D_tapering_function(win_size, win_type="flat-hanning"):
 
         T = win_size[1] / 4.0
         W = win_size[1] / 2.0
-        B = np.linspace(-W, W, 2 * W)
+        B = np.linspace(-W, W, int(2 * W))
         R = np.abs(B) - T
         R[R < 0] = 0.0
         A = 0.5 * (1.0 + np.cos(np.pi * R / T))

--- a/pysteps/verification/probscores.py
+++ b/pysteps/verification/probscores.py
@@ -203,7 +203,7 @@ def reldiag_init(X_min, n_bins=10, min_count=10):
     reldiag = {}
 
     reldiag["X_min"] = X_min
-    reldiag["bin_edges"] = np.linspace(-1e-6, 1+1e-6, n_bins+1)
+    reldiag["bin_edges"] = np.linspace(-1e-6, 1 + 1e-6, int(n_bins + 1))
     reldiag["n_bins"] = n_bins
     reldiag["X_sum"] = np.zeros(n_bins)
     reldiag["Y_sum"] = np.zeros(n_bins, dtype=int)
@@ -340,7 +340,7 @@ def ROC_curve_init(X_min, n_prob_thrs=10):
     ROC["misses"] = np.zeros(n_prob_thrs, dtype=int)
     ROC["false_alarms"] = np.zeros(n_prob_thrs, dtype=int)
     ROC["corr_neg"] = np.zeros(n_prob_thrs, dtype=int)
-    ROC["prob_thrs"] = np.linspace(0.0, 1.0, n_prob_thrs)
+    ROC["prob_thrs"] = np.linspace(0.0, 1.0, int(n_prob_thrs))
 
     return ROC
 


### PR DESCRIPTION
https://numpy.org/devdocs/release/1.18.0-notes.html 
> np.linspace parameter num must be an integer. Deprecated in NumPy 1.12. (gh-14620)