### PR TITLE
Improved extrapolation

### DIFF
--- a/pysteps/extrapolation/interface.py
+++ b/pysteps/extrapolation/interface.py
@@ -20,7 +20,7 @@ from outside the domain.
 Optional keyword arguments that are specific to a given extrapolation
 method are passed as a dictionary.
 
-The output of each method is an array precip that includes the time series of
+The output of each method is an array that contains the time series of
 extrapolated fields of shape (num_timesteps, m, n).
 
 .. currentmodule:: pysteps.extrapolation.interface

--- a/pysteps/extrapolation/interface.py
+++ b/pysteps/extrapolation/interface.py
@@ -20,7 +20,7 @@ from outside the domain.
 Optional keyword arguments that are specific to a given extrapolation
 method are passed as a dictionary.
 
-The output of each method is an array R_e that includes the time series of
+The output of each method is an array precip that includes the time series of
 extrapolated fields of shape (num_timesteps, m, n).
 
 .. currentmodule:: pysteps.extrapolation.interface

--- a/pysteps/extrapolation/interface.py
+++ b/pysteps/extrapolation/interface.py
@@ -49,11 +49,11 @@ def eulerian_persistence(precip, velocity, timesteps, outval=np.nan, **kwargs):
         Array of shape (m,n) containing the input precipitation field. All
         values are required to be finite.
     velocity : array-like
-        Not used by the method. 
+        Not used by the method.
     timesteps : int or list
         Number of time steps or a list of time steps.
     outval : float, optional
-        Not used by the method. 
+        Not used by the method.
 
     Other Parameters
     ----------------
@@ -72,7 +72,7 @@ def eulerian_persistence(precip, velocity, timesteps, outval=np.nan, **kwargs):
 
     References
     ----------
-    :cite:`GZ2002` Germann et al (2002)
+    :cite:`GZ2002`
 
     """
     del velocity, outval  # Unused by _eulerian_persistence
@@ -84,7 +84,15 @@ def eulerian_persistence(precip, velocity, timesteps, outval=np.nan, **kwargs):
 
     return_displacement = kwargs.get("return_displacement", False)
 
-    extrapolated_precip = np.repeat(precip[np.newaxis, :, :,], num_timesteps, axis=0)
+    extrapolated_precip = np.repeat(
+        precip[
+            np.newaxis,
+            :,
+            :,
+        ],
+        num_timesteps,
+        axis=0,
+    )
 
     if not return_displacement:
         return extrapolated_precip
@@ -124,8 +132,8 @@ def get_method(name):
     |  eulerian       | this methods does not apply any advection to the input |
     |                 | precipitation field (Eulerian persistence)             |
     +-----------------+--------------------------------------------------------+
-    | semilagrangian  | implementation of the semi-Lagrangian method of        |
-    |                 | Germann et al. (2002) :cite:`GZ2002`                   |
+    | semilagrangian  | implementation of the semi-Lagrangian method described |
+    |                 | in :cite:`GZ2002`                                      |
     +-----------------+--------------------------------------------------------+
 
     """

--- a/pysteps/extrapolation/semilagrangian.py
+++ b/pysteps/extrapolation/semilagrangian.py
@@ -2,8 +2,7 @@
 pysteps.extrapolation.semilagrangian
 ====================================
 
-Implementation of the semi-Lagrangian method of Germann et al (2002).
-:cite:`GZ2002`
+Implementation of the semi-Lagrangian method described in :cite:`GZ2002`.
 
 .. autosummary::
     :toctree: ../generated/
