### PR TITLE
Support Python >= 3.6

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,7 +10,7 @@ formats:
     - pdf
 
 python:
-  version: 3.7
+  version: 3.8
   install:
     - requirements: requirements.txt
     - requirements: doc/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,7 +10,7 @@ formats:
     - pdf
 
 python:
-  version: 3.8
+  version: 3.7
   install:
     - requirements: requirements.txt
     - requirements: doc/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 
 env:
   global:
-    - MINIMAL_DEPENDENCIES="cython numpy attrdict jsmin jsonschema matplotlib-base netCDF4 opencv pillow pyproj scipy dask"
+    - MINIMAL_DEPENDENCIES="cython numpy attrdict jsmin jsonschema matplotlib netCDF4 opencv pillow pyproj scipy dask"
     - OPTIONAL_DEPENDENCIES="dask pyfftw cartopy h5py PyWavelets"
     - TEST_DEPENDENCIES="pytest pytest-cov codecov"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ env:
 matrix:
   include:
     - os: linux
-      python: 3.7
+      python: 3.8
       env:
-        - PYTHON_VERSION=3.7
+        - PYTHON_VERSION=3.8
         - RUN_TESTS=false
 
     - os: linux
@@ -26,11 +26,17 @@ matrix:
         - PYTHON_VERSION=3.7
         - RUN_TESTS=true
 
+    - os: linux
+      python: 3.8
+      env:
+        - PYTHON_VERSION=3.7
+        - RUN_TESTS=true
+
     - os: osx
       language: generic
       osx_image: xcode10.1
       env:
-        - PYTHON_VERSION=3.7
+        - PYTHON_VERSION=3.8
         - RUN_TESTS=false
 
     - os: osx
@@ -45,6 +51,13 @@ matrix:
       osx_image: xcode10.1
       env:
         - PYTHON_VERSION=3.7
+        - RUN_TESTS=true
+
+    - os: osx
+      language: generic
+      osx_image: xcode10.1
+      env:
+        - PYTHON_VERSION=3.8
         - RUN_TESTS=true
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,18 +47,18 @@ matrix:
         - RUN_TESTS=true
 
     - os: osx
-    language: generic
-    osx_image: xcode10.1
-    env:
-      - PYTHON_VERSION=3.7
-      - RUN_TESTS=true
+      language: generic
+      osx_image: xcode10.1
+      env:
+        - PYTHON_VERSION=3.7
+        - RUN_TESTS=true
 
     - os: osx
-    language: generic
-    osx_image: xcode10.1
-    env:
-      - PYTHON_VERSION=3.8
-      - RUN_TESTS=true
+      language: generic
+      osx_image: xcode10.1
+      env:
+        - PYTHON_VERSION=3.8
+        - RUN_TESTS=true
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,6 +111,7 @@ install:
   # ---------------
   - export PYSTEPS_BUILD_DIR="$( pwd )"
   - pip install .
+  - conda list
   - cd ~
 
   # Check that the pysteps package can be imported

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 
 env:
   global:
-    - MINIMAL_DEPENDENCIES="cython numpy attrdict jsmin jsonschema matplotlib netCDF4 opencv pillow pyproj scipy dask"
+    - MINIMAL_DEPENDENCIES="cython numpy attrdict jsmin jsonschema matplotlib-base netCDF4 opencv pillow pyproj scipy dask"
     - OPTIONAL_DEPENDENCIES="dask pyfftw cartopy basemap h5py PyWavelets"
     - TEST_DEPENDENCIES="pytest pytest-cov codecov"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
     - os: linux
       python: 3.8
       env:
-        - PYTHON_VERSION=3.7
+        - PYTHON_VERSION=3.8
         - RUN_TESTS=true
 
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 env:
   global:
     - MINIMAL_DEPENDENCIES="cython numpy attrdict jsmin jsonschema matplotlib-base netCDF4 opencv pillow pyproj scipy dask"
-    - OPTIONAL_DEPENDENCIES="dask pyfftw cartopy basemap h5py PyWavelets"
+    - OPTIONAL_DEPENDENCIES="dask pyfftw cartopy h5py PyWavelets"
     - TEST_DEPENDENCIES="pytest pytest-cov codecov"
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ env:
 matrix:
   include:
     - os: linux
-      python: 3.8
+      python: 3.7
       env:
-        - PYTHON_VERSION=3.8
+        - PYTHON_VERSION=3.7
         - RUN_TESTS=false
 
     - os: linux
