### PR TITLE
Remove AttrDict dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 
 env:
   global:
-    - MINIMAL_DEPENDENCIES="cython numpy attrdict jsmin jsonschema matplotlib netCDF4 opencv pillow pyproj scipy dask"
+    - MINIMAL_DEPENDENCIES="cython numpy jsmin jsonschema matplotlib netCDF4 opencv pillow pyproj scipy dask"
     - OPTIONAL_DEPENDENCIES="dask pyfftw cartopy h5py PyWavelets"
     - TEST_DEPENDENCIES="pytest pytest-cov codecov"
 

--- a/doc/source/user_guide/install_pysteps.rst
+++ b/doc/source/user_guide/install_pysteps.rst
@@ -9,8 +9,6 @@ Dependencies
 The pysteps package needs the following dependencies
 
 * `python >=3.6 <http://www.python.org/>`_
-* `attrdict <https://pypi.org/project/attrdict/>`_
-* `jsmin <https://pypi.org/project/jsmin/>`_
 * `jsonschema <https://pypi.org/project/jsonschema/>`_
 * `matplotlib <http://matplotlib.org/>`_
 * `netCDF4 <https://pypi.org/project/netCDF4/>`_
@@ -163,12 +161,12 @@ Setting up the user-defined configuration file
 ----------------------------------------------
 
 .. _JSON: https://en.wikipedia.org/wiki/JSON
-.. _AttrDict: https://pypi.org/project/attrdict/
 
 The pysteps package allows the users to customize the default settings
 and configuration.
 The configuration parameters used by default are loaded from a user-defined
-JSON_ file and then stored in the **pysteps.rcparams** AttrDict_.
+JSON_ file and then stored in the **pysteps.rcparams**, a dictionary-like object
+that can be accessed as attributes or as items.
 
 .. toctree::
     :maxdepth: 1

--- a/doc/source/user_guide/set_pystepsrc.rst
+++ b/doc/source/user_guide/set_pystepsrc.rst
@@ -4,15 +4,12 @@ The pySTEPS configuration file (pystepsrc)
 ==========================================
 
 .. _JSON: https://en.wikipedia.org/wiki/JSON
-.. _AttrDict: https://pypi.org/project/attrdict/
 
 The pysteps package allows the users to customize the default settings
 and configuration.
 The configuration parameters used by default are loaded from a user-defined
-JSON_ file and then stored in the **pysteps.rcparams** AttrDict_.
-
-The configuration parameters can be accessed as attributes or as items
-in a dictionary.
+JSON_ file and then stored in `pysteps.rcparams`, a dictionary-like object
+that can be accessed as attributes or as items.
 For example, the default parameters can be obtained using any of the following ways::
 
     import pysteps

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,6 @@ channels:
 - defaults
 dependencies:
   - python>=3.6
-  - attrdict
   - jsmin
   - jsonschema
   - matplotlib

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -6,7 +6,6 @@ channels:
 dependencies:
   - python>=3.6
   - pip
-  - attrdict
   - jsmin
   - jsonschema
   - matplotlib

--- a/pysteps/__init__.py
+++ b/pysteps/__init__.py
@@ -166,6 +166,12 @@ def load_config_file(params_file=None, verbose=False, dryrun=False):
     dryrun: bool
         If False, perform a dry run that does not update the `pysteps.rcparams`
         attribute.
+
+    Returns
+    -------
+
+    rcparams : DotDictify
+        Configuration parameters loaded from file.
     """
 
     global rcparams

--- a/pysteps/__init__.py
+++ b/pysteps/__init__.py
@@ -29,7 +29,7 @@ def _get_config_file_schema():
     Return the path to the parameters file json schema.
     """
     module_file = _decode_filesystem_path(__file__)
-    return os.path.join(os.path.dirname(module_file), 'pystepsrc_schema.json')
+    return os.path.join(os.path.dirname(module_file), "pystepsrc_schema.json")
 
 
 def _fconfig_candidates_generator():