@@ -160,10 +159,18 @@ def extrapolate(
         coords_warped = [coords_warped[1, :, :], coords_warped[0, :, :]]
 
         velocity_inc_x = ip.map_coordinates(
-            velocity[0, :, :], coords_warped, mode="nearest", order=1, prefilter=False,
+            velocity[0, :, :],
+            coords_warped,
+            mode="nearest",
+            order=1,
+            prefilter=False,
         )
         velocity_inc_y = ip.map_coordinates(
-            velocity[1, :, :], coords_warped, mode="nearest", order=1, prefilter=False,
+            velocity[1, :, :],
+            coords_warped,
+            mode="nearest",
+            order=1,
+            prefilter=False,
         )
 
         velocity_inc[0, :, :] = velocity_inc_x

--- a/pysteps/extrapolation/semilagrangian.py
+++ b/pysteps/extrapolation/semilagrangian.py
@@ -12,6 +12,7 @@ Implementation of the semi-Lagrangian method described in :cite:`GZ2002`.
 """
 
 import time
+import warnings
 
 import numpy as np
 import scipy.ndimage.interpolation as ip
@@ -96,7 +97,7 @@ def extrapolate(
 
     References
     ----------
-    :cite:`GZ2002` Germann et al (2002)
+    :cite:`GZ2002`
 
     """
     if len(precip.shape) != 2:
@@ -118,6 +119,12 @@ def extrapolate(
     n_iter = kwargs.get("n_iter", 1)
     return_displacement = kwargs.get("return_displacement", False)
     interp_order = kwargs.get("interp_order", 1)
+
+    if "D_prev" in kwargs.keys():
+        warnings.warn(
+            "deprecated argument D_prev is ignored, use displacement_prev instead",
+            DeprecationWarning,
+        )
 
     # if interp_order > 1, apply separate masking to preserve nan and
     # non-precipitation values

--- a/pysteps/extrapolation/semilagrangian.py
+++ b/pysteps/extrapolation/semilagrangian.py
@@ -116,6 +116,14 @@ def extrapolate(
     n_iter = kwargs.get("n_iter", 1)
     return_displacement = kwargs.get("return_displacement", False)
 
+    # replace nans with zeros and apply separate masking if interp_order > 1
+    if interp_order > 1:
+        mask = np.isfinite(precip)
+        precip = precip.copy()
+        precip[~mask] = 0.0
+
+    prefilter = True if interp_order > 1 else False
+
     if isinstance(timesteps, int):
         timesteps = np.arange(1, timesteps + 1)
         vel_timestep = 1.0
@@ -143,10 +151,18 @@ def extrapolate(
         XYW = [XYW[1, :, :], XYW[0, :, :]]
 
         VWX = ip.map_coordinates(
-            velocity[0, :, :], XYW, mode="nearest", order=interp_order, prefilter=False
+            velocity[0, :, :],
+            XYW,
+            mode="nearest",
+            order=interp_order,
+            prefilter=prefilter,
         )
         VWY = ip.map_coordinates(
-            velocity[1, :, :], XYW, mode="nearest", order=interp_order, prefilter=False
+            velocity[1, :, :],
+            XYW,
+            mode="nearest",
+            order=interp_order,
+            prefilter=prefilter,
         )
 
         V_inc[0, :, :] = VWX
@@ -187,7 +203,7 @@ def extrapolate(
             mode="constant",
             cval=outval,
             order=interp_order,
-            prefilter=False,
+            prefilter=prefilter,
         )
         R_e.append(np.reshape(IW, precip.shape))
 

--- a/pysteps/extrapolation/semilagrangian.py
+++ b/pysteps/extrapolation/semilagrangian.py
@@ -26,7 +26,7 @@ def extrapolate(
     xy_coords=None,
     allow_nonfinite_values=False,
     vel_timestep=None,
-    interp_order=3,
+    interp_order=1,
     **kwargs,
 ):
     """Apply semi-Lagrangian backward extrapolation to a two-dimensional
@@ -82,7 +82,11 @@ def extrapolate(
         The time step of the velocity field. It is assumed to have the same
         unit as the timesteps argument.
     interp_order : int
-        Order of the interpolation to use. Default : 3 (cubic).
+        Order of the interpolation to use. Default : 1 (linear). Setting this
+        to 0 (nearest neighbor) gives the best computational performance but
+        may produce visible artefacts. Setting this to 3 (cubic) gives the best
+        ability to reproduce small-scale variability but may significantly
+        increase the computation time.
 
     Returns
     -------

--- a/pysteps/extrapolation/semilagrangian.py
+++ b/pysteps/extrapolation/semilagrangian.py
@@ -26,7 +26,6 @@ def extrapolate(
     xy_coords=None,
     allow_nonfinite_values=False,
     vel_timestep=None,
-    interp_order=1,
     **kwargs,
 ):
     """Apply semi-Lagrangian backward extrapolation to a two-dimensional
@@ -119,6 +118,7 @@ def extrapolate(
     displacement_prev = kwargs.get("displacement_prev", None)
     n_iter = kwargs.get("n_iter", 1)
     return_displacement = kwargs.get("return_displacement", False)
+    interp_order = kwargs.get("interp_order", 1)
 
     # if interp_order > 1, apply separate masking to preserve nan and
     # non-precipitation values

--- a/pysteps/extrapolation/semilagrangian.py
+++ b/pysteps/extrapolation/semilagrangian.py
@@ -123,7 +123,6 @@ def extrapolate(
     if "D_prev" in kwargs.keys():
         warnings.warn(
             "deprecated argument D_prev is ignored, use displacement_prev instead",
-            DeprecationWarning,
         )
 
     # if interp_order > 1, apply separate masking to preserve nan and

--- a/pysteps/extrapolation/semilagrangian.py
+++ b/pysteps/extrapolation/semilagrangian.py
@@ -82,7 +82,7 @@ def extrapolate(
         The time step of the velocity field. It is assumed to have the same
         unit as the timesteps argument.
     interp_order : int
-        Order of the interpolation to use. Default : 0 (nearest interpolation).
+        Order of the interpolation to use. Default : 3 (cubic).
 
     Returns
     -------

--- a/pysteps/extrapolation/semilagrangian.py
+++ b/pysteps/extrapolation/semilagrangian.py
@@ -48,7 +48,7 @@ def extrapolate(
     outval : float, optional
         Optional argument for specifying the value for pixels advected from
         outside the domain. If outval is set to 'min', the value is taken as
-        the minimum value of R.
+        the minimum value of precip.
         Default : np.nan
     xy_coords : ndarray, optional
         Array with the coordinates of the grid dimension (2, m, n ).
@@ -82,7 +82,7 @@ def extrapolate(
         The time step of the velocity field. It is assumed to have the same
         unit as the timesteps argument.
     interp_order : int
-        Order of the interpolation to use. Default : 1 (linear). Setting this
+        The order of interpolation to use. Default : 1 (linear). Setting this
         to 0 (nearest neighbor) gives the best computational performance but
         may produce visible artefacts. Setting this to 3 (cubic) gives the best
         ability to reproduce small-scale variability but may significantly

--- a/pysteps/extrapolation/semilagrangian.py
+++ b/pysteps/extrapolation/semilagrangian.py
@@ -26,7 +26,7 @@ def extrapolate(
     xy_coords=None,
     allow_nonfinite_values=False,
     vel_timestep=None,
-    interp_order=0,
+    interp_order=3,
     **kwargs,
 ):
     """Apply semi-Lagrangian backward extrapolation to a two-dimensional
@@ -121,6 +121,7 @@ def extrapolate(
         mask = np.isfinite(precip)
         precip = precip.copy()
         precip[~mask] = 0.0
+        mask = mask.astype(float)
 
     prefilter = True if interp_order > 1 else False
 
@@ -197,6 +198,13 @@ def extrapolate(
             order=interp_order,
             prefilter=prefilter,
         )
+
+        if interp_order > 1:
+            MW = ip.map_coordinates(
+                mask, XYW, mode="constant", cval=0, order=1, prefilter=False
+            )
+            IW[MW < 0.5] = np.nan
+
         R_e.append(np.reshape(IW, precip.shape))
 
     if verbose:

--- a/pysteps/extrapolation/semilagrangian.py
+++ b/pysteps/extrapolation/semilagrangian.py
@@ -26,6 +26,7 @@ def extrapolate(
     xy_coords=None,
     allow_nonfinite_values=False,
     vel_timestep=None,
+    interp_order=0,
     **kwargs,
 ):
     """Apply semi-Lagrangian backward extrapolation to a two-dimensional
@@ -80,6 +81,8 @@ def extrapolate(
     vel_timestep : float
         The time step of the velocity field. It is assumed to have the same
         unit as the timesteps argument.
+    interp_order : int
+        Order of the interpolation to use. Default : 0 (nearest interpolation).
 
     Returns
     -------
@@ -140,10 +143,10 @@ def extrapolate(
         XYW = [XYW[1, :, :], XYW[0, :, :]]
 
         VWX = ip.map_coordinates(
-            velocity[0, :, :], XYW, mode="nearest", order=0, prefilter=False
+            velocity[0, :, :], XYW, mode="nearest", order=interp_order, prefilter=False
         )
         VWY = ip.map_coordinates(
-            velocity[1, :, :], XYW, mode="nearest", order=0, prefilter=False
+            velocity[1, :, :], XYW, mode="nearest", order=interp_order, prefilter=False
         )
 
         V_inc[0, :, :] = VWX
@@ -179,7 +182,12 @@ def extrapolate(
         XYW = [XYW[1, :, :], XYW[0, :, :]]
 
         IW = ip.map_coordinates(
-            precip, XYW, mode="constant", cval=outval, order=0, prefilter=False
+            precip,
+            XYW,
+            mode="constant",
+            cval=outval,
+            order=interp_order,
+            prefilter=False,
         )
         R_e.append(np.reshape(IW, precip.shape))
 

--- a/pysteps/extrapolation/semilagrangian.py
+++ b/pysteps/extrapolation/semilagrangian.py
@@ -151,18 +151,10 @@ def extrapolate(
         XYW = [XYW[1, :, :], XYW[0, :, :]]
 
         VWX = ip.map_coordinates(
-            velocity[0, :, :],
-            XYW,
-            mode="nearest",
-            order=interp_order,
-            prefilter=prefilter,
+            velocity[0, :, :], XYW, mode="nearest", order=1, prefilter=False,
         )
         VWY = ip.map_coordinates(
-            velocity[1, :, :],
-            XYW,
-            mode="nearest",
-            order=interp_order,
-            prefilter=prefilter,
+            velocity[1, :, :], XYW, mode="nearest", order=1, prefilter=False,
         )
 
         V_inc[0, :, :] = VWX

--- a/pysteps/nowcasts/anvil.py
+++ b/pysteps/nowcasts/anvil.py
@@ -331,7 +331,11 @@ def forecast(
 
         # extrapolate to the current nowcast lead time
         extrap_kwargs.update(
-            {"D_prev": dp, "return_displacement": True, "allow_nonfinite_values": True}
+            {
+                "displacement_prev": dp,
+                "return_displacement": True,
+                "allow_nonfinite_values": True,
+            }
         )
         r_f_, dp = extrapolator(r_f_, velocity, 1, **extrap_kwargs)
 

--- a/pysteps/nowcasts/sprog.py
+++ b/pysteps/nowcasts/sprog.py
@@ -344,7 +344,7 @@ def forecast(
 
         # advect the recomposed precipitation field to obtain the forecast for
         # time step t
-        extrap_kwargs.update({"D_prev": D, "return_displacement": True})
+        extrap_kwargs.update({"displacement_prev": D, "return_displacement": True})
         R_f_, D_ = extrapolator_method(R_c_, V, 1, **extrap_kwargs)
         D = D_
         R_f_ = R_f_[0]

--- a/pysteps/nowcasts/sseps.py
+++ b/pysteps/nowcasts/sseps.py
@@ -750,7 +750,9 @@ def forecast(
 
             # advect the recomposed precipitation field to obtain the forecast
             # for time step t
-            extrap_kwargs.update({"D_prev": D[j], "return_displacement": True})
+            extrap_kwargs.update(
+                {"displacement_prev": D[j], "return_displacement": True}
+            )
             R_f_, D_ = extrapolator_method(R_c_, V_, 1, **extrap_kwargs)
             D[j] = D_
             R_f_ = R_f_[0]

--- a/pysteps/nowcasts/steps.py
+++ b/pysteps/nowcasts/steps.py
@@ -704,7 +704,9 @@ def forecast(
 
             # advect the recomposed precipitation field to obtain the forecast
             # for time step t
-            extrap_kwargs.update({"D_prev": D[j], "return_displacement": True})
+            extrap_kwargs.update(
+                {"displacement_prev": D[j], "return_displacement": True}
+            )
             R_f_, D_ = extrapolator_method(R_c_, V_, 1, **extrap_kwargs)
             D[j] = D_
             R_f_ = R_f_[0]


### PR DESCRIPTION
This pull request aims to fix issue #182. The following changes were done to `pysteps.extrapolation.semilagrangian`:
- Allow the user to choose the interpolation order (keyword argument `order` of `scipy.ndimage.interpolation.map_coordinates`) and set its default value to 1
- Apply prefiltering if `order>1`, as suggested in the documentation of map_coordinates
- Use `order=1` for the advection field
- If `order>1`, replace nans with zeros and apply an extrapolated mask separately. this is needed because prefiltering cannot handle nan values
- Replace uppercase variable names with more descriptive ones