@@ -26,17 +26,11 @@ matrix:
         - PYTHON_VERSION=3.7
         - RUN_TESTS=true
 
-    - os: linux
-      python: 3.8
-      env:
-        - PYTHON_VERSION=3.7
-        - RUN_TESTS=true
-
     - os: osx
       language: generic
       osx_image: xcode10.1
       env:
-        - PYTHON_VERSION=3.8
+        - PYTHON_VERSION=3.7
         - RUN_TESTS=false
 
     - os: osx
@@ -51,13 +45,6 @@ matrix:
       osx_image: xcode10.1
       env:
         - PYTHON_VERSION=3.7
-        - RUN_TESTS=true
-
-    - os: osx
-      language: generic
-      osx_image: xcode10.1
-      env:
-        - PYTHON_VERSION=3.8
         - RUN_TESTS=true
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,7 +111,6 @@ install:
   # ---------------
   - export PYSTEPS_BUILD_DIR="$( pwd )"
   - pip install .
-  - conda list
   - cd ~
 
   # Check that the pysteps package can be imported

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ env:
 matrix:
   include:
     - os: linux
-      python: 3.6
+      python: 3.8
       env:
-        - PYTHON_VERSION=3.6
+        - PYTHON_VERSION=3.8
         - RUN_TESTS=false
 
     - os: linux
@@ -20,11 +20,23 @@ matrix:
         - PYTHON_VERSION=3.6
         - RUN_TESTS=true
 
+    - os: linux
+      python: 3.7
+      env:
+        - PYTHON_VERSION=3.7
+        - RUN_TESTS=true
+
+    - os: linux
+      python: 3.8
+      env:
+        - PYTHON_VERSION=3.7
+        - RUN_TESTS=true
+
     - os: osx
       language: generic
       osx_image: xcode10.1
       env:
-        - PYTHON_VERSION=3.6
+        - PYTHON_VERSION=3.8
         - RUN_TESTS=false
 
     - os: osx
@@ -33,6 +45,20 @@ matrix:
       env: 
         - PYTHON_VERSION=3.6
         - RUN_TESTS=true
+
+    - os: osx
+    language: generic
+    osx_image: xcode10.1
+    env:
+      - PYTHON_VERSION=3.7
+      - RUN_TESTS=true
+
+    - os: osx
+    language: generic
+    osx_image: xcode10.1
+    env:
+      - PYTHON_VERSION=3.8
+      - RUN_TESTS=true
 
 sudo: false
 

--- a/doc/source/user_guide/install_pysteps.rst
+++ b/doc/source/user_guide/install_pysteps.rst
@@ -31,8 +31,7 @@ efficiency:
 
 Other optional dependencies include:
 
