### PR TITLE
Fix for a crash when importing a OPERA HDF5 file

### DIFF
--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -1016,10 +1016,11 @@ def import_opera_hdf5(filename, **kwargs):
             what_grp_found = False
             # check if the "what" group is in the "dataset" group
             if "what" in list(dsg[1].keys()):
-                qty_, gain, offset, nodata, undetect = _read_opera_hdf5_what_group(
-                    dsg[1]["what"]
-                )
-                what_grp_found = True
+                if "quantity" in dsg[1]["what"].attrs.keys():
+                    qty_, gain, offset, nodata, undetect = _read_opera_hdf5_what_group(
+                        dsg[1]["what"]
+                    )
+                    what_grp_found = True
 
             for dg in dsg[1].items():
                 if dg[0][0:4] == "data":


### PR DESCRIPTION
The ODIM specification allows for including metadata for data in two different places: either under "/dataset/what" group or under "/dataset/data/what" group. If the metadata is included in the latter location, the first location would be empty. However, pysteps doesn't take this into account and tries to read the metadata from "/dataset/what", resulting in a KeyError.

This fix makes it so that pysteps will ignore the "/dataset/what" group if it exists, but doesn't include "quantity" attribute.