### PR TITLE
Fix mask arrays in LK

### DIFF
--- a/examples/LK_buffer_mask.py
+++ b/examples/LK_buffer_mask.py
@@ -109,7 +109,6 @@ LK_optflow = motion.get_method("LK")
 
 # Mask invalid values
 R = np.ma.masked_invalid(R)
-R.data[R.mask] = np.nan
 
 # Use default settings (i.e., no buffering of the radar mask)
 fd_kwargs1 = {"buffer_mask":0}

--- a/pysteps/motion/lucaskanade.py
+++ b/pysteps/motion/lucaskanade.py
@@ -216,11 +216,11 @@ def dense_lucaskanade(input_images,
         prvs_img = input_images[n, :, :].copy()
         next_img = input_images[n + 1, :, :].copy()
 
-        if ~isinstance(prvs_img, MaskedArray):
+        if not isinstance(prvs_img, MaskedArray):
             prvs_img = np.ma.masked_invalid(prvs_img)
         np.ma.set_fill_value(prvs_img, prvs_img.min())
 
-        if ~isinstance(next_img, MaskedArray):
+        if not isinstance(next_img, MaskedArray):
             next_img = np.ma.masked_invalid(next_img)
         np.ma.set_fill_value(next_img, next_img.min())
 
@@ -392,11 +392,11 @@ def track_features(
     next_img = np.copy(next_image)
     p0 = np.copy(points)
 
-    if ~isinstance(prvs_img, MaskedArray):
+    if not isinstance(prvs_img, MaskedArray):
         prvs_img = np.ma.masked_invalid(prvs_img)
     np.ma.set_fill_value(prvs_img, prvs_img.min())
 
-    if ~isinstance(next_img, MaskedArray):
+    if not isinstance(next_img, MaskedArray):
         next_img = np.ma.masked_invalid(next_img)
     np.ma.set_fill_value(next_img, next_img.min())
 

--- a/pysteps/motion/lucaskanade.py
+++ b/pysteps/motion/lucaskanade.py
@@ -394,8 +394,8 @@ def track_features(
             "routine but it is not installed"
         )
 
-    prvs_img = np.copy(prvs_image)
-    next_img = np.copy(next_image)
+    prvs_img = prvs_image.copy()
+    next_img = next_image.copy()
     p0 = np.copy(points)
 
     if not isinstance(prvs_img, MaskedArray):

--- a/pysteps/motion/lucaskanade.py
+++ b/pysteps/motion/lucaskanade.py
@@ -68,6 +68,9 @@ def dense_lucaskanade(input_images,
     .. _MaskedArray:\
         https://docs.scipy.org/doc/numpy/reference/maskedarray.baseclass.html#numpy.ma.MaskedArray
 
+    .. _ndarray:\
+    https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.html
+
     Interface to the OpenCV_ implementation of the local `Lucas-Kanade`_ optical
     flow method applied in combination to a feature detection routine.
 
@@ -77,7 +80,7 @@ def dense_lucaskanade(input_images,
     Parameters
     ----------
 
-    input_images : array_like or MaskedArray_
+    input_images : ndarray_ or MaskedArray_
         Array of shape (T, m, n) containing a sequence of *T* two-dimensional
         input images of shape (m, n). The indexing order in **input_images** is
         assumed to be (time, latitude, longitude).
@@ -86,7 +89,7 @@ def dense_lucaskanade(input_images,
         With *T* > 2, all the resulting sparse vectors are pooled together for
         the final interpolation on a regular grid.
 
-        In case of array_like, invalid values (Nans or infs) are masked,
+        In case of ndarray_, invalid values (Nans or infs) are masked,
         otherwise the mask of the MaskedArray_ is used. Such mask defines a
         region where features are not detected for the tracking algorithm.
 
@@ -156,7 +159,7 @@ def dense_lucaskanade(input_images,
     Returns
     -------
 
-    out : array_like or tuple
+    out : ndarray_ or tuple
         If **dense=True** (the default), return the advection field having shape
         (2, m, n), where out[0, :, :] contains the x-components of the motion
         vectors and out[1, :, :] contains the y-components.
@@ -310,14 +313,17 @@ def track_features(
     .. _MaskedArray:\
         https://docs.scipy.org/doc/numpy/reference/maskedarray.baseclass.html#numpy.ma.MaskedArray
 
+    .. _ndarray:\
+    https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.html
+
     Parameters
     ----------
 
-    prvs_image : array_like or MaskedArray_
+    prvs_image : ndarray_ or MaskedArray_
         Array of shape (m, n) containing the first image.
         Invalid values (Nans or infs) are filled using the min value.
 
-    next_image : array_like or MaskedArray_
+    next_image : ndarray_ or MaskedArray_
         Array of shape (m, n) containing the successive image.
         Invalid values (Nans or infs) are filled using the min value.
 
@@ -351,11 +357,11 @@ def track_features(
     Returns
     -------
 
-    xy : array_like
+    xy : ndarray_
         Array of shape (d, 2) with the x- and y-coordinates of *d* <= *p*
         detected sparse motion vectors.
 
-    uv : array_like
+    uv : ndarray_
         Array of shape (d, 2) with the u- and v-components of *d* <= *p*
         detected sparse motion vectors.
 

--- a/pysteps/motion/lucaskanade.py
+++ b/pysteps/motion/lucaskanade.py
@@ -219,6 +219,7 @@ def dense_lucaskanade(input_images,
         prvs_img = input_images[n, :, :].copy()
         next_img = input_images[n + 1, :, :].copy()
 
+        # Check if a MaskedArray is used. If not, mask the ndarray
         if not isinstance(prvs_img, MaskedArray):
             prvs_img = np.ma.masked_invalid(prvs_img)
         np.ma.set_fill_value(prvs_img, prvs_img.min())
@@ -398,6 +399,7 @@ def track_features(
     next_img = next_image.copy()
     p0 = np.copy(points)
 
+    # Check if a MaskedArray is used. If not, mask the ndarray
     if not isinstance(prvs_img, MaskedArray):
         prvs_img = np.ma.masked_invalid(prvs_img)
     np.ma.set_fill_value(prvs_img, prvs_img.min())
@@ -414,7 +416,7 @@ def track_features(
                     (im_max - im_min) * 255)
     else:
         prvs_img = (prvs_img.filled() - im_min)
-                    
+
     im_min = next_img.min()
     im_max = next_img.max()
     if im_max - im_min > 1e-8:

--- a/pysteps/tests/test_motion.py
+++ b/pysteps/tests/test_motion.py
@@ -344,3 +344,28 @@ def test_vet_cost_function():
     # errors should contain all zeros
     assert (errors < tolerance).any()
     assert (returned_values[0] - 1548250.87627097) < 0.001
+
+
+def test_lk_masked_array():
+    """
+    Passing a ndarray with NaNs or a masked array should produce the same results.
+    """
+    pytest.importorskip('cv2')
+
+    __, precip_obs = _create_observations(reference_field.copy(),
+                                                    'linear_y',
+                                                    num_times=2)
+    motion_method = motion.get_method('LK')
+
+    # ndarray with nans
+    np.ma.set_fill_value(precip_obs, -15)
+    ndarray = precip_obs.filled()
+    ndarray[ndarray == -15] = np.nan
+    uv_ndarray = motion_method(ndarray, fd_kwargs={'buffer_mask':20}, verbose=False)
+
+    # masked array
+    mdarray = np.ma.masked_invalid(ndarray)
+    mdarray.data[mdarray.mask] = -15
+    uv_mdarray = motion_method(mdarray, fd_kwargs={'buffer_mask':20}, verbose=False)
+
+    assert np.abs(uv_mdarray - uv_ndarray).max() < 0.01

--- a/pysteps/utils/images.py
+++ b/pysteps/utils/images.py
@@ -187,10 +187,16 @@ def morph_opening(input_image, thr, n):
     """Filter out small scale noise on the image by applying a binary
     morphological opening, that is, erosion followed by dilation.
 
+    .. _MaskedArray:\
+        https://docs.scipy.org/doc/numpy/reference/maskedarray.baseclass.html#numpy.ma.MaskedArray
+
+    .. _ndarray:\
+    https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.html
+
     Parameters
     ----------
 
-    input_image : array_like
+    input_image : ndarray_ or MaskedArray_
         Array of shape (m, n) containing the input image.
 
     thr : float
@@ -202,7 +208,7 @@ def morph_opening(input_image, thr, n):
     Returns
     -------
 
-    input_image : array_like
+    input_image : ndarray_ or MaskedArray_
         Array of shape (m,n) containing the filtered image.
     """
     if not CV2_IMPORTED:
@@ -211,8 +217,18 @@ def morph_opening(input_image, thr, n):
             "routine but it is not installed"
         )
 
+    input_image = input_image.copy()
+
+    # masked array
+    to_ndarray = False
+    if not isinstance(input_image, MaskedArray):
+        to_ndarray = True
+        input_image = np.ma.masked_invalid(input_image)
+
+    np.ma.set_fill_value(input_image, input_image.min())
+
     # Convert to binary image
-    field_bin = np.ndarray.astype(input_image > thr, "uint8")
+    field_bin = np.ndarray.astype(input_image.filled() > thr, "uint8")
 
     # Build a structuring element of size n
     kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (n, n))
@@ -225,5 +241,8 @@ def morph_opening(input_image, thr, n):
 
     # Filter out small isolated pixels based on mask
     input_image[mask] = np.nanmin(input_image)
+
+    if to_ndarray:
+        input_image = np.array(input_image)
 
     return input_image

--- a/pysteps/utils/images.py
+++ b/pysteps/utils/images.py
@@ -51,6 +51,9 @@ def ShiTomasi_detection(input_image,
     .. _MaskedArray:\
         https://docs.scipy.org/doc/numpy/reference/maskedarray.baseclass.html#numpy.ma.MaskedArray
 
+    .. _ndarray:\
+    https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.html
+
     .. _`Harris detector`:\
         https://docs.opencv.org/3.4.1/dd/d1a/group__imgproc__feature.html#gac1fc3598018010880e370e2f709b4345
 
@@ -61,10 +64,10 @@ def ShiTomasi_detection(input_image,
     Parameters
     ----------
 
-    input_image : array_like or MaskedArray_
+    input_image : ndarray_ or MaskedArray_
         Array of shape (m, n) containing the input image.
 
-        In case of array_like, invalid values (Nans or infs) are masked,
+        In case of ndarray_, invalid values (Nans or infs) are masked,
         otherwise the mask of the MaskedArray_ is used. Such mask defines a
         region where features are not detected.
 
@@ -110,7 +113,7 @@ def ShiTomasi_detection(input_image,
     Returns
     -------
 
-    points : array_like
+    points : ndarray_
         Array of shape (p, 2) indicating the pixel coordinates of *p* detected
         corners.
 

--- a/pysteps/utils/images.py
+++ b/pysteps/utils/images.py
@@ -135,7 +135,7 @@ def ShiTomasi_detection(input_image,
     if input_image.ndim != 2:
         raise ValueError("input_image must be a two-dimensional array")
 
-    # masked array
+    # Check if a MaskedArray is used. If not, mask the ndarray
     if not isinstance(input_image, MaskedArray):
         input_image = np.ma.masked_invalid(input_image)
 
@@ -219,7 +219,7 @@ def morph_opening(input_image, thr, n):
 
     input_image = input_image.copy()
 
-    # masked array
+    # Check if a MaskedArray is used. If not, mask the ndarray
     to_ndarray = False
     if not isinstance(input_image, MaskedArray):
         to_ndarray = True

--- a/pysteps/utils/images.py
+++ b/pysteps/utils/images.py
@@ -130,7 +130,7 @@ def ShiTomasi_detection(input_image,
             "routine but it is not installed"
         )
 
-    input_image = np.copy(input_image)
+    input_image = input_image.copy()
 
     if input_image.ndim != 2:
         raise ValueError("input_image must be a two-dimensional array")

--- a/pysteps/utils/interpolate.py
+++ b/pysteps/utils/interpolate.py
@@ -29,6 +29,9 @@ def rbfinterp2d(
     """Fast 2-D grid interpolation of a sparse (multivariate) array using a
     radial basis function.
 
+    .. _ndarray:\
+    https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.html
+
     Parameters
     ----------
 
@@ -69,7 +72,7 @@ def rbfinterp2d(
     Returns
     -------
 
-    output_array : array_like
+    output_array : ndarray_
         The interpolated field(s) having shape (m, ygrid.size, xgrid.size).
 
     Notes


### PR DESCRIPTION
This PR fixes few issues in the LK motion method concerning the handling of MaskedArrays, namely
- wrong if statements
- inaccurate documentation 
- copy of MaskedArray returned ndarray instead
- unsupported MaskedArrays in `images.morph_opening`

These caused LK motion  routine to recompute a new masked array on the input data, thus ignoring the mask that was passed, unless the masked values where nans. 

A simple test to check whether using MaskedArrays or ndarrays produces the same results was added.