-* `cartopy <https://scitools.org.uk/cartopy/docs/v0.16/>`_ or
-  `basemap <https://matplotlib.org/basemap/>`_ (for geo-referenced
+* `cartopy <https://scitools.org.uk/cartopy/docs/v0.16/>`_ (for geo-referenced
   visualization)
 * `h5py <https://www.h5py.org/>`_ (for importing HDF5 data)
 * `pywavelets <https://pywavelets.readthedocs.io/en/latest/>`_

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
 - conda-forge
 - defaults
 dependencies:
-  - python>=3.6
+  - python=3.7
   - attrdict
   - jsmin
   - jsonschema

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
 - conda-forge
 - defaults
 dependencies:
-  - python=3.6
+  - python>=3.6
   - attrdict
   - jsmin
   - jsonschema

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
 - conda-forge
 - defaults
 dependencies:
-  - python=3.7
+  - python>=3.6
   - attrdict
   - jsmin
   - jsonschema

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - attrdict
   - jsmin
   - jsonschema
-  - matplotlib
+  - matplotlib-base
   - netCDF4
   - numpy
   - opencv

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - attrdict
   - jsmin
   - jsonschema
-  - matplotlib-base
+  - matplotlib
   - netCDF4
   - numpy
   - opencv

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -4,7 +4,7 @@ channels:
 - conda-forge
 - defaults
 dependencies:
-  - python>=3.6
+  - python=3.7
   - pip
   - attrdict
   - jsmin

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -4,7 +4,7 @@ channels:
 - conda-forge
 - defaults
 dependencies:
-  - python=3.7
+  - python>=3.6
   - pip
   - attrdict
   - jsmin

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -4,7 +4,7 @@ channels:
 - conda-forge
 - defaults
 dependencies:
-  - python=3.6
+  - python>=3.6
   - pip
   - attrdict
   - jsmin

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -9,7 +9,7 @@ dependencies:
   - attrdict
   - jsmin
   - jsonschema
-  - matplotlib
+  - matplotlib-base
   - netCDF4
   - numpy
   - opencv

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -9,7 +9,7 @@ dependencies:
   - attrdict
   - jsmin
   - jsonschema
-  - matplotlib-base
+  - matplotlib
   - netCDF4
   - numpy
   - opencv

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ opencv-python
 pillow
 pyproj
 scipy
-matplotlib-base
+matplotlib
 attrdict
 jsmin
 jsonschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ opencv-python
 pillow
 pyproj
 scipy
-matplotlib
+matplotlib-base
 attrdict
 jsmin
 jsonschema

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,7 +15,6 @@ netCDF4
 dask
 pyfftw
 cartopy
-basemap
 h5py
 
 # Testing

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,7 +5,7 @@ opencv-python
 pillow
 pyproj
 scipy
-matplotlib-base
+matplotlib
 attrdict
 jsmin
 jsonschema

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,7 +5,7 @@ opencv-python
 pillow
 pyproj
 scipy
-matplotlib
+matplotlib-base
 attrdict
 jsmin
 jsonschema

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,6 @@ conda_deps =
     netCDF4
     pyproj
     cartopy
-    basemap
 setenv =
     TOX_TEST_DATA_DIR = {toxworkdir}/pysteps-data
     PYSTEPSRC = {toxworkdir}/pysteps-data/pystepsrc.tox

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,8 @@ conda_deps =
     netCDF4
     pyproj
     cartopy
+conda_channels =
+    conda-forge
 setenv =
     TOX_TEST_DATA_DIR = {toxworkdir}/pysteps-data
     PYSTEPSRC = {toxworkdir}/pysteps-data/pystepsrc.tox
@@ -38,6 +40,7 @@ setenv =
     PROJ_LIB={envdir}/share/proj
 commands =
     python {toxinidir}/scripts/create_pystepsrc_tox.py
+    pip install -e .
     pytest --pyargs pysteps --cov=pysteps -ra --disable-warnings
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@
 #   > pip install tox tox-conda
 
 [tox]
-envlist = py36
+envlist = py36, py37, py38
 skipsdist = True
 
 
@@ -39,7 +39,7 @@ setenv =
     PROJ_LIB={envdir}/share/proj
 commands =
     python {toxinidir}/scripts/create_pystepsrc_tox.py
-    pytest --pyargs pysteps --cov=pysteps -ra
+    pytest --pyargs pysteps --cov=pysteps -ra --disable-warnings
 
 
 [testenv:install]
@@ -50,7 +50,7 @@ changedir = {homedir}
 commands =
     pip install -U {toxinidir}/
     python -c "import pysteps"
-    pytest --pyargs pysteps
+    pytest --pyargs pysteps --disable-warnings
 
 [testenv:install_full]
 description = Test the installation of the package in an environment with all the dependencies
@@ -65,7 +65,7 @@ changedir = {homedir}
 commands =
     pip install --no-cache-dir pysteps
     python -c "import pysteps"
-    pytest --pyargs pysteps
+    pytest --pyargs pysteps --disable-warnings
 
 [testenv:pypi_test]
 description = Test the installation of the package from the test-PyPI in a clean environment
@@ -75,7 +75,7 @@ changedir = {homedir}
 commands =
     pip install --no-cache-dir --index-url https://test.pypi.org/simple/  --extra-index-url=https://pypi.org/simple/ pysteps
     python -c "import pysteps"
-    pytest --pyargs pysteps
+    pytest --pyargs pysteps --disable-warnings
 
 
 [testenv:pypi_test_full]

--- a/tox.ini
+++ b/tox.ini
@@ -6,11 +6,17 @@
 #
 # Alternatively, you can install them using pip:
 #   > pip install tox tox-conda
+#
+# The python 3.6, 3.7, and 3.8 environments must be available to run all the tests.
+# If a given environments (python version) is not available, the tests for that
+# environment are ignored.
+#
+# If for example the python 3.8 environments is missing, you can create it by running:
+#   > conda create -n py38  python=3.8
+#
 
 [tox]
 envlist = py36, py37, py38
-skipsdist = True
-
 
 [testenv]
 description = Run the pysteps's test suite


### PR DESCRIPTION
- Implement testing for Python >= 3.6 (#136)
- Use Python=3.8 for building documentation
- Remove basemap as optional dependency (incompatible for OsX and python3.8)
- Use conda-forge channel when installing conda dependencies with tox