@@ -39,34 +39,34 @@ def _fconfig_candidates_generator():
     See :py:func:~config_fname for more details.
     """
 
-    yield os.path.join(os.getcwd(), 'pystepsrc')
+    yield os.path.join(os.getcwd(), "pystepsrc")
 
     try:
-        pystepsrc = os.environ['PYSTEPSRC']
+        pystepsrc = os.environ["PYSTEPSRC"]
     except KeyError:
         pass
     else:
         yield pystepsrc
-        yield os.path.join(pystepsrc, 'pystepsrc')
+        yield os.path.join(pystepsrc, "pystepsrc")
 
     if os.name == "nt":
         # Windows environment
-        env_variable = 'USERPROFILE'
-        subdir = 'pysteps'
+        env_variable = "USERPROFILE"
+        subdir = "pysteps"
     else:
         # UNIX like
-        env_variable = 'HOME'
-        subdir = '.pysteps'
+        env_variable = "HOME"
+        subdir = ".pysteps"
 
     try:
         pystepsrc = os.environ[env_variable]
     except KeyError:
         pass
     else:
-        yield os.path.join(pystepsrc, subdir, 'pystepsrc')
+        yield os.path.join(pystepsrc, subdir, "pystepsrc")
 
     module_file = _decode_filesystem_path(__file__)
-    yield os.path.join(os.path.dirname(module_file), 'pystepsrc')
+    yield os.path.join(os.path.dirname(module_file), "pystepsrc")
     yield None
 
 
@@ -164,21 +164,22 @@ def load_config_file(params_file=None, verbose=False):
         params_file = config_fname()
 
         if params_file is None:
-            warnings.warn("pystepsrc file not found."
-                          + "The defaults parameters are left empty",
-                          category=ImportWarning)
+            warnings.warn(
+                "pystepsrc file not found."
+                + "The defaults parameters are left empty",
+                category=ImportWarning,
+            )
 
             rcparams = dict()
             return
 
-    with open(params_file, 'r') as f:
+    with open(params_file, "r") as f:
         rcparams = json.loads(jsmin(f.read()))
 
     if (not rcparams.get("silent_import", False)) or verbose:
-        print("Pysteps configuration file found at: " + params_file
-              + "\n")
+        print("Pysteps configuration file found at: " + params_file + "\n")
 
-    with open(_get_config_file_schema(), 'r') as f:
+    with open(_get_config_file_schema(), "r") as f:
         schema = json.loads(jsmin(f.read()))
         validator = Draft4Validator(schema)
 

--- a/pysteps/__init__.py
+++ b/pysteps/__init__.py
@@ -113,7 +113,7 @@ def _decode_filesystem_path(path):
         return path
 
 
-class DotDictify(dict):
+class _DotDictify(dict):
     """
     Class used to recursively access dict via attributes as well
     as index access.
@@ -129,14 +129,14 @@ class DotDictify(dict):
     """
 
     def __setitem__(self, key, value):
-        if isinstance(value, dict) and not isinstance(value, DotDictify):
-            value = DotDictify(value)
+        if isinstance(value, dict) and not isinstance(value, _DotDictify):
+            value = _DotDictify(value)
         super().__setitem__(key, value)
 
     def __getitem__(self, key):
         value = super().__getitem__(key)
-        if isinstance(value, dict) and not isinstance(value, DotDictify):
-            value = DotDictify(value)
+        if isinstance(value, dict) and not isinstance(value, _DotDictify):
+            value = _DotDictify(value)
             super().__setitem__(key, value)
         return value
 
@@ -170,7 +170,7 @@ def load_config_file(params_file=None, verbose=False, dryrun=False):
     Returns
     -------
 
-    rcparams : DotDictify
+    rcparams : _DotDictify
         Configuration parameters loaded from file.
     """
 
@@ -209,7 +209,7 @@ def load_config_file(params_file=None, verbose=False, dryrun=False):
         if error_count > 0:
             raise RuntimeError(error_msg)
 
-    _rcparams = DotDictify(_rcparams)
+    _rcparams = _DotDictify(_rcparams)
 
     if not dryrun:
         rcparams = _rcparams

--- a/pysteps/__init__.py
+++ b/pysteps/__init__.py
@@ -4,7 +4,6 @@ import stat
 import sys
 import warnings
 
-from attrdict import AttrDict
 from jsmin import jsmin
 from jsonschema import Draft4Validator
 
@@ -114,7 +113,7 @@ def _decode_filesystem_path(path):
         return path
 
 
-class DotDictify(AttrDict):
+class DotDictify(dict):
     """
     Class used to recursively access dict via attributes as well
     as index access.

--- a/pysteps/tests/test_paramsrc.py
+++ b/pysteps/tests/test_paramsrc.py
@@ -26,7 +26,7 @@ minimal_pystepsrc_file = """
             "importer_kwargs": {
                 "gzipped": true
             }
