### PR TITLE
Fix vet padding bug (#163)

### DIFF
--- a/pysteps/motion/vet.py
+++ b/pysteps/motion/vet.py
@@ -529,7 +529,7 @@ def vet(
             constant_values=numpy.nan,
         )
 
-        mask = numpy.pad(mask, padding_tuple, "constant", constant_values="True")
+        mask = numpy.pad(mask, padding_tuple, "constant", constant_values=True)
 
         input_images = numpy.ma.MaskedArray(data=input_images_data, mask=mask)
 

--- a/pysteps/motion/vet.py
+++ b/pysteps/motion/vet.py
@@ -513,20 +513,25 @@ def vet(
             + "Supported values: {0}".format(str(valid_indexing))
         )
 
-    # Get mask
-    if isinstance(input_images, MaskedArray):
-        mask = numpy.ma.getmaskarray(input_images)
-    else:
-        # Mask invalid data
-        if padding > 0:
-            padding_tuple = ((0, 0), (padding, padding), (padding, padding))
-
-            input_images = numpy.pad(
-                input_images, padding_tuple, "constant", constant_values=numpy.nan
-            )
-
+    # Convert input_images to a MaskedArray if it is a regular ndarray
+    if not isinstance(input_images, MaskedArray):
         input_images = numpy.ma.masked_invalid(input_images)
-        mask = numpy.ma.getmaskarray(input_images)
+
+    mask = numpy.ma.getmaskarray(input_images)
+
+    if padding > 0:
+        padding_tuple = ((0, 0), (padding, padding), (padding, padding))
+
+        input_images_data = numpy.pad(
+            numpy.ma.getdata(input_images),
+            padding_tuple,
+            "constant",
+            constant_values=numpy.nan,
+        )
+
+        mask = numpy.pad(mask, padding_tuple, "constant", constant_values="True")
+
+        input_images = numpy.ma.MaskedArray(data=input_images_data, mask=mask)
 
     input_images.data[mask] = 0  # Remove any Nan from the raw data
 

--- a/pysteps/tests/test_motion.py
+++ b/pysteps/tests/test_motion.py
@@ -18,6 +18,7 @@ the retrieval.
 """
 
 from contextlib import contextmanager
+from functools import partial
 
 import numpy as np
 import pytest
@@ -322,6 +323,35 @@ def test_input_shape_checks(
             motion_method(np.zeros((frames, image_size, image_size)), verbose=False)
         for frames in range(maximum_input_frames + 1, maximum_input_frames + 4):
             motion_method(np.zeros((frames, image_size, image_size)), verbose=False)
+
+
+def test_vet_padding():
+    """
+    Test that the padding functionality in vet works correctly with ndarrays and
+    masked arrays.
+    """
+
+    _, precip_obs = _create_observations(
+        reference_field.copy(), "linear_y", num_times=2
+    )
+
+    precip_obs = precip_obs[
+        :, 200:427, 250:456
+    ]  # Use a small region to speed up the test
+
+    # precip_obs.shape == (227 , 206)
+    # 227 is a prime number ; 206 = 2*103
+    vet_method = partial(
+        motion.get_method("vet"),
+        verbose=False,
+        sectors=((16, 4, 2), (16, 4, 2)),
+        options=dict(maxiter=5)
+        # We use only a few iterations since
+        # we don't care about convergence in this test
+    )
+
+    assert precip_obs.shape == vet_method(precip_obs).shape
+    assert precip_obs.shape == vet_method(np.ma.masked_invalid(precip_obs)).shape
 
 
 def test_vet_cost_function():


### PR DESCRIPTION
This PR fixes issue #163. 

- Fix the issue with the **vet function's** padding keyword when MaskedArrays are used. 
- Add a short test to check that the function now works correctly, and correctly pad Masked and Non-Masked input images.

[Edited]