### PR TITLE
Refactor interface to plot_geography

### DIFF
--- a/doc/source/pysteps_reference/visualization.rst
+++ b/doc/source/pysteps_reference/visualization.rst
@@ -5,6 +5,7 @@ pysteps.visualization
 Methods for plotting precipitation and motion fields.
 
 .. automodule:: pysteps.visualization.animations
+.. automodule:: pysteps.visualization.basemaps
 .. automodule:: pysteps.visualization.motionfields
 .. automodule:: pysteps.visualization.precipfields
 .. automodule:: pysteps.visualization.spectral

--- a/pysteps/tests/test_plt_cartopy.py
+++ b/pysteps/tests/test_plt_cartopy.py
@@ -9,7 +9,7 @@ import matplotlib.pyplot as pl
 
 pytest.importorskip("cartopy")
 
-plt_arg_names = ("source", "map", "drawlonlatlines", "lw")
+plt_arg_names = ("source", "plot_map", "drawlonlatlines", "lw")
 
 plt_arg_values = [
     ("mch", "cartopy", False, 0.5),
@@ -23,7 +23,7 @@ plt_arg_values = [
 
 
 @pytest.mark.parametrize(plt_arg_names, plt_arg_values)
-def test_visualization_plot_precip_field(source, map, drawlonlatlines, lw):
+def test_visualization_plot_precip_field(source, plot_map, drawlonlatlines, lw):
 
     field, metadata = get_precipitation_fields(0, 0, True, True, None, source)
     field = field.squeeze()
@@ -33,7 +33,7 @@ def test_visualization_plot_precip_field(source, map, drawlonlatlines, lw):
         field,
         type="intensity",
         geodata=metadata,
-        map=map,
+        plot_map=plot_map,
         drawlonlatlines=drawlonlatlines,
         lw=lw,
     )

--- a/pysteps/tests/test_plt_motionfields.py
+++ b/pysteps/tests/test_plt_motionfields.py
@@ -11,37 +11,37 @@ from pysteps.tests.helpers import get_precipitation_fields
 
 arg_names_quiver = (
     "source",
-    "map",
-    "drawlonlatlines",
-    "lw",
     "axis",
     "step",
     "quiver_kwargs",
+    "plot_map",
+    "drawlonlatlines",
+    "lw",
     "upscale",
 )
 
 arg_values_quiver = [
-    (None, None, False, 0.5, "off", 10, None, None),
-    ("bom", None, False, 0.5, "on", 10, None, 4000),
-    ("bom", "cartopy", True, 0.5, "on", 10, None, 4000),
-    ("mch", "cartopy", False, 0.5, "on", 20, None, 2000),
-    ("bom", "basemap", False, 0.5, "off", 10, None, 4000),
+    (None, "off", 10, None, None, False, 0.5, None),
+    ("bom", "on", 10, None, None, False, 0.5, 4000),
+    ("bom", "on", 10, None, "cartopy", True, 0.5, 4000),
+    ("mch", "on", 20, None, "cartopy", False, 0.5, 2000),
+    ("bom", "off", 10, None, "basemap", False, 0.5, 4000),
 ]
 
 
 @pytest.mark.parametrize(arg_names_quiver, arg_values_quiver)
 def test_visualization_motionfields_quiver(
-    source, map, drawlonlatlines, lw, axis, step, quiver_kwargs, upscale,
+    source, axis, step, quiver_kwargs, plot_map, drawlonlatlines, lw, upscale,
 ):
 
-    if map == "cartopy":
+    if plot_map == "cartopy":
         pytest.importorskip("cartopy")
-    elif map == "basemap":
+    elif plot_map == "basemap":
         pytest.importorskip("basemap")
 
     if source is not None:
         fields, geodata = get_precipitation_fields(0, 2, False, True, upscale, source)
-        ax = plot_precip_field(fields[-1], map=map, geodata=geodata,)
+        ax = plot_precip_field(fields[-1], geodata=geodata, plot_map=plot_map,)
         oflow_method = motion.get_method("LK")
         UV = oflow_method(fields)
 
@@ -54,39 +54,49 @@ def test_visualization_motionfields_quiver(
         U, V = np.meshgrid(u, v)
         UV = np.concatenate([U[None, :], V[None, :]])
 
-    __ = quiver(UV, ax, map, geodata, drawlonlatlines, lw, axis, step, quiver_kwargs)
+    __ = quiver(
+        UV,
+        ax,
+        geodata,
+        axis,
+        step,
+        quiver_kwargs,
+        plot_map=plot_map,
+        drawlonlatlines=drawlonlatlines,
+        lw=lw,
+    )
 
 
 arg_names_streamplot = (
     "source",
-    "map",
-    "drawlonlatlines",
-    "lw",
     "axis",
     "streamplot_kwargs",
+    "plot_map",
+    "drawlonlatlines",
+    "lw",
     "upscale",
 )
 
 arg_values_streamplot = [
-    (None, None, False, 0.5, "off", None, None),
-    ("bom", None, False, 0.5, "on", None, 4000),
-    ("bom", "cartopy", True, 0.5, "on", {"density": 0.1}, 4000),
+    (None, "off", None, None, False, 0.5, None),
+    ("bom", "on", None, None, False, 0.5, 4000),
+    ("bom", "on", {"density": 0.1}, "cartopy", True, 0.5, 4000),
 ]
 
 
 @pytest.mark.parametrize(arg_names_streamplot, arg_values_streamplot)
 def test_visualization_motionfields_streamplot(
-    source, map, drawlonlatlines, lw, axis, streamplot_kwargs, upscale,
+    source, axis, streamplot_kwargs, plot_map, drawlonlatlines, lw, upscale,
 ):
 
-    if map == "cartopy":
+    if plot_map == "cartopy":
         pytest.importorskip("cartopy")
-    elif map == "basemap":
+    elif plot_map == "basemap":
         pytest.importorskip("basemap")
 
     if source is not None:
         fields, geodata = get_precipitation_fields(0, 2, False, True, upscale, source)
-        ax = plot_precip_field(fields[-1], map=map, geodata=geodata,)
+        ax = plot_precip_field(fields[-1], geodata=geodata, plot_map=plot_map,)
         oflow_method = motion.get_method("LK")
         UV = oflow_method(fields)
 
@@ -99,7 +109,16 @@ def test_visualization_motionfields_streamplot(
         U, V = np.meshgrid(u, v)
         UV = np.concatenate([U[None, :], V[None, :]])
 
-    __ = streamplot(UV, ax, map, geodata, drawlonlatlines, lw, axis, streamplot_kwargs)
+    __ = streamplot(
+        UV,
+        ax,
+        geodata,
+        axis,
+        streamplot_kwargs,
+        plot_map=plot_map,
+        drawlonlatlines=drawlonlatlines,
+        lw=lw,
+    )
 
 
 if __name__ == "__main__":

--- a/pysteps/visualization/animations.py
+++ b/pysteps/visualization/animations.py
@@ -91,7 +91,7 @@ def animate(
         Units of the input array (mm/h or dBZ)
     colorscale : str
         The *colorscale* argument to
-        :py:func:`pysteps.visualization.precipifields.plot_precip_field`.
+        :py:func:`pysteps.visualization.precipfields.plot_precip_field`.
     title : str or None
         If not None, print the string as title on top of the plot.
     colorbar : bool
@@ -115,7 +115,7 @@ def animate(
         Path to folder where to save the frames.
     kwargs : dict
         Optional keyword arguments that are supplied to
-        :py:func:`pysteps.visualization.precipifields.plot_precip_field`,
+        :py:func:`pysteps.visualization.precipfields.plot_precip_field`,
         :py:func:`pysteps.visualization.motionfields.quiver`, and
         :py:func:`pysteps.visualization.motionfields.streamplot`.
 

--- a/pysteps/visualization/animations.py
+++ b/pysteps/visualization/animations.py
@@ -90,13 +90,14 @@ def animate(
 
     map : str
         Optional method for plotting a map.
-        See pysteps.visualization.precipifields.plot_precip.field.
+        See :py:func:`pysteps.visualization.precipifields.plot_precip_field`.
     units : str
         Units of the input array (mm/h or dBZ)
     colorscale : str
-        Which colorscale to use.
-    title : str
-        If not None, print the title on top of the plot.
+        The *colorscale* argument to
+        :py:func:`pysteps.visualization.precipifields.plot_precip_field`.
+    title : str or None
+        If not None, print the string as title on top of the plot.
     colorbar : bool
         If set to True, add a colorbar on the right side of the plot.
     type : {'ensemble', 'mean', 'prob'}, str
@@ -117,8 +118,10 @@ def animate(
     path_outputs : string
         Path to folder where to save the frames.
     kwargs : dict
-        Optional keyword arguments that are supplied to plot_precip_field
-        and quiver/streamplot.
+        Optional keyword arguments that are supplied to
+        :py:func:`pysteps.visualization.precipifields.plot_precip_field`,
+        :py:func:`pysteps.visualization.motionfields.quiver`, and
+        :py:func:`pysteps.visualization.motionfields.streamplot`.
 
     Returns
     -------

--- a/pysteps/visualization/animations.py
+++ b/pysteps/visualization/animations.py
@@ -25,7 +25,6 @@ def animate(
     UV=None,
     motion_plot="quiver",
     geodata=None,
-    map=None,
     colorscale="pysteps",
     units="mm/h",
     colorbar=True,
@@ -88,9 +87,6 @@ def animate(
         |                | 'upper' = upper border, 'lower' = lower border     |
         +----------------+----------------------------------------------------+
 
-    map : str
-        Optional method for plotting a map.
-        See :py:func:`pysteps.visualization.precipifields.plot_precip_field`.
     units : str
         Units of the input array (mm/h or dBZ)
     colorscale : str
@@ -128,13 +124,6 @@ def animate(
     ax : fig axes
         Figure axes. Needed if one wants to add e.g. text inside the plot.
     """
-    if map is not None:
-        FutureWarning(
-            "'map' argument will be renamed to 'plot_map' in 1.4.0. Use 'plot_map' to silence this warning."
-        )
-        plot_map = map
-    else:
-        plot_map = kwargs.pop("plot_map", None)
 
     if timestamps is not None:
         startdate_str = timestamps[-1].strftime("%Y%m%d%H%M")
@@ -183,7 +172,6 @@ def animate(
                         ax = st.plt.plot_precip_field(
                             P_obs,
                             type="prob",
-                            plot_map=plot_map,
                             geodata=geodata,
                             units=units,
                             probthr=prob_thr,
@@ -194,7 +182,6 @@ def animate(
                         title += "Observed Rainfall"
                         ax = st.plt.plot_precip_field(
                             R_obs[i, :, :],
-                            plot_map=plot_map,
                             geodata=geodata,
                             units=units,
                             colorscale=colorscale,
@@ -245,7 +232,6 @@ def animate(
                         ax = st.plt.plot_precip_field(
                             P,
                             type="prob",
-                            plot_map=plot_map,
                             geodata=geodata,
                             units=units,
                             probthr=prob_thr,
@@ -259,7 +245,6 @@ def animate(
                         )
                         ax = st.plt.plot_precip_field(
                             EM,
-                            plot_map=plot_map,
                             geodata=geodata,
                             units=units,
                             title=title,
@@ -271,7 +256,6 @@ def animate(
                         title += "Forecast Rainfall"
                         ax = st.plt.plot_precip_field(
                             R_fct[n, i - n_obs, :, :],
-                            plot_map=plot_map,
                             geodata=geodata,
                             units=units,
                             title=title,

--- a/pysteps/visualization/basemaps.py
+++ b/pysteps/visualization/basemaps.py
@@ -40,7 +40,9 @@ except ImportError:
 from . import utils
 
 
-def plot_geography(plot_map, proj4str, extent, lw=0.5, drawlonlatlines=False, **kwargs):
+def plot_geography(
+    proj4str, extent, plot_map="cartopy", lw=0.5, drawlonlatlines=False, **kwargs
+):
     """
     Plot geographical map using either cartopy_ or basemap_ in a chosen projection.
 
@@ -52,33 +54,32 @@ def plot_geography(plot_map, proj4str, extent, lw=0.5, drawlonlatlines=False, **
 
     Parameters
     ----------
-    plot_map : {'cartopy', 'basemap'}
-        The type of basemap.
     proj4str : str
         The PROJ.4-compatible projection string.
     extent: scalars (left, right, bottom, top)
         The bounding box in proj4str coordinates.
+    plot_map : {'cartopy', 'basemap'}, optional
+        The type of basemap, either 'cartopy_' or 'basemap_'.
     lw: float, optional
         Linewidth of the map (administrative boundaries and coastlines).
     drawlonlatlines : bool, optional
-        If set to True, draw longitude and latitude lines. Applicable if map is
+        If set to True, draw longitude and latitude lines. Applicable if plot_map is
         'basemap' or 'cartopy'.
 
     Other parameters
     ----------------
     resolution : str, optional
-        The resolution of the map, see the documentation of
-        `mpl_toolkits.basemap`_.
-        Applicable if map is 'basemap'. Default ``'l'``.
+        The resolution of the map, see the documentation of `basemap`_.
+        Applicable if 'plot_map' is 'basemap'. Default ``'l'``.
     scale_args : list, optional
         If not None, a map scale bar is drawn with basemap_scale_args supplied
-        to mpl_toolkits.basemap.Basemap.drawmapscale. Applicable if map is
+        to mpl_toolkits.basemap.Basemap.drawmapscale. Applicable if 'plot_map' is
         'basemap'. Default ``None``.
     scale : {'10m', '50m', '110m'}, optional
-        The scale (resolution) of the map. The available options are '10m',
-        '50m', and '110m'. Applicable if map is 'cartopy'. Default ``'50m'``
+        The scale (resolution) of the plot_map. The available options are '10m',
+        '50m', and '110m'. Applicable if plot_map is 'cartopy'. Default ``'50m'``
     subplot : tuple or SubplotSpec_ instance, optional
-        The cartopy subplot to plot into. Applicable if map is 'cartopy'.
+        The cartopy subplot to plot into. Applicable if plot_map is 'cartopy'.
         Default ``'(1, 1, 1)'``
 
     Returns
@@ -92,21 +93,21 @@ def plot_geography(plot_map, proj4str, extent, lw=0.5, drawlonlatlines=False, **
 
     if plot_map not in ["basemap", "cartopy"]:
         raise ValueError(
-            "unknown map method %s: must be" + " 'basemap' or 'cartopy'" % plot_map
+            "unknown plot_map method %s: must be" + " 'basemap' or 'cartopy'" % plot_map
         )
     if plot_map == "basemap" and not basemap_imported:
         raise MissingOptionalDependency(
-            "map='basemap' option passed to plot_geography function "
+            "plot_map='basemap' option passed to plot_geography function "
             "but the basemap package is not installed"
         )
     if plot_map == "cartopy" and not cartopy_imported:
         raise MissingOptionalDependency(
-            "map='cartopy' option passed to plot_geography function "
+            "plot_map='cartopy' option passed to plot_geography function "
             "but the cartopy package is not installed"
         )
     if plot_map is not None and not pyproj_imported:
         raise MissingOptionalDependency(
-            "map!=None option passed to plot_geography function "
+            "plot_map!=None option passed to plot_geography function "
             "but the pyproj package is not installed"
         )
 
@@ -189,7 +190,7 @@ def plot_map_basemap(
     """
     if not basemap_imported:
         raise MissingOptionalDependency(
-            "map='basemap' option passed to plot_map_basemap function "
+            "plot_map='basemap' option passed to plot_map_basemap function "
             "but the basemap package is not installed"
         )
 
@@ -261,7 +262,7 @@ def plot_map_cartopy(
     """
     if not cartopy_imported:
         raise MissingOptionalDependency(
-            "map='cartopy' option passed to plot_map_cartopy function "
+            "plot_map='cartopy' option passed to plot_map_cartopy function "
             "but the cartopy package is not installed"
         )
 

--- a/pysteps/visualization/motionfields.py
+++ b/pysteps/visualization/motionfields.py
@@ -20,16 +20,7 @@ from . import utils
 
 
 def quiver(
-    UV,
-    ax=None,
-    map=None,
-    geodata=None,
-    drawlonlatlines=False,
-    lw=0.5,
-    axis="on",
-    step=20,
-    quiver_kwargs=None,
-    **kwargs,
+    UV, ax=None, geodata=None, axis="on", step=20, quiver_kwargs=None, **kwargs,
 ):
     """Function to plot a motion field as arrows.
 
@@ -43,15 +34,12 @@ def quiver(
         Array of shape (2,m,n) containing the input motion field.
     ax : axis object
         Optional axis object to use for plotting.
-    map : {'basemap', 'cartopy'}, optional
-        Optional method for plotting a map: 'basemap' or 'cartopy'. The former
-        uses `mpl_toolkits.basemap`_, while the latter uses cartopy_.
     geodata : dictionary
         Optional dictionary containing geographical information about
         the field.
-        
+
         If geodata is not None, it must contain the following key-value pairs:
-        
+
         .. tabularcolumns:: |p{1.5cm}|L|
 
         +----------------+----------------------------------------------------+
@@ -75,11 +63,6 @@ def quiver(
         |                 | element in the data raster w.r.t. y-axis:         |
         |                 | 'upper' = upper border, 'lower' = lower border    |
         +-----------------+---------------------------------------------------+
-    drawlonlatlines : bool, optional
-        If set to True, draw longitude and latitude lines. Applicable if map is
-        'basemap' or 'cartopy'.
-    lw: float, optional
-        Linewidth of the map (administrative boundaries and coastlines).
     axis : {'off','on'}, optional
         Whether to turn off or on the x and y axis.
     step : int
@@ -87,11 +70,12 @@ def quiver(
     quiver_kwargs : dict, optional
       Optional dictionary containing keyword arguments for the quiver method.
       See the documentation of matplotlib.pyplot.quiver.
-    
-    
+
+
     Other parameters
     ----------------
-    Optional parameters are contained in **kwargs. See basemaps.plot_geography.
+    Optional parameters that need to be passed to
+    :py:func:`pysteps.visualization.basemaps.plot_geography`.
 
     Returns
     -------
@@ -99,16 +83,9 @@ def quiver(
         Figure axes. Needed if one wants to add e.g. text inside the plot.
 
     """
-    if map is not None:
-        FutureWarning(
-            "'map' argument will be renamed to 'plot_map' in 1.4.0. Use 'plot_map' to silence this warning."
-        )
-        plot_map = map
-    else:
-        plot_map = kwargs.pop("plot_map", None)
-
+    plot_map = kwargs.get("plot_map", None)
     if plot_map is not None and geodata is None:
-        raise ValueError("map!=None but geodata=None")
+        raise ValueError("plot_map!=None but geodata=None")
 
     if quiver_kwargs is None:
         quiver_kwargs = dict()
@@ -160,14 +137,7 @@ def quiver(
     # draw basemaps
     if plot_map is not None:
         try:
-            ax = basemaps.plot_geography(
-                plot_map,
-                geodata["projection"],
-                extent,
-                lw=lw,
-                drawlonlatlines=drawlonlatlines,
-                **kwargs,
-            )
+            ax = basemaps.plot_geography(geodata["projection"], extent, **kwargs,)
 
         except UnsupportedSomercProjection:
             # Define default fall-back projection for Swiss data(EPSG:3035)
@@ -177,14 +147,7 @@ def quiver(
             extent = (geodata["x1"], geodata["x2"], geodata["y1"], geodata["y2"])
             X, Y = geodata["X_grid"], geodata["Y_grid"]
 
-            ax = basemaps.plot_geography(
-                plot_map,
-                geodata["projection"],
-                extent,
-                lw=lw,
-                drawlonlatlines=drawlonlatlines,
-                **kwargs,
-            )
+            ax = basemaps.plot_geography(geodata["projection"], extent, **kwargs,)
     else:
         ax = plt.gca()
 
@@ -214,15 +177,7 @@ def quiver(
 
 
 def streamplot(
-    UV,
-    ax=None,
-    map=None,
-    geodata=None,
-    drawlonlatlines=False,
-    lw=0.5,
-    axis="on",
-    streamplot_kwargs=None,
-    **kwargs,
+    UV, ax=None, geodata=None, axis="on", streamplot_kwargs=None, **kwargs,
 ):
     """Function to plot a motion field as streamlines.
 
@@ -239,14 +194,11 @@ def streamplot(
         Array of shape (2, m,n) containing the input motion field.
     ax : axis object
         Optional axis object to use for plotting.
-    map : {'basemap', 'cartopy'}, optional
-        Optional method for plotting a map: 'basemap' or 'cartopy'.
-        The former uses `mpl_toolkits.basemap`_, while the latter uses cartopy_.
     geodata : dictionary
         Optional dictionary containing geographical information about
         the field.
         If geodata is not None, it must contain the following key-value pairs:
-        
+
         .. tabularcolumns:: |p{1.5cm}|L|
 
         +----------------+----------------------------------------------------+
@@ -270,20 +222,16 @@ def streamplot(
         |                | element in the data raster w.r.t. y-axis:          |
         |                | 'upper' = upper border, 'lower' = lower border     |
         +----------------+----------------------------------------------------+
-    drawlonlatlines : bool, optional
-        If set to True, draw longitude and latitude lines. Applicable if map is
-        'basemap' or 'cartopy'.
-    lw: float, optional
-        Linewidth of the map (administrative boundaries and coastlines).
     axis : {'off','on'}, optional
         Whether to turn off or on the x and y axis.
     streamplot_kwargs : dict, optional
       Optional dictionary containing keyword arguments for the streamplot method.
       See the documentation of matplotlib.pyplot.streamplot.
-    
+
     Other parameters
     ----------------
-    Optional parameters are contained in **kwargs. See basemaps.plot_geography.
+    Optional parameters that need to be passed to
+    :py:func:`pysteps.visualization.basemaps.plot_geography`.
 
     Returns
     -------
@@ -291,16 +239,10 @@ def streamplot(
         Figure axes. Needed if one wants to add e.g. text inside the plot.
 
     """
-    if map is not None:
-        FutureWarning(
-            "'map' argument will be renamed to 'plot_map' in 1.4.0. Use 'plot_map' to silence this warning."
-        )
-        plot_map = map
-    else:
-        plot_map = kwargs.pop("plot_map", None)
+    plot_map = kwargs.get("plot_map", None)
 
     if plot_map is not None and geodata is None:
-        raise ValueError("map!=None but geodata=None")
+        raise ValueError("plot_map!=None but geodata=None")
 
     if streamplot_kwargs is None:
         streamplot_kwargs = dict()
@@ -350,14 +292,7 @@ def streamplot(
     # draw basemaps
     if plot_map is not None:
         try:
-            ax = basemaps.plot_geography(
-                plot_map,
-                geodata["projection"],
-                extent,
-                lw=lw,
-                drawlonlatlines=drawlonlatlines,
-                **kwargs,
-            )
+            ax = basemaps.plot_geography(geodata["projection"], extent, **kwargs,)
         except UnsupportedSomercProjection:
             # Define default fall-back projection for Swiss data(EPSG:3035)
             # This will work reasonably well for Europe only.
@@ -368,14 +303,7 @@ def streamplot(
             x = X[0, :]
             y = Y[:, 0]
 
-            ax = basemaps.plot_geography(
-                plot_map,
-                geodata["projection"],
-                extent,
-                lw=lw,
-                drawlonlatlines=drawlonlatlines,
-                **kwargs,
-            )
+            ax = basemaps.plot_geography(geodata["projection"], extent, **kwargs,)
     else:
         ax = plt.gca()
 

--- a/pysteps/visualization/motionfields.py
+++ b/pysteps/visualization/motionfields.py
@@ -59,10 +59,10 @@ def quiver(
         |    y2          | y-coordinate of the upper-right corner of the data |
         |                | raster                                             |
         +----------------+----------------------------------------------------+
-        |    yorigin      | a string specifying the location of the first     |
-        |                 | element in the data raster w.r.t. y-axis:         |
-        |                 | 'upper' = upper border, 'lower' = lower border    |
-        +-----------------+---------------------------------------------------+
+        |    yorigin     | a string specifying the location of the first      |
+        |                | element in the data raster w.r.t. y-axis:          |
+        |                | 'upper' = upper border, 'lower' = lower border     |
+        +----------------+----------------------------------------------------+
     axis : {'off','on'}, optional
         Whether to turn off or on the x and y axis.
     step : int
@@ -74,8 +74,9 @@ def quiver(
 
     Other parameters
     ----------------
-    Optional parameters that need to be passed to
-    :py:func:`pysteps.visualization.basemaps.plot_geography`.
+    kwargs: dict
+        Optional parameters that need to be passed to
+        :py:func:`pysteps.visualization.basemaps.plot_geography`.
 
     Returns
     -------
@@ -230,8 +231,9 @@ def streamplot(
 
     Other parameters
     ----------------
-    Optional parameters that need to be passed to
-    :py:func:`pysteps.visualization.basemaps.plot_geography`.
+    kwargs: dict
+        Optional parameters that need to be passed to
+        :py:func:`pysteps.visualization.basemaps.plot_geography`.
 
     Returns
     -------

--- a/pysteps/visualization/precipfields.py
+++ b/pysteps/visualization/precipfields.py
@@ -114,8 +114,9 @@ def plot_precip_field(
 
     Other parameters
     ----------------
-    Optional parameters that need to be passed to
-    :py:func:`pysteps.visualization.basemaps.plot_geography`.
+    kwargs: dict
+        Optional parameters that need to be passed to
+        :py:func:`pysteps.visualization.basemaps.plot_geography`.
 
     Returns
     -------

--- a/pysteps/visualization/precipfields.py
+++ b/pysteps/visualization/precipfields.py
@@ -30,7 +30,6 @@ from . import utils
 def plot_precip_field(
     R,
     type="intensity",
-    map=None,
     geodata=None,
     units="mm/h",
     bbox=None,
@@ -38,8 +37,6 @@ def plot_precip_field(
     probthr=None,
     title=None,
     colorbar=True,
-    drawlonlatlines=False,
-    lw=0.5,
     axis="on",
     cax=None,
     **kwargs,
@@ -52,10 +49,6 @@ def plot_precip_field(
 
     .. _SubplotSpec: https://matplotlib.org/api/_as_gen/matplotlib.gridspec.SubplotSpec.html
 
-    .. _cartopy: https://scitools.org.uk/cartopy/docs/latest
-
-    .. _mpl_toolkits.basemap: https://matplotlib.org/basemap
-
     Parameters
     ----------
     R : array-like
@@ -65,9 +58,6 @@ def plot_precip_field(
         Type of the map to plot: 'intensity' = precipitation intensity field,
         'depth' = precipitation depth (accumulation) field,
         'prob' = exceedance probability field.
-    map : {'basemap', 'cartopy'}, optional
-        Optional method for plotting a map: 'basemap' or 'cartopy'. The former
-        uses `mpl_toolkits.basemap`_, while the latter uses cartopy_.
     geodata : dictionary, optional
         Optional dictionary containing geographical information about
         the field. Required is map is not None.
@@ -116,11 +106,6 @@ def plot_precip_field(
         If not None, print the title on top of the plot.
     colorbar : bool, optional
         If set to True, add a colorbar on the right side of the plot.
-    drawlonlatlines : bool, optional
-        If set to True, draw longitude and latitude lines. Applicable if map is
-        'basemap' or 'cartopy'.
-    lw: float, optional
-        Linewidth of the map (administrative boundaries and coastlines).
     axis : {'off','on'}, optional
         Whether to turn off or on the x and y axis.
     cax : Axes_ object, optional
@@ -129,7 +114,8 @@ def plot_precip_field(
 
     Other parameters
     ----------------
-    Optional parameters are contained in **kwargs. See basemaps.plot_geography.
+    Optional parameters that need to be passed to
+    :py:func:`pysteps.visualization.basemaps.plot_geography`.
 
     Returns
     -------
@@ -137,13 +123,6 @@ def plot_precip_field(
         Figure axes. Needed if one wants to add e.g. text inside the plot.
 
     """
-    if map is not None:
-        FutureWarning(
-            "'map' argument will be renamed to 'plot_map' in 1.4.0. Use 'plot_map' to silence this warning."
-        )
-        plot_map = map
-    else:
-        plot_map = kwargs.pop("plot_map", None)
 
     if type not in ["intensity", "depth", "prob"]:
         raise ValueError(
@@ -155,6 +134,7 @@ def plot_precip_field(
         )
     if type == "prob" and colorbar and probthr is None:
         raise ValueError("type='prob' but probthr not specified")
+    plot_map = kwargs.get("plot_map", None)
     if plot_map is not None and geodata is None:
         raise ValueError("map!=None but geodata=None")
     if len(R.shape) != 2:
@@ -187,14 +167,7 @@ def plot_precip_field(
     # plot geography
     if plot_map is not None:
         try:
-            ax = basemaps.plot_geography(
-                plot_map,
-                geodata["projection"],
-                bm_extent,
-                lw=lw,
-                drawlonlatlines=drawlonlatlines,
-                **kwargs,
-            )
+            ax = basemaps.plot_geography(geodata["projection"], bm_extent, **kwargs,)
             regular_grid = True
         except UnsupportedSomercProjection:
             # Define default fall-back projection for Swiss data(EPSG:3035)
@@ -209,14 +182,7 @@ def plot_precip_field(
             X, Y = geodata["X_grid"], geodata["Y_grid"]
             regular_grid = geodata["regular_grid"]
 
-            ax = basemaps.plot_geography(
-                plot_map,
-                geodata["projection"],
-                bm_extent,
-                lw=lw,
-                drawlonlatlines=drawlonlatlines,
-                **kwargs,
-            )
+            ax = basemaps.plot_geography(geodata["projection"], bm_extent, **kwargs,)
     else:
         regular_grid = True
 
@@ -269,12 +235,7 @@ def plot_precip_field(
         else:
             extend = "neither"
         cbar = plt.colorbar(
-            im,
-            ticks=clevs,
-            spacing="uniform",
-            extend=extend,
-            shrink=0.8,
-            cax=cax,
+            im, ticks=clevs, spacing="uniform", extend=extend, shrink=0.8, cax=cax,
         )
         if clevsStr is not None:
             cbar.ax.set_yticklabels(clevsStr)


### PR DESCRIPTION
Addressing FutureWarning from 1.3.2 which concerns the interface to the `plot_geography` method.

In short:
* rename `map` to `plot_map` 
* set `plot_map` as optional argument

Remaining open question: 
Should we remove option to use the deprecated basemap module and leave cartopy as unique option?