-        }
+        }        
     }
 }
 """
@@ -39,7 +39,10 @@ def test_read_paramsrc():
     with NamedTemporaryFile(mode="w") as tmp_paramsrc:
         tmp_paramsrc.write(minimal_pystepsrc_file)
         tmp_paramsrc.flush()
-        load_config_file(tmp_paramsrc.name)
+
+        # Perform a dry run that do not update
+        # the internal pysteps.rcparams values.
+        load_config_file(tmp_paramsrc.name, dryrun=True, verbose=False)
 
         rcparams = pysteps.rcparams
 

--- a/pysteps/tests/test_paramsrc.py
+++ b/pysteps/tests/test_paramsrc.py
@@ -42,9 +42,9 @@ def test_read_paramsrc():
 
         # Perform a dry run that do not update
         # the internal pysteps.rcparams values.
-        load_config_file(tmp_paramsrc.name, dryrun=True, verbose=False)
-
-        rcparams = pysteps.rcparams
+        rcparams = load_config_file(tmp_paramsrc.name,
+                                    dryrun=True,
+                                    verbose=False)
 
         # Test item and attribute getters
         assert rcparams["data_sources"]["bom"]["fn_ext"] == "nc"

--- a/pysteps/tests/test_paramsrc.py
+++ b/pysteps/tests/test_paramsrc.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+from tempfile import NamedTemporaryFile
+
+import pysteps
+from pysteps import load_config_file
+
+minimal_pystepsrc_file = """
+// pysteps configuration
+{
+    "silent_import": false,
+    "outputs": {
+        "path_outputs": "./"
+    },
+    "plot": {
+        "motion_plot": "quiver",
+        "colorscale": "pysteps"
+    },
+    "data_sources": {
+        "bom": {
+            "root_path": "./radar/bom",
+            "path_fmt": "prcp-cscn/2/%Y/%m/%d",
+            "fn_pattern": "2_%Y%m%d_%H%M00.prcp-cscn",
+            "fn_ext": "nc",
+            "importer": "bom_rf3",
+            "timestep": 6,
+            "importer_kwargs": {
+                "gzipped": true
+            }
+        }
+    }
+}
+"""
+
+
+def test_read_paramsrc():
+    """Test that the parameter file is read correctly and the resulting
+    pysteps.paramsrc dict can be access by attributes too.
+    """
+    with NamedTemporaryFile(mode="w") as tmp_paramsrc:
+        tmp_paramsrc.write(minimal_pystepsrc_file)
+        tmp_paramsrc.flush()
+        load_config_file(tmp_paramsrc.name)
+
+        rcparams = pysteps.rcparams
+
+        # Test item and attribute getters
+        assert rcparams["data_sources"]["bom"]["fn_ext"] == "nc"
+        assert rcparams.data_sources.bom.fn_ext == "nc"
+
+        bom_datasource_as_dict = rcparams["data_sources"]["bom"]
+        bom_datasource_as_attr = rcparams.data_sources.bom
+        assert bom_datasource_as_dict is bom_datasource_as_attr
+        bom_datasource = bom_datasource_as_attr
+
+        timestep_as_dict = bom_datasource["timestep"]
+        timestep_as_attr = bom_datasource.timestep
+        assert timestep_as_dict == 6
+        assert timestep_as_attr == 6
+        assert timestep_as_dict is timestep_as_attr
+
+        importer_kwargs_dict = bom_datasource["importer_kwargs"]
+        importer_kwargs_attr = bom_datasource.importer_kwargs
+        assert importer_kwargs_attr is importer_kwargs_dict
+
+        assert importer_kwargs_attr["gzipped"] is importer_kwargs_attr.gzipped
+        assert importer_kwargs_attr["gzipped"] is True
+
+        # Test item and attribute setters
+        rcparams.test = 4
+        assert rcparams.test == 4
+        assert rcparams.test is rcparams["test"]
+
+        rcparams["test2"] = 4
+        assert rcparams.test2 == 4
+        assert rcparams.test2 is rcparams["test2"]
+
+        rcparams.test = dict(a=1, b="test")
+        assert rcparams.test == dict(a=1, b="test")
+        assert rcparams.test["a"] == 1
+        assert rcparams.test["b"] == "test"
+
+        assert rcparams.test["a"] is rcparams["test"].a
+        assert rcparams.test["b"] is rcparams["test"].b

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ pillow
 pyproj
 scipy
 matplotlib
-attrdict
 jsmin
 jsonschema
 netCDF4

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,6 @@ pillow
 pyproj
 scipy
 matplotlib
-attrdict
 jsmin
 jsonschema
 netCDF4

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,6 @@ external_modules = cythonize(extensions, force=True, language_level=3)
 
 requirements = [
     "numpy",
-    "attrdict",
     "jsmin",
     "scipy",
     "matplotlib",


### PR DESCRIPTION
This PR removes the AttrDict package as a dependency and closes #144. 

It turns out that inheriting AttrDict in the `DotDictify` class was not needed for the common *set* and _get_ operations used in pysteps.

With this PR, `DotDictify` inherits a `dict` class.  To make sure that the rcparams can be accessed as items or as attributes, a series of tests were added.






