### PR TITLE
Refactor visualization module

### DIFF
--- a/.github/workflows/test_pysteps.yml
+++ b/.github/workflows/test_pysteps.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           brew update-reset
           brew update
-          brew install gcc@9
+          brew install gcc@9 || brew upgrade gcc@9
           gcc-9 --version
           pip install .
 

--- a/.github/workflows/test_pysteps.yml
+++ b/.github/workflows/test_pysteps.yml
@@ -62,8 +62,7 @@ jobs:
         run: |
           brew update-reset
           brew update
-          brew install gcc@9 || brew upgrade gcc@9
-          gcc-9 --version
+          gcc-9 --version || brew install gcc@9
           pip install .
 
       - name: Install pygrib (not win)

--- a/examples/advection_correction.py
+++ b/examples/advection_correction.py
@@ -17,7 +17,7 @@ precipitation features.
 """
 
 from datetime import datetime
-import matplotlib.pyplot as pl
+import matplotlib.pyplot as plt
 import numpy as np
 
 from pysteps import io, motion, rcparams
@@ -134,13 +134,13 @@ R_ac /= R.shape[0]
 # correction to account for this spatial shift. The final result is a smoother
 # rainfall accumulation map.
 
-pl.figure(figsize=(9, 4))
-pl.subplot(121)
+plt.figure(figsize=(9, 4))
+plt.subplot(121)
 plot_precip_field(R.mean(axis=0), title="3-h rainfall accumulation")
-pl.subplot(122)
+plt.subplot(122)
 plot_precip_field(R_ac, title="Same with advection correction")
-pl.tight_layout()
-pl.show()
+plt.tight_layout()
+plt.show()
 
 ################################################################################
 # Reference

--- a/examples/plot_cascade_decomposition.py
+++ b/examples/plot_cascade_decomposition.py
@@ -8,7 +8,7 @@ a single radar precipitation field in pysteps.
 
 """
 
-from matplotlib import cm, pyplot
+from matplotlib import cm, pyplot as plt
 import numpy as np
 import os
 from pprint import pprint
@@ -40,6 +40,7 @@ pprint(metadata)
 
 # Plot the rainfall field
 plot_precip_field(R, geodata=metadata)
+plt.show()
 
 # Log-transform the data
 R, metadata = transformation.dB_transform(R, metadata, threshold=0.1, zerovalue=-15.0)
@@ -58,7 +59,7 @@ F = abs(np.fft.fftshift(np.fft.fft2(R)))
 
 # Plot the power spectrum
 M, N = F.shape
-fig, ax = pyplot.subplots()
+fig, ax = plt.subplots()
 im = ax.imshow(
     np.log(F ** 2), vmin=4, vmax=24, cmap=cm.jet, extent=(-N / 2, N / 2, -M / 2, M / 2)
 )
@@ -66,6 +67,7 @@ cb = fig.colorbar(im)
 ax.set_xlabel("Wavenumber $k_x$")
 ax.set_ylabel("Wavenumber $k_y$")
 ax.set_title("Log-power spectrum of R")
+plt.show()
 
 ###############################################################################
 # Cascade decomposition
@@ -81,7 +83,7 @@ filter = filter_gaussian(R.shape, num_cascade_levels)
 
 # Plot the bandpass filter weights
 L = max(N, M)
-fig, ax = pyplot.subplots()
+fig, ax = plt.subplots()
 for k in range(num_cascade_levels):
     ax.semilogx(
         np.linspace(0, L / 2, len(filter["weights_1d"][k, :])),
@@ -97,6 +99,7 @@ ax.set_xticklabels(["%.2f" % cf for cf in filter["central_wavenumbers"]])
 ax.set_xlabel("Radial wavenumber $|\mathbf{k}|$")
 ax.set_ylabel("Normalized weight")
 ax.set_title("Bandpass filter weights")
+plt.show()
 
 ###############################################################################
 # Finally, apply the 2D Gaussian filters to decompose the radar rainfall field
@@ -110,7 +113,7 @@ for i in range(num_cascade_levels):
     sigma = decomp["stds"][i]
     decomp["cascade_levels"][i] = (decomp["cascade_levels"][i] - mu) / sigma
 
-fig, ax = pyplot.subplots(nrows=2, ncols=4)
+fig, ax = plt.subplots(nrows=2, ncols=4)
 
 ax[0, 0].imshow(R, cmap=cm.RdBu_r, vmin=-5, vmax=5)
 ax[0, 1].imshow(decomp["cascade_levels"][0], cmap=cm.RdBu_r, vmin=-3, vmax=3)
@@ -134,6 +137,7 @@ for i in range(2):
     for j in range(4):
         ax[i, j].set_xticks([])
         ax[i, j].set_yticks([])
-pyplot.tight_layout()
+plt.tight_layout()
+plt.show()
 
 # sphinx_gallery_thumbnail_number = 4

--- a/examples/plot_noise_generators.py
+++ b/examples/plot_noise_generators.py
@@ -11,7 +11,7 @@ nowcast in order to represent the uncertainty in the evolution of the rainfall
 field.
 """
 
-from matplotlib import cm, pyplot
+from matplotlib import cm, pyplot as plt
 import numpy as np
 import os
 from pprint import pprint
@@ -44,6 +44,7 @@ pprint(metadata)
 
 # Plot the rainfall field
 plot_precip_field(R, geodata=metadata)
+plt.show()
 
 # Log-transform the data
 R, metadata = transformation.dB_transform(R, metadata, threshold=0.1, zerovalue=-15.0)
@@ -79,7 +80,7 @@ b1 = Fp["pars"][2]
 b2 = Fp["pars"][3]
 
 # Plot the observed power spectrum and the model
-fig, ax = pyplot.subplots()
+fig, ax = plt.subplots()
 plot_scales = [512, 256, 128, 64, 32, 16, 8, 4]
 plot_spectrum1d(
     freq,
@@ -101,11 +102,12 @@ plot_spectrum1d(
     label="Fit",
     wavelength_ticks=plot_scales,
 )
-pyplot.legend()
+plt.legend()
 ax.set_title(
     "Radially averaged log-power spectrum of R\n"
     r"$\omega_0=%.0f km, \beta_1=%.1f, \beta_2=%.1f$" % (w0, b1, b2)
 )
+plt.show()
 
 ###############################################################################
 # Nonparametric filter
@@ -136,7 +138,7 @@ for k in range(num_realizations):
 
 # Plot the generated noise fields
 
-fig, ax = pyplot.subplots(nrows=2, ncols=3)
+fig, ax = plt.subplots(nrows=2, ncols=3)
 
 # parametric noise
 ax[0, 0].imshow(Np[0], cmap=cm.RdBu_r, vmin=-3, vmax=3)
@@ -152,7 +154,8 @@ for i in range(2):
     for j in range(3):
         ax[i, j].set_xticks([])
         ax[i, j].set_yticks([])
-pyplot.tight_layout()
+plt.tight_layout()
+plt.show()
 
 ###############################################################################
 # The above figure highlights the main limitation of the parametric approach

--- a/examples/plot_steps_nowcast.py
+++ b/examples/plot_steps_nowcast.py
@@ -61,6 +61,7 @@ R, metadata = dimension.aggregate_fields_space(R, metadata, 2000)
 
 # Plot the rainfall field
 plot_precip_field(R[-1, :, :], geodata=metadata)
+plt.show()
 
 # Log-transform the data to unit of dBR, set the threshold to 0.1 mm/h,
 # set the fill value to -15 dBR
@@ -104,6 +105,7 @@ plot_precip_field(
     geodata=metadata,
     title="S-PROG (+ %i min)" % (n_leadtimes * timestep),
 )
+plt.show()
 
 ###############################################################################
 # As we can see from the figure above, the forecast produced by S-PROG is a
@@ -150,6 +152,7 @@ plot_precip_field(
     geodata=metadata,
     title="Ensemble mean (+ %i min)" % (n_leadtimes * timestep),
 )
+plt.show()
 
 ###############################################################################
 # The mean of the ensemble displays similar properties as the S-PROG
@@ -166,6 +169,7 @@ for i in range(4):
     )
     ax.set_title("Member %02d" % i)
 plt.tight_layout()
+plt.show()
 
 ###############################################################################
 # As we can see from these two members of the ensemble, the stochastic forecast
@@ -188,5 +192,6 @@ plot_precip_field(
     probthr=0.5,
     title="Exceedence probability (+ %i min)" % (n_leadtimes * timestep),
 )
+plt.show()
 
 # sphinx_gallery_thumbnail_number = 5

--- a/examples/plot_steps_nowcast.py
+++ b/examples/plot_steps_nowcast.py
@@ -183,7 +183,7 @@ P = excprob(R_f[:, -1, :, :], 0.5)
 plot_precip_field(
     P,
     geodata=metadata,
-    type="prob",
+    ptype="prob",
     units="mm/h",
     probthr=0.5,
     title="Exceedence probability (+ %i min)" % (n_leadtimes * timestep),

--- a/examples/rainfarm_downscale.py
+++ b/examples/rainfarm_downscale.py
@@ -46,8 +46,8 @@ precip, metadata = square_domain(precip, metadata, "crop")
 pprint(metadata)
 
 # Plot the original rainfall field
-plt.figure()
 plot_precip_field(precip, geodata=metadata)
+plt.show()
 
 # Assign the fill value to all the Nans
 precip[~np.isfinite(precip)] = metadata["zerovalue"]
@@ -116,7 +116,7 @@ for n in range(num_realizations):
     plt.subplots_adjust(wspace=0, hspace=0)
 
 plt.tight_layout()
-
+plt.show()
 
 ###############################################################################
 # Remarks

--- a/pysteps/exceptions.py
+++ b/pysteps/exceptions.py
@@ -19,14 +19,3 @@ class DataModelError(Exception):
     """Raised when a file is not compilant with the Data Information Model."""
 
     pass
-
-
-class UnsupportedSomercProjection(Exception):
-    """
-    Raised when the Swiss Oblique Mercator (somerc) projection is passed
-    to cartopy.
-    Necessary since cartopy doesn't support the Swiss projection.
-    TODO: remove once the somerc projection is supported in cartopy.
-    """
-
-    pass

--- a/pysteps/tests/test_plt_animate.py
+++ b/pysteps/tests/test_plt_animate.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+import os
+
+import numpy as np
+import pytest
+
+from pysteps.tests.helpers import get_precipitation_fields
+from pysteps.visualization.animations import animate
+
+def test_animate(tmp_path):
+
+    # test data
+    precip, metadata = get_precipitation_fields(
+        num_prev_files=2,
+        num_next_files=0,
+        return_raw=True,
+        metadata=True,
+        upscale=2000,
+    )
+
+    # obs only
+    animate(precip)
+    animate(precip, title="title")
+    animate(precip, timestamps_obs=metadata["timestamps"])
+    animate(precip, geodata=metadata, map_kwargs={"plot_map": None})
+    with pytest.raises(ValueError):
+        animate(precip, timestamps_obs=metadata["timestamps"][:2])
+    animate(precip, motion_field=np.ones((2, *precip.shape[1:])))
+    with pytest.raises(ValueError):
+        animate(precip, motion_plot="test")
+
+    # with forecast
+    animate(precip, precip)
+    animate(precip, precip, title="title")
+    animate(precip, precip, timestamps_obs=metadata["timestamps"])
+    animate(precip, precip, timestamps_obs=metadata["timestamps"], timestep_min=5)
+    with pytest.raises(ValueError):
+        animate(precip, precip, ptype="prob")
+    animate(precip, precip, ptype="prob", prob_thr=1)
+    animate(precip, precip, ptype="mean")
+    animate(precip, np.stack((precip, precip)), ptype="ensemble")
+
+    # save frames
+    animate(precip, np.stack((precip, precip)), display_animation=False, savefig=True, path_outputs=tmp_path, fig_dpi=10)
+    assert len(os.listdir(tmp_path)) == 9

--- a/pysteps/tests/test_plt_animate.py
+++ b/pysteps/tests/test_plt_animate.py
@@ -8,6 +8,7 @@ import pytest
 from pysteps.tests.helpers import get_precipitation_fields
 from pysteps.visualization.animations import animate
 
+
 def test_animate(tmp_path):
 
     # test data
@@ -42,5 +43,12 @@ def test_animate(tmp_path):
     animate(precip, np.stack((precip, precip)), ptype="ensemble")
 
     # save frames
-    animate(precip, np.stack((precip, precip)), display_animation=False, savefig=True, path_outputs=tmp_path, fig_dpi=10)
+    animate(
+        precip,
+        np.stack((precip, precip)),
+        display_animation=False,
+        savefig=True,
+        path_outputs=tmp_path,
+        fig_dpi=10,
+    )
     assert len(os.listdir(tmp_path)) == 9

--- a/pysteps/tests/test_plt_cartopy.py
+++ b/pysteps/tests/test_plt_cartopy.py
@@ -32,7 +32,7 @@ def test_visualization_plot_precip_field(source, map_kwargs, pass_geodata):
     if not pass_geodata:
         metadata = None
 
-    plot_precip_field(field, type="intensity", geodata=metadata, map_kwargs=map_kwargs)
+    plot_precip_field(field, ptype="intensity", geodata=metadata, map_kwargs=map_kwargs)
 
 
 if __name__ == "__main__":

--- a/pysteps/tests/test_plt_precipfields.py
+++ b/pysteps/tests/test_plt_precipfields.py
@@ -60,7 +60,7 @@ def test_visualization_plot_precip_field(
     field_orig = field.copy()
     ax = plot_precip_field(
         field.copy(),
-        type=plot_type,
+        ptype=plot_type,
         bbox=bbox,
         geodata=None,
         colorscale=colorscale,

--- a/pysteps/visualization/animations.py
+++ b/pysteps/visualization/animations.py
@@ -19,8 +19,13 @@ import numpy as np
 import pysteps as st
 
 PRECIP_VALID_TYPES = ("ensemble", "mean", "prob")
-PRECIP_DEPRECATED_ARGUMENTS = ("units", "colorbar", "colorscale")  # TODO: remove in version >= 1.6
+PRECIP_DEPRECATED_ARGUMENTS = (
+    "units",
+    "colorbar",
+    "colorscale",
+)  # TODO: remove in version >= 1.6
 MOTION_VALID_METHODS = ("quiver", "streamplot")
+
 
 def animate(
     precip_obs,
@@ -141,7 +146,7 @@ def animate(
     -------
     None
     """
-    
+
     if precip_kwargs is None:
         precip_kwargs = {}
 
@@ -184,7 +189,7 @@ def animate(
             "Use 'ptype' instead."
         )
         ptype = kwargs.get("type")
-        
+
     # TODO: remove in version >= 1.6
     if "timestamps" in kwargs:
         warnings.warn(
@@ -192,7 +197,7 @@ def animate(
             "Use 'timestamps_obs' instead."
         )
         timestamps_obs = kwargs.get("timestamps")
-        
+
     # TODO: remove in version >= 1.6
     if "plotanimation" in kwargs:
         warnings.warn(
@@ -242,7 +247,9 @@ def animate(
 
                     title = title_first_line + "Analysis"
                     if timestamps_obs is not None:
-                        title += f" valid for {timestamps_obs[i].strftime('%Y-%m-%d %H:%M')}"
+                        title += (
+                            f" valid for {timestamps_obs[i].strftime('%Y-%m-%d %H:%M')}"
+                        )
 
                     plt.clf()
                     if ptype == "prob":
@@ -269,7 +276,9 @@ def animate(
 
                     if motion_field is not None:
                         if motion_plot == "quiver":
-                            st.plt.quiver(motion_field, ax=ax, geodata=geodata, **motion_kwargs)
+                            st.plt.quiver(
+                                motion_field, ax=ax, geodata=geodata, **motion_kwargs
+                            )
                         elif motion_plot == "streamplot":
                             st.plt.streamplot(
                                 motion_field, ax=ax, geodata=geodata, **motion_kwargs
@@ -329,7 +338,9 @@ def animate(
 
                     if motion_field is not None:
                         if motion_plot == "quiver":
-                            st.plt.quiver(motion_field, ax=ax, geodata=geodata, **motion_kwargs)
+                            st.plt.quiver(
+                                motion_field, ax=ax, geodata=geodata, **motion_kwargs
+                            )
                         elif motion_plot == "streamplot":
                             st.plt.streamplot(
                                 motion_field, ax=ax, geodata=geodata, **motion_kwargs

--- a/pysteps/visualization/animations.py
+++ b/pysteps/visualization/animations.py
@@ -12,58 +12,67 @@ Functions to produce animations for pysteps.
 """
 
 import os
+import warnings
 
 import matplotlib.pylab as plt
 import numpy as np
 import pysteps as st
 
+PRECIP_VALID_TYPES = ("ensemble", "mean", "prob")
+PRECIP_DEPRECATED_ARGUMENTS = ("units", "colorbar", "colorscale")  # TODO: remove in version >= 1.6
+MOTION_VALID_METHODS = ("quiver", "streamplot")
 
-# TODO: Add documentation for the output files.
 def animate(
-    R_obs,
-    nloops=2,
-    timestamps=None,
-    R_fct=None,
-    timestep_min=5,
-    UV=None,
+    precip_obs,
+    precip_fct=None,
+    timestamps_obs=None,
+    timestep_min=None,
+    motion_field=None,
+    ptype="ensemble",
     motion_plot="quiver",
     geodata=None,
-    colorscale="pysteps",
-    units="mm/h",
-    colorbar=True,
-    type="ensemble",
+    title=None,
     prob_thr=None,
-    plotanimation=True,
+    display_animation=True,
+    nloops=1,
+    time_wait=0.2,
     savefig=False,
-    fig_dpi=150,
+    fig_dpi=100,
     fig_format="png",
     path_outputs="",
-    motion_kwargs={},
-    map_kwargs={},
+    precip_kwargs=None,
+    motion_kwargs=None,
+    map_kwargs=None,
+    **kwargs,
 ):
     """Function to animate observations and forecasts in pysteps.
 
+    It also allows to export the individual frames as figures, which
+    is useful for constructing animated GIFs or similar.
+
+    .. _Axes: https://matplotlib.org/api/axes_api.html#matplotlib.axes.Axes
+
     Parameters
     ----------
-    R_obs: array-like
+    precip_obs: array-like
         Three-dimensional array containing the time series of observed
         precipitation fields.
-
-    Other parameters
-    ----------------
-    nloops: int
-        Optional, the number of loops in the animation.
-    R_fct: array-like
-        Optional, the three or four-dimensional (for ensembles) array
+    precip_fct: array-like, optional
+        The three or four-dimensional (for ensembles) array
         containing the time series of forecasted precipitation field.
-    timestep_min: float
+    timestamps_obs: list of datetimes, optional
+        List of datetime objects corresponding to the time stamps of
+        the fields in precip_obs.
+    timestep_min: float, optional
         The time resolution in minutes of the forecast.
-    UV: array-like
-        Optional, the motion field used for the forecast.
-    motion_plot: string
-        The method to plot the motion field.
-    geodata: dictionary or None
-        Optional dictionary containing geographical information about
+    motion_field: array-like, optional
+        Three-dimensional array containing the u and v components of
+        the motion field.
+    motion_plot: string, optional
+        The method to plot the motion field. See plot methods in
+        :py:mod:`pysteps.visualization.motionfields`.
+    geodata: dictionary or None, optional
+        Dictionary containing geographical information about
         the field.
         If geodata is not None, it must contain the following key-value pairs:
 
@@ -91,69 +100,136 @@ def animate(
         |                | 'upper' = upper border, 'lower' = lower border     |
         +----------------+----------------------------------------------------+
 
-    units: str
-        Units of the input array (mm/h or dBZ)
-    colorscale: str
-        The *colorscale* argument to
-        :py:func:`pysteps.visualization.precipfields.plot_precip_field`.
-    title: str or None
+    title: str or None, optional
         If not None, print the string as title on top of the plot.
-    colorbar: bool
-        If set to True, add a colorbar on the right side of the plot.
-    type: {'ensemble', 'mean', 'prob'}, str
-        Type of the map to animate. 'ensemble' = ensemble members,
+    ptype: {'ensemble', 'mean', 'prob'}, str, optional
+        Type of the plot to animate. 'ensemble' = ensemble members,
         'mean' = ensemble mean, 'prob' = exceedance probability
         (using threshold defined in prob_thrs).
-    prob_thr: float
+    prob_thr: float, optional
         Intensity threshold for the exceedance probability maps. Applicable
-        if type = 'prob'.
-    plotanimation: bool
-        If set to True, visualize the animation (useful when one is only
-        interested in saving the individual frames).
-    savefig: bool
-        If set to True, save the individual frames to path_outputs.
-    fig_dpi: scalar > 0
-        Resolution of the output figures, see the documentation of
-        matplotlib.pyplot.savefig. Applicable if savefig is True.
-    path_outputs: string
-        Path to folder where to save the frames.
-    motion_kwargs: dict
-        Optional keyword arguments that are supplied to
-        :py:func:`pysteps.visualization.precipfields.plot_precip_field` or
-        :py:func:`pysteps.visualization.motionfields.quiver`.
-    map_kwargs: dict
-        Optional keyword arguments that are supplied to
+        if ptype = 'prob'.
+    display_animation: bool, optional
+        If set to True, display the animation (set to False if only
+        interested in saving the animation frames).
+    nloops: int, optional
+        The number of loops in the animation.
+    time_wait: float, optional
+        The time in seconds between one frame and the next. Applicable
+        if display_animation is True.
+    savefig: bool, optional
+        If set to True, save the individual frames into path_outputs.
+    fig_dpi: float, optional
+        The resolution in dots per inch. Applicable if savefig is True.
+    path_outputs: string, optional
+        Path to folder where to save the frames. Applicable if savefig is True.
+
+    Other parameters
+    ----------------
+    precip_kwargs: dict, optional
+        Optional parameters that are supplied to
+        :py:func:`pysteps.visualization.precipfields.plot_precip_field`.
+    motion_kwargs: dict, optional
+        Optional parameters that are supplied to
+        :py:func:`pysteps.visualization.motionfields.quiver` or
         :py:func:`pysteps.visualization.motionfields.streamplot`.
+    map_kwargs: dict, optional
+        Optional parameters that need to be passed to
+        :py:func:`pysteps.visualization.basemaps.plot_geography`.
 
     Returns
     -------
-    ax: fig axes
-        Figure axes. Needed if one wants to add e.g. text inside the plot.
+    None
     """
+    
+    if precip_kwargs is None:
+        precip_kwargs = {}
 
-    if timestamps is not None:
-        startdate_str = timestamps[-1].strftime("%Y%m%d%H%M")
-    else:
-        startdate_str = None
+    if motion_kwargs is None:
+        motion_kwargs = {}
 
-    if R_fct is not None:
-        if len(R_fct.shape) == 3:
-            R_fct = R_fct[None, :, :, :]
+    if map_kwargs is None:
+        map_kwargs = {}
 
-    if R_fct is not None:
-        n_lead_times = R_fct.shape[1]
-        n_members = R_fct.shape[0]
+    if precip_fct is not None:
+        if len(precip_fct.shape) == 3:
+            precip_fct = precip_fct[None, ...]
+        n_lead_times = precip_fct.shape[1]
+        n_members = precip_fct.shape[0]
     else:
         n_lead_times = 0
         n_members = 1
 
-    if type == "prob" and prob_thr is None:
-        raise ValueError("type 'prob' needs a prob_thr value")
+    if title is not None and isinstance(title, str):
+        title_first_line = title + "\n"
+    else:
+        title_first_line = ""
 
-    if type != "ensemble":
+    if motion_plot not in MOTION_VALID_METHODS:
+        raise ValueError(
+            f"Invalid motion plot method '{motion_plot}'."
+            f"Supported: {str(MOTION_VALID_METHODS)}"
+        )
+
+    if ptype not in PRECIP_VALID_TYPES:
+        raise ValueError(
+            f"Invalid precipitation type '{ptype}'."
+            f"Supported: {str(PRECIP_VALID_TYPES)}"
+        )
+
+    # TODO: remove in version >= 1.6
+    if "type" in kwargs:
+        warnings.warn(
+            "The 'type' keyword will be deprecated in version 1.6. "
+            "Use 'ptype' instead."
+        )
+        ptype = kwargs.get("type")
+        
+    # TODO: remove in version >= 1.6
+    if "timestamps" in kwargs:
+        warnings.warn(
+            "The 'timestamps' keyword will be deprecated in version 1.6. "
+            "Use 'timestamps_obs' instead."
+        )
+        timestamps_obs = kwargs.get("timestamps")
+        
+    # TODO: remove in version >= 1.6
+    if "plotanimation" in kwargs:
+        warnings.warn(
+            "The 'plotanimation' keyword will be deprecated in version 1.6. "
+            "Use 'display_animation' instead."
+        )
+        display_animation = kwargs.get("timestamps")
+
+    # TODO: remove in version >= 1.6
+    for depr_key in PRECIP_DEPRECATED_ARGUMENTS:
+        if depr_key in kwargs:
+            warnings.warn(
+                f"The {depr_key} argument will be deprecated in version 1.6. "
+                "Add it to 'precip_kwargs' instead."
+            )
+            precip_kwargs[depr_key] = kwargs.get(depr_key)
+
+    if timestamps_obs is not None:
+        if len(timestamps_obs) != precip_obs.shape[0]:
+            raise ValueError(
+                f"The number of timestamps does not match the size of precip_obs: "
+                f"{len(timestamps_obs)} != {precip_obs.shape[0]}"
+            )
+        if precip_fct is not None:
+            reftime_str = timestamps_obs[-1].strftime("%Y%m%d%H%M")
+        else:
+            reftime_str = timestamps_obs[0].strftime("%Y%m%d%H%M")
+    else:
+        reftime_str = None
+
+    if ptype == "prob" and prob_thr is None:
+        raise ValueError("ptype 'prob' needs a prob_thr value")
+
+    if ptype != "ensemble":
         n_members = 1
 
-    n_obs = R_obs.shape[0]
+    n_obs = precip_obs.shape[0]
 
     loop = 0
     while loop < nloops:
@@ -162,129 +238,104 @@ def animate(
                 plt.clf()
 
                 # Observations
-                if i < n_obs and (plotanimation or n == 0):
+                if i < n_obs and (display_animation or n == 0):
 
-                    title = ""
-                    if timestamps is not None:
-                        title += timestamps[i].strftime("%Y-%m-%d %H:%M\n")
+                    title = title_first_line + "Analysis"
+                    if timestamps_obs is not None:
+                        title += f" valid for {timestamps_obs[i].strftime('%Y-%m-%d %H:%M')}"
 
                     plt.clf()
-                    if type == "prob":
-                        title += "Observed Probability"
-                        R_obs_ = R_obs[np.newaxis, ::]
-                        P_obs = st.postprocessing.ensemblestats.excprob(
-                            R_obs_[:, i, :, :], prob_thr
+                    if ptype == "prob":
+                        prob_field = st.postprocessing.ensemblestats.excprob(
+                            precip_obs[None, i, ...], prob_thr
                         )
                         ax = st.plt.plot_precip_field(
-                            P_obs,
-                            type="prob",
+                            prob_field,
+                            ptype="prob",
                             geodata=geodata,
-                            units=units,
                             probthr=prob_thr,
                             title=title,
                             map_kwargs=map_kwargs,
+                            **precip_kwargs,
                         )
                     else:
-                        title += "Observed Rainfall"
                         ax = st.plt.plot_precip_field(
-                            R_obs[i, :, :],
+                            precip_obs[i, :, :],
                             geodata=geodata,
-                            units=units,
-                            colorscale=colorscale,
                             title=title,
-                            colorbar=colorbar,
                             map_kwargs=map_kwargs,
+                            **precip_kwargs,
                         )
 
-                    if UV is not None and motion_plot is not None:
-                        if motion_plot.lower() == "quiver":
-                            st.plt.quiver(UV, ax=ax, geodata=geodata, **motion_kwargs)
-                        elif motion_plot.lower() == "streamplot":
+                    if motion_field is not None:
+                        if motion_plot == "quiver":
+                            st.plt.quiver(motion_field, ax=ax, geodata=geodata, **motion_kwargs)
+                        elif motion_plot == "streamplot":
                             st.plt.streamplot(
-                                UV, ax=ax, geodata=geodata, **motion_kwargs
+                                motion_field, ax=ax, geodata=geodata, **motion_kwargs
                             )
 
                     if savefig & (loop == 0):
-                        if type == "prob":
-                            figname = os.path.join(
-                                "%s, %s_frame_%02d_binmap_%.1f.%s"
-                                % (path_outputs, startdate_str, i, prob_thr, fig_format)
-                            )
-                        else:
-                            figname = os.path.join(
-                                "%s, %s_frame_%02d.%s"
-                                % (path_outputs, startdate_str, i, fig_format)
-                            )
-                        plt.savefig(figname, bbox_inches="tight", dpi=fig_dpi)
-                        print(figname, "saved.")
+                        figtags = [reftime_str, ptype, f"f{i:02d}"]
+                        figname = "_".join([tag for tag in figtags if tag])
+                        filename = os.path.join(path_outputs, f"{figname}.{fig_format}")
+                        plt.savefig(filename, bbox_inches="tight", dpi=fig_dpi)
+                        print("saved: ", filename)
 
                 # Forecasts
-                elif i >= n_obs and R_fct is not None:
+                elif i >= n_obs and precip_fct is not None:
 
-                    title = ""
-                    if timestamps is not None:
-                        title += timestamps[-1].strftime("%Y-%m-%d %H:%M\n")
-                    leadtime = "+%02d min" % ((1 + i - n_obs) * timestep_min)
+                    title = title_first_line + "Forecast"
+                    if timestamps_obs is not None:
+                        title += f" valid for {timestamps_obs[-1].strftime('%Y-%m-%d %H:%M')}"
+                    if timestep_min is not None:
+                        title += " +%02d min" % ((1 + i - n_obs) * timestep_min)
+                    else:
+                        title += " +%02d" % (1 + i - n_obs)
 
                     plt.clf()
-                    if type == "prob":
-                        title += "Forecast Probability"
-                        P = st.postprocessing.ensemblestats.excprob(
-                            R_fct[:, i - n_obs, :, :], prob_thr
+                    if ptype == "prob":
+                        prob_field = st.postprocessing.ensemblestats.excprob(
+                            precip_fct[:, i - n_obs, :, :], prob_thr
                         )
                         ax = st.plt.plot_precip_field(
-                            P,
-                            type="prob",
+                            prob_field,
+                            ptype="prob",
                             geodata=geodata,
-                            units=units,
                             probthr=prob_thr,
                             title=title,
                             map_kwargs=map_kwargs,
+                            **precip_kwargs,
                         )
-                    elif type == "mean":
-                        title += "Forecast Ensemble Mean"
-                        EM = st.postprocessing.ensemblestats.mean(
-                            R_fct[:, i - n_obs, :, :]
+                    elif ptype == "mean":
+                        ens_mean = st.postprocessing.ensemblestats.mean(
+                            precip_fct[:, i - n_obs, :, :]
                         )
                         ax = st.plt.plot_precip_field(
-                            EM,
+                            ens_mean,
                             geodata=geodata,
-                            units=units,
                             title=title,
-                            colorscale=colorscale,
-                            colorbar=colorbar,
                             map_kwargs=map_kwargs,
+                            **precip_kwargs,
                         )
                     else:
-                        title += "Forecast Rainfall"
                         ax = st.plt.plot_precip_field(
-                            R_fct[n, i - n_obs, :, :],
+                            precip_fct[n, i - n_obs, ...],
                             geodata=geodata,
-                            units=units,
                             title=title,
-                            colorscale=colorscale,
-                            colorbar=colorbar,
                             map_kwargs=map_kwargs,
+                            **precip_kwargs,
                         )
 
-                    if UV is not None and motion_plot is not None:
-                        if motion_plot.lower() == "quiver":
-                            st.plt.quiver(UV, ax=ax, geodata=geodata, **motion_kwargs)
-                        elif motion_plot.lower() == "streamplot":
+                    if motion_field is not None:
+                        if motion_plot == "quiver":
+                            st.plt.quiver(motion_field, ax=ax, geodata=geodata, **motion_kwargs)
+                        elif motion_plot == "streamplot":
                             st.plt.streamplot(
-                                UV, ax=ax, geodata=geodata, **motion_kwargs
+                                motion_field, ax=ax, geodata=geodata, **motion_kwargs
                             )
 
-                    if leadtime is not None:
-                        plt.text(
-                            0.99,
-                            0.99,
-                            leadtime,
-                            transform=ax.transAxes,
-                            ha="right",
-                            va="top",
-                        )
-                    if type == "ensemble" and n_members > 1:
+                    if ptype == "ensemble" and n_members > 1:
                         plt.text(
                             0.01,
                             0.99,
@@ -295,29 +346,17 @@ def animate(
                         )
 
                     if savefig & (loop == 0):
-                        if type == "prob":
-                            figname = os.path.join(
-                                "%s, %s_frame_%02d_probmap_%.1f.%s"
-                                % (path_outputs, startdate_str, i, prob_thr, fig_format)
-                            )
-                        elif type == "mean":
-                            figname = os.path.join(
-                                "%s, %s_frame_%02d_ensmean.%s"
-                                % (path_outputs, startdate_str, i, fig_format)
-                            )
-                        else:
-                            figname = os.path.join(
-                                "%s, %s_member_%02d_frame_%02d.%s"
-                                % (path_outputs, startdate_str, (n + 1), i, fig_format)
-                            )
-                        plt.savefig(figname, bbox_inches="tight", dpi=fig_dpi)
-                        print(figname, "saved.")
+                        figtags = [reftime_str, ptype, f"f{i:02d}", f"m{n + 1:02d}"]
+                        figname = "_".join([tag for tag in figtags if tag])
+                        filename = os.path.join(path_outputs, f"{figname}.{fig_format}")
+                        plt.savefig(filename, bbox_inches="tight", dpi=fig_dpi)
+                        print("saved: ", filename)
 
-                if plotanimation:
-                    plt.pause(0.2)
+                if display_animation:
+                    plt.pause(time_wait)
 
-            if plotanimation:
-                plt.pause(0.5)
+            if display_animation:
+                plt.pause(2 * time_wait)
 
         loop += 1
 

--- a/pysteps/visualization/animations.py
+++ b/pysteps/visualization/animations.py
@@ -15,7 +15,6 @@ import os
 import warnings
 
 import matplotlib.pylab as plt
-import numpy as np
 import pysteps as st
 
 PRECIP_VALID_TYPES = ("ensemble", "mean", "prob")
@@ -126,11 +125,10 @@ def animate(
         If set to True, save the individual frames into path_outputs.
     fig_dpi: float, optional
         The resolution in dots per inch. Applicable if savefig is True.
+    fig_format: str, optional
+        Filename extension. Applicable if savefig is True.
     path_outputs: string, optional
         Path to folder where to save the frames. Applicable if savefig is True.
-
-    Other parameters
-    ----------------
     precip_kwargs: dict, optional
         Optional parameters that are supplied to
         :py:func:`pysteps.visualization.precipfields.plot_precip_field`.

--- a/pysteps/visualization/basemaps.py
+++ b/pysteps/visualization/basemaps.py
@@ -11,6 +11,7 @@ Methods for plotting geographical maps using Cartopy.
     plot_geography
     plot_map_cartopy
 """
+from cartopy.mpl.geoaxes import GeoAxesSubplot
 from matplotlib import gridspec
 import matplotlib.pylab as plt
 import numpy as np
@@ -33,7 +34,18 @@ except ImportError:
 
 from . import utils
 
-VALID_BASEMAPS = ["cartopy"]
+VALID_BASEMAPS = ("cartopy",)
+
+#########################
+# Basemap features zorder
+# - ocean: 0
+# - land: 0
+# - lakes: 0
+# - rivers_lake_centerlines: 0
+# - coastline: 2
+# - cultural: 2
+# - reefs: 2
+# - minor_islands: 2
 
 
 def plot_geography(
@@ -60,7 +72,7 @@ def plot_geography(
         The PROJ.4-compatible projection string.
     extent: scalars (left, right, bottom, top)
         The bounding box in proj4str coordinates.
-    lw: float, optional
+    lw: float, optional`
         Linewidth of the map (administrative boundaries and coastlines).
     drawlonlatlines: bool, optional
         If set to True, draw longitude and latitude lines.
@@ -113,13 +125,6 @@ def plot_geography(
         )
 
     crs = utils.proj4_to_cartopy(proj4str)
-
-    # Replace current axis
-    if subplot is None:
-        cax = plt.gca()
-        subplot = cax.get_subplotspec()
-        cax.clear()
-        cax.set_axis_off()
 
     ax = plot_map_cartopy(
         crs,
@@ -182,17 +187,18 @@ def plot_map_cartopy(
             " but it is not installed"
         )
 
-    # Replace current axis
     if subplot is None:
-        cax = plt.gca()
-        subplot = cax.get_subplotspec()
-        cax.clear()
-        cax.set_axis_off()
-
-    if isinstance(subplot, gridspec.SubplotSpec):
-        ax = plt.subplot(subplot, projection=crs)
+        ax = plt.gca()
     else:
-        ax = plt.subplot(*subplot, projection=crs)
+        if isinstance(subplot, gridspec.SubplotSpec):
+            ax = plt.subplot(subplot, projection=crs)
+        else:
+            ax = plt.subplot(*subplot, projection=crs)
+
+    if not isinstance(ax, GeoAxesSubplot):
+        ax = plt.subplot(ax.get_subplotspec(), projection=crs)
+        # cax.clear()
+        ax.set_axis_off()
 
     ax.add_feature(
         cfeature.NaturalEarthFeature(

--- a/pysteps/visualization/basemaps.py
+++ b/pysteps/visualization/basemaps.py
@@ -281,12 +281,12 @@ def plot_map_cartopy(
         )
 
     if drawlonlatlines:
-        gl = ax.gridlines(
+        grid_lines = ax.gridlines(
             crs=ccrs.PlateCarree(), draw_labels=drawlonlatlabels, dms=True
         )
-        gl.top_labels = gl.right_labels = False
-        gl.y_inline = gl.x_inline = False
-        gl.rotate_labels = False
+        grid_lines.top_labels = grid_lines.right_labels = False
+        grid_lines.y_inline = grid_lines.x_inline = False
+        grid_lines.rotate_labels = False
 
     ax.set_extent(extent, crs)
 

--- a/pysteps/visualization/basemaps.py
+++ b/pysteps/visualization/basemaps.py
@@ -17,7 +17,6 @@ import numpy as np
 import warnings
 from pysteps.exceptions import MissingOptionalDependency
 
-
 try:
     import cartopy.crs as ccrs
     import cartopy.feature as cfeature
@@ -34,12 +33,19 @@ except ImportError:
 
 from . import utils
 
-
 VALID_BASEMAPS = ["cartopy"]
 
 
 def plot_geography(
-    proj4str, extent, lw=0.5, drawlonlatlines=False, drawlonlatlabels=True, **kwargs
+    proj4str,
+    extent,
+    lw=0.5,
+    drawlonlatlines=False,
+    drawlonlatlabels=True,
+    plot_map="cartopy",
+    scale="50m",
+    subplot=None,
+    **kwargs,
 ):
     """
     Plot geographical map using cartopy_ in a chosen projection.
@@ -61,9 +67,6 @@ def plot_geography(
     drawlonlatlabels: bool, optional
         If set to True, draw longitude and latitude labels.  Valid only if
         'drawlonlatlines' is True.
-
-    Other parameters
-    ----------------
     plot_map: {'cartopy', None}, optional
         The type of basemap, either 'cartopy_' or None. If None, the figure
         axis is returned without any basemap drawn. Default ``'cartopy'``.
@@ -80,7 +83,13 @@ def plot_geography(
         Cartopy axes.
     """
 
-    plot_map = kwargs.get("plot_map", "cartopy")
+    if len(kwargs) > 0:
+        warnings.warn(
+            "plot_geography: The following keywords are ignored:\n"
+            + str(kwargs)
+            + "\nIn version 1.5, passing unsupported arguments will raise an error.",
+            DeprecationWarning,
+        )
 
     if plot_map is None:
         return plt.gca()
@@ -94,35 +103,32 @@ def plot_geography(
     if plot_map == "cartopy" and not CARTOPY_IMPORTED:
         raise MissingOptionalDependency(
             "the cartopy package is required to plot the geographical map "
-            " but it is not installed"
+            "but it is not installed"
         )
 
     if not PYPROJ_IMPORTED:
         raise MissingOptionalDependency(
-            "the pyproj package is required to plot the geographical map"
+            "the pyproj package is required to plot the geographical map "
             "but it is not installed"
         )
 
-    # if plot_map == "cartopy": # not really an option for the moment
-    cartopy_scale = kwargs.get("scale", "50m")
-    cartopy_subplot = kwargs.get("subplot", None)
     crs = utils.proj4_to_cartopy(proj4str)
 
     # Replace current axis
-    if cartopy_subplot is None:
+    if subplot is None:
         cax = plt.gca()
-        cartopy_subplot = cax.get_subplotspec()
+        subplot = cax.get_subplotspec()
         cax.clear()
         cax.set_axis_off()
 
     ax = plot_map_cartopy(
         crs,
         extent,
-        cartopy_scale,
+        scale,
         drawlonlatlines=drawlonlatlines,
         drawlonlatlabels=drawlonlatlabels,
         lw=lw,
-        subplot=cartopy_subplot,
+        subplot=subplot,
     )
 
     return ax

--- a/pysteps/visualization/basemaps.py
+++ b/pysteps/visualization/basemaps.py
@@ -11,7 +11,7 @@ Methods for plotting geographical maps using Cartopy.
     plot_geography
     plot_map_cartopy
 """
-from cartopy.mpl.geoaxes import GeoAxesSubplot
+
 from matplotlib import gridspec
 import matplotlib.pylab as plt
 import numpy as np
@@ -21,6 +21,7 @@ from pysteps.exceptions import MissingOptionalDependency
 try:
     import cartopy.crs as ccrs
     import cartopy.feature as cfeature
+    from cartopy.mpl.geoaxes import GeoAxesSubplot
 
     CARTOPY_IMPORTED = True
 except ImportError:
@@ -35,6 +36,7 @@ except ImportError:
 from . import utils
 
 VALID_BASEMAPS = ("cartopy",)
+
 
 #########################
 # Basemap features zorder
@@ -142,7 +144,7 @@ def plot_geography(
 def plot_map_cartopy(
     crs,
     extent,
-    scale,
+    cartopy_scale,
     drawlonlatlines=False,
     drawlonlatlabels=True,
     lw=0.5,
@@ -167,7 +169,7 @@ def plot_map_cartopy(
     drawlonlatlabels: bool, optional
         If set to True, draw longitude and latitude labels. Valid only if
         'drawlonlatlines' is True.
-    scale: {'10m', '50m', '110m'}
+    cartopy_scale: {'10m', '50m', '110m'}
         The scale (resolution) of the map. The available options are '10m',
         '50m', and '110m'.
     lw: float
@@ -204,7 +206,7 @@ def plot_map_cartopy(
         cfeature.NaturalEarthFeature(
             "physical",
             "ocean",
-            scale="50m" if scale == "10m" else scale,
+            scale="50m" if cartopy_scale == "10m" else cartopy_scale,
             edgecolor="none",
             facecolor=np.array([0.59375, 0.71484375, 0.8828125]),
         ),
@@ -214,7 +216,7 @@ def plot_map_cartopy(
         cfeature.NaturalEarthFeature(
             "physical",
             "land",
-            scale=scale,
+            scale=cartopy_scale,
             edgecolor="none",
             facecolor=np.array([0.9375, 0.9375, 0.859375]),
         ),
@@ -224,7 +226,7 @@ def plot_map_cartopy(
         cfeature.NaturalEarthFeature(
             "physical",
             "coastline",
-            scale=scale,
+            scale=cartopy_scale,
             edgecolor="black",
             facecolor="none",
             linewidth=lw,
@@ -235,7 +237,7 @@ def plot_map_cartopy(
         cfeature.NaturalEarthFeature(
             "physical",
             "lakes",
-            scale=scale,
+            scale=cartopy_scale,
             edgecolor="none",
             facecolor=np.array([0.59375, 0.71484375, 0.8828125]),
         ),
@@ -245,7 +247,7 @@ def plot_map_cartopy(
         cfeature.NaturalEarthFeature(
             "physical",
             "rivers_lake_centerlines",
-            scale=scale,
+            scale=cartopy_scale,
             edgecolor=np.array([0.59375, 0.71484375, 0.8828125]),
             facecolor="none",
         ),
@@ -255,14 +257,14 @@ def plot_map_cartopy(
         cfeature.NaturalEarthFeature(
             "cultural",
             "admin_0_boundary_lines_land",
-            scale=scale,
+            scale=cartopy_scale,
             edgecolor="black",
             facecolor="none",
             linewidth=lw,
         ),
         zorder=2,
     )
-    if scale in ["10m", "50m"]:
+    if cartopy_scale in ["10m", "50m"]:
         ax.add_feature(
             cfeature.NaturalEarthFeature(
                 "physical",

--- a/pysteps/visualization/basemaps.py
+++ b/pysteps/visualization/basemaps.py
@@ -62,9 +62,7 @@ def plot_geography(
     **kwargs,
 ):
     """
-    Plot geographical map using cartopy_ in a chosen projection.
-
-    .. _cartopy: https://scitools.org.uk/cartopy/docs/latest
+    Plot geographical map in a chosen projection using cartopy.
 
     .. _SubplotSpec: https://matplotlib.org/api/_as_gen/matplotlib.gridspec.SubplotSpec.html
 
@@ -82,8 +80,8 @@ def plot_geography(
         If set to True, draw longitude and latitude labels.  Valid only if
         'drawlonlatlines' is True.
     plot_map: {'cartopy', None}, optional
-        The type of basemap, either 'cartopy_' or None. If None, the figure
-        axis is returned without any basemap drawn. Default ``'cartopy'``.
+        The type of basemap, either 'cartopy' or None. If None, the figure
+        axis is returned without any basemap drawn. Default `'cartopy'`.
     scale: {'10m', '50m', '110m'}, optional
         The scale (resolution). Applicable if 'plot_map' is 'cartopy'.
         The available options are '10m', '50m', and '110m'. Default ``'50m'``.
@@ -93,7 +91,7 @@ def plot_geography(
 
     Returns
     -------
-    ax: fig Axes_
+    ax: fig Axes
         Cartopy axes.
     """
 
@@ -115,16 +113,18 @@ def plot_geography(
         )
 
     if plot_map == "cartopy" and not CARTOPY_IMPORTED:
-        raise MissingOptionalDependency(
-            "the cartopy package is required to plot the geographical map "
-            "but it is not installed"
+        warnings.warn(
+            "The cartopy package is required to plot the geographical map but it is "
+            "not installed. Ignoring the geographic information."
         )
+        return plt.gca()
 
     if not PYPROJ_IMPORTED:
-        raise MissingOptionalDependency(
+        warnings.warn(
             "the pyproj package is required to plot the geographical map "
             "but it is not installed"
         )
+        return plt.gca()
 
     crs = utils.proj4_to_cartopy(proj4str)
 
@@ -151,9 +151,7 @@ def plot_map_cartopy(
     subplot=None,
 ):
     """
-    Plot coastlines, countries, rivers and meridians/parallels using cartopy_.
-
-    .. _cartopy: https://scitools.org.uk/cartopy/docs/latest
+    Plot coastlines, countries, rivers and meridians/parallels using cartopy.
 
     .. _SubplotSpec: https://matplotlib.org/api/_as_gen/matplotlib.gridspec.SubplotSpec.html
 

--- a/pysteps/visualization/basemaps.py
+++ b/pysteps/visualization/basemaps.py
@@ -44,10 +44,10 @@ VALID_BASEMAPS = ("cartopy",)
 # - land: 0
 # - lakes: 0
 # - rivers_lake_centerlines: 0
-# - coastline: 2
-# - cultural: 2
-# - reefs: 2
-# - minor_islands: 2
+# - coastline: 15
+# - cultural: 15
+# - reefs: 15
+# - minor_islands: 15
 
 
 def plot_geography(
@@ -231,7 +231,7 @@ def plot_map_cartopy(
             facecolor="none",
             linewidth=lw,
         ),
-        zorder=2,
+        zorder=15,
     )
     ax.add_feature(
         cfeature.NaturalEarthFeature(
@@ -262,7 +262,7 @@ def plot_map_cartopy(
             facecolor="none",
             linewidth=lw,
         ),
-        zorder=2,
+        zorder=15,
     )
     if cartopy_scale in ["10m", "50m"]:
         ax.add_feature(
@@ -274,7 +274,7 @@ def plot_map_cartopy(
                 facecolor="none",
                 linewidth=lw,
             ),
-            zorder=2,
+            zorder=15,
         )
         ax.add_feature(
             cfeature.NaturalEarthFeature(
@@ -285,7 +285,7 @@ def plot_map_cartopy(
                 facecolor="none",
                 linewidth=lw,
             ),
-            zorder=2,
+            zorder=15,
         )
 
     if drawlonlatlines:

--- a/pysteps/visualization/motionfields.py
+++ b/pysteps/visualization/motionfields.py
@@ -8,6 +8,7 @@ Functions to plot motion fields.
 .. autosummary::
     :toctree: ../generated/
 
+    motion_plot
     quiver
     streamplot
 """
@@ -25,9 +26,9 @@ VALID_PLOT_TYPES = ("quiver", "streamplot", "stream")
 # - stream function: 30
 
 
-def _quiver_or_streamplot(
+def motion_plot(
     uv_motion_field,
-    plot_type,
+    plot_type="quiver",
     ax=None,
     geodata=None,
     axis="on",
@@ -35,6 +36,69 @@ def _quiver_or_streamplot(
     map_kwargs=None,
     step=20,
 ):
+    """
+    Function to plot a motion field as arrows (quiver) or as stream lines (streamplot).
+
+    .. _cartopy: https://scitools.org.uk/cartopy/docs/latest/
+    .. _SubplotSpec: https://matplotlib.org/api/_as_gen/matplotlib.gridspec.SubplotSpec.html
+    .. _quiver_doc: https://matplotlib.org/api/_as_gen/matplotlib.pyplot.quiver.htm
+    .. _streamplot_doc: https://matplotlib.org/api/_as_gen/matplotlib.pyplot.streamplot.html
+
+    Parameters
+    ----------
+    uv_motion_field: array-like
+        Array of shape (2,m,n) containing the input motion field.
+    plot_type: str
+        Plot type. "quiver" or "streamplot".
+    ax: axis object
+        Optional axis object to use for plotting.
+    geodata: dictionary or None
+        Optional dictionary containing geographical information about
+        the field.
+
+        If geodata is not None, it must contain the following key-value pairs:
+
+        .. tabularcolumns:: |p{1.5cm}|L|
+
+        +----------------+----------------------------------------------------+
+        |        Key     |                  Value                             |
+        +================+====================================================+
+        |   projection   | PROJ.4-compatible projection definition            |
+        +----------------+----------------------------------------------------+
+        |    x1          | x-coordinate of the lower-left corner of the data  |
+        |                | raster                                             |
+        +----------------+----------------------------------------------------+
+        |    y1          | y-coordinate of the lower-left corner of the data  |
+        |                | raster                                             |
+        +----------------+----------------------------------------------------+
+        |    x2          | x-coordinate of the upper-right corner of the data |
+        |                | raster                                             |
+        +----------------+----------------------------------------------------+
+        |    y2          | y-coordinate of the upper-right corner of the data |
+        |                | raster                                             |
+        +----------------+----------------------------------------------------+
+        |    yorigin     | a string specifying the location of the first      |
+        |                | element in the data raster w.r.t. y-axis:          |
+        |                | 'upper' = upper border, 'lower' = lower border     |
+        +----------------+----------------------------------------------------+
+    axis: {'off','on'}, optional
+        Whether to turn off or on the x and y axis.
+    step: int
+        Optional resample step to control the density of the arrows.
+    plot_kwargs: dict, optional
+      Optional dictionary containing keyword arguments passed to `quiver()` or
+      `streamplot`.
+      For more information, see the quiver_doc_ and stream_plot_doc_ matplotlib's
+      documentation.
+    map_kwargs: dict
+        Optional parameters that need to be passed to
+        :py:func:`pysteps.visualization.basemaps.plot_geography`.
+
+    Returns
+    -------
+    out: axis object
+        Figure axes. Needed if one wants to add e.g. text inside the plot.
+    """
     if plot_type not in VALID_PLOT_TYPES:
         raise ValueError(
             f"Invalid plot_type: {plot_type}.\nSupported: {str(VALID_PLOT_TYPES)}"
@@ -91,65 +155,34 @@ def quiver(
     map_kwargs=None,
 ):
     """Function to plot a motion field as arrows.
+    Wrapper for :func:`pysteps.motionfields.motion_plot` with  `plot_type="quiver"`.
 
-    .. _cartopy: https://scitools.org.uk/cartopy/docs/latest/
-    .. _SubplotSpec: https://matplotlib.org/api/_as_gen/matplotlib.gridspec.SubplotSpec.html?highlight=subplotspec#matplotlib.gridspec.SubplotSpec
+    .. _quiver_doc: https://matplotlib.org/api/_as_gen/matplotlib.pyplot.quiver.htm
 
     Parameters
     ----------
     uv_motion_field: array-like
-        Array of shape (2,m,n) containing the input motion field.
-    ax: axis object
-        Optional axis object to use for plotting.
-    geodata: dictionary or None
-        Optional dictionary containing geographical information about
-        the field.
-
-        If geodata is not None, it must contain the following key-value pairs:
-
-        .. tabularcolumns:: |p{1.5cm}|L|
-
-        +----------------+----------------------------------------------------+
-        |        Key     |                  Value                             |
-        +================+====================================================+
-        |   projection   | PROJ.4-compatible projection definition            |
-        +----------------+----------------------------------------------------+
-        |    x1          | x-coordinate of the lower-left corner of the data  |
-        |                | raster                                             |
-        +----------------+----------------------------------------------------+
-        |    y1          | y-coordinate of the lower-left corner of the data  |
-        |                | raster                                             |
-        +----------------+----------------------------------------------------+
-        |    x2          | x-coordinate of the upper-right corner of the data |
-        |                | raster                                             |
-        +----------------+----------------------------------------------------+
-        |    y2          | y-coordinate of the upper-right corner of the data |
-        |                | raster                                             |
-        +----------------+----------------------------------------------------+
-        |    yorigin     | a string specifying the location of the first      |
-        |                | element in the data raster w.r.t. y-axis:          |
-        |                | 'upper' = upper border, 'lower' = lower border     |
-        +----------------+----------------------------------------------------+
-    axis: {'off','on'}, optional
-        Whether to turn off or on the x and y axis.
-    step: int
-        Optional resample step to control the density of the arrows.
+        Array of shape (2, m,n) containing the input motion field.
     quiver_kwargs: dict, optional
       Optional dictionary containing keyword arguments for the quiver method.
-      See the documentation of matplotlib.pyplot.quiver.
-    map_kwargs: dict
-        Optional parameters that need to be passed to
-        :py:func:`pysteps.visualization.basemaps.plot_geography`.
+      This argument is passed to
+      See the quiver_doc_ matplotlib's documentation.
+
+    Other parameters
+    ----------------
+    See :func:`pysteps.motionfields.motion_plot`.
 
     Returns
     -------
     out: axis object
         Figure axes. Needed if one wants to add e.g. text inside the plot.
     """
+    if quiver_kwargs is None:
+        quiver_kwargs = dict()
 
-    return _quiver_or_streamplot(
+    return motion_plot(
         uv_motion_field,
-        "quiver",
+        plot_type="quiver",
         ax=ax,
         geodata=geodata,
         axis=axis,
@@ -169,58 +202,22 @@ def streamplot(
     step=20,
 ):
     """Function to plot a motion field as streamlines.
+    Wrapper for :func:`pysteps.motionfields.motion_plot` with `plot_type="streamplot"`.
 
-    .. _SubplotSpec: https://matplotlib.org/api/_as_gen/matplotlib.gridspec.SubplotSpec.html?highlight=subplotspec#matplotlib.gridspec.SubplotSpec
-    .. _cartopy: https://scitools.org.uk/cartopy/docs/latest/
+    .. _streamplot_doc: https://matplotlib.org/api/_as_gen/matplotlib.pyplot.streamplot.html
 
     Parameters
     ----------
     uv_motion_field: array-like
         Array of shape (2, m,n) containing the input motion field.
-    ax: axis object
-        Optional axis object to use for plotting.
-    geodata: dictionary or None
-        Optional dictionary containing geographical information about
-        the field.
-        If geodata is not None, it must contain the following key-value pairs:
-
-        .. tabularcolumns:: |p{1.5cm}|L|
-
-        +----------------+----------------------------------------------------+
-        |        Key     |                  Value                             |
-        +================+====================================================+
-        |   projection   | PROJ.4-compatible projection definition            |
-        +----------------+----------------------------------------------------+
-        |    x1          | x-coordinate of the lower-left corner of the data  |
-        |                | raster                                             |
-        +----------------+----------------------------------------------------+
-        |    y1          | y-coordinate of the lower-left corner of the data  |
-        |                | raster                                             |
-        +----------------+----------------------------------------------------+
-        |    x2          | x-coordinate of the upper-right corner of the data |
-        |                | raster                                             |
-        +----------------+----------------------------------------------------+
-        |    y2          | y-coordinate of the upper-right corner of the data |
-        |                | raster                                             |
-        +----------------+----------------------------------------------------+
-        |    yorigin     | a string specifying the location of the first      |
-        |                | element in the data raster w.r.t. y-axis:          |
-        |                | 'upper' = upper border, 'lower' = lower border     |
-        +----------------+----------------------------------------------------+
-    axis: {'off','on'}, optional
-        Whether to turn off or on the x and y axis.
-    step: int
-        Optional resample step to control the number of grid points used to compute the
-        stream function.
     streamplot_kwargs: dict, optional
-      Optional dictionary containing keyword arguments for the streamplot method.
-      See the documentation of matplotlib.pyplot.streamplot.
+      Optional dictionary containing keyword arguments for the quiver method.
+      This argument is passed to
+      See the quiver_doc_ matplotlib's documentation.
 
     Other parameters
     ----------------
-    map_kwargs: dict
-        Optional parameters that need to be passed to
-        :py:func:`pysteps.visualization.basemaps.plot_geography`.
+    See :func:`pysteps.motionfields.motion_plot`.
 
     Returns
     -------
@@ -228,9 +225,12 @@ def streamplot(
         Figure axes. Needed if one wants to add e.g. text inside the plot.
     """
 
-    return _quiver_or_streamplot(
+    if streamplot_kwargs is None:
+        streamplot_kwargs = dict()
+
+    return motion_plot(
         uv_motion_field,
-        "streamplot",
+        plot_type="streamplot",
         ax=ax,
         geodata=geodata,
         axis=axis,

--- a/pysteps/visualization/motionfields.py
+++ b/pysteps/visualization/motionfields.py
@@ -130,6 +130,9 @@ def motion_plot(
     else:
         ax.streamplot(x_grid, y_grid, dx, dy, zorder=30, **plot_kwargs)
 
+    # Quiver sometimes do not produce tight axes
+    ax.autoscale(enable=True, axis="both", tight=True)
+
     if geodata is None or axis == "off":
         ax.xaxis.set_ticks([])
         ax.xaxis.set_ticklabels([])

--- a/pysteps/visualization/motionfields.py
+++ b/pysteps/visualization/motionfields.py
@@ -13,8 +13,6 @@ Functions to plot motion fields.
     streamplot
 """
 
-import numpy as np
-
 from pysteps.visualization import utils
 
 VALID_PLOT_TYPES = ("quiver", "streamplot", "stream")

--- a/pysteps/visualization/motionfields.py
+++ b/pysteps/visualization/motionfields.py
@@ -31,9 +31,9 @@ def _quiver_or_streamplot(
     ax=None,
     geodata=None,
     axis="on",
-    step=20,
     plot_kwargs=None,
     map_kwargs=None,
+    step=20,
 ):
     if plot_type not in VALID_PLOT_TYPES:
         raise ValueError(
@@ -170,9 +170,9 @@ def streamplot(
     ax=None,
     geodata=None,
     axis="on",
-    step=20,
     streamplot_kwargs=None,
     map_kwargs=None,
+    step=20,
 ):
     """Function to plot a motion field as streamlines.
 

--- a/pysteps/visualization/motionfields.py
+++ b/pysteps/visualization/motionfields.py
@@ -48,7 +48,7 @@ def _quiver_or_streamplot(
     # Assumes the input dimensions are lat/lon
     _, nlat, nlon = uv_motion_field.shape
 
-    x_grid, y_grid, extent, _, origin = utils.get_geogrid(nlat, nlon, geodata=geodata)
+    x_grid, y_grid, extent, _, _ = utils.get_geogrid(nlat, nlon, geodata=geodata)
 
     ax = utils.get_basemap_axis(extent, ax=ax, geodata=geodata, map_kwargs=map_kwargs)
 

--- a/pysteps/visualization/motionfields.py
+++ b/pysteps/visualization/motionfields.py
@@ -48,9 +48,7 @@ def _quiver_or_streamplot(
     # Assumes the input dimensions are lat/lon
     _, nlat, nlon = uv_motion_field.shape
 
-    x_grid, y_grid, extent, regular_grid, origin = utils.get_geogrid(
-        nlat, nlon, geodata=geodata
-    )
+    x_grid, y_grid, extent, _, origin = utils.get_geogrid(nlat, nlon, geodata=geodata)
 
     ax = utils.get_basemap_axis(extent, ax=ax, geodata=geodata, map_kwargs=map_kwargs)
 

--- a/pysteps/visualization/motionfields.py
+++ b/pysteps/visualization/motionfields.py
@@ -139,10 +139,6 @@ def quiver(
     quiver_kwargs: dict, optional
       Optional dictionary containing keyword arguments for the quiver method.
       See the documentation of matplotlib.pyplot.quiver.
-
-
-    Other parameters
-    ----------------
     map_kwargs: dict
         Optional parameters that need to be passed to
         :py:func:`pysteps.visualization.basemaps.plot_geography`.

--- a/pysteps/visualization/motionfields.py
+++ b/pysteps/visualization/motionfields.py
@@ -157,7 +157,7 @@ def quiver(
     Wrapper for :func:`pysteps.visualization.motionfields.motion_plot` passing
     `plot_type="quiver"`.
 
-    .. _`quiver_doc`: https://matplotlib.org/api/_as_gen/matplotlib.pyplot.quiver.htm
+    .. _`quiver_doc`: https://matplotlib.org/api/_as_gen/matplotlib.pyplot.quiver.html
 
     Parameters
     ----------

--- a/pysteps/visualization/motionfields.py
+++ b/pysteps/visualization/motionfields.py
@@ -39,10 +39,9 @@ def motion_plot(
     """
     Function to plot a motion field as arrows (quiver) or as stream lines (streamplot).
 
-    .. _cartopy: https://scitools.org.uk/cartopy/docs/latest/
-    .. _SubplotSpec: https://matplotlib.org/api/_as_gen/matplotlib.gridspec.SubplotSpec.html
-    .. _quiver_doc: https://matplotlib.org/api/_as_gen/matplotlib.pyplot.quiver.htm
-    .. _streamplot_doc: https://matplotlib.org/api/_as_gen/matplotlib.pyplot.streamplot.html
+    .. _`quiver_doc`: https://matplotlib.org/api/_as_gen/matplotlib.pyplot.quiver.htm
+
+    .. _`streamplot_doc`: https://matplotlib.org/api/_as_gen/matplotlib.pyplot.streamplot.html
 
     Parameters
     ----------
@@ -88,7 +87,7 @@ def motion_plot(
     plot_kwargs: dict, optional
       Optional dictionary containing keyword arguments passed to `quiver()` or
       `streamplot`.
-      For more information, see the quiver_doc_ and stream_plot_doc_ matplotlib's
+      For more information, see the `quiver_doc`_ and `streamplot_doc`_ matplotlib's
       documentation.
     map_kwargs: dict
         Optional parameters that need to be passed to
@@ -155,9 +154,10 @@ def quiver(
     map_kwargs=None,
 ):
     """Function to plot a motion field as arrows.
-    Wrapper for :func:`pysteps.motionfields.motion_plot` with  `plot_type="quiver"`.
+    Wrapper for :func:`pysteps.visualization.motionfields.motion_plot` passing
+    `plot_type="quiver"`.
 
-    .. _quiver_doc: https://matplotlib.org/api/_as_gen/matplotlib.pyplot.quiver.htm
+    .. _`quiver_doc`: https://matplotlib.org/api/_as_gen/matplotlib.pyplot.quiver.htm
 
     Parameters
     ----------
@@ -166,15 +166,15 @@ def quiver(
     quiver_kwargs: dict, optional
       Optional dictionary containing keyword arguments for the quiver method.
       This argument is passed to
-      See the quiver_doc_ matplotlib's documentation.
+      See the `quiver_doc`_ matplotlib's documentation.
 
     Other parameters
     ----------------
-    See :func:`pysteps.motionfields.motion_plot`.
+    See :py::func:`pysteps.visualization.motionfields.motion_plot`.
 
     Returns
     -------
-    out: axis object
+    out: axis object0
         Figure axes. Needed if one wants to add e.g. text inside the plot.
     """
     if quiver_kwargs is None:
@@ -202,9 +202,10 @@ def streamplot(
     step=20,
 ):
     """Function to plot a motion field as streamlines.
-    Wrapper for :func:`pysteps.motionfields.motion_plot` with `plot_type="streamplot"`.
+    Wrapper for :func:`pysteps.visualization.motionfields.motion_plot` passing
+    `plot_type="streamplot"`.
 
-    .. _streamplot_doc: https://matplotlib.org/api/_as_gen/matplotlib.pyplot.streamplot.html
+    .. _`streamplot_doc`: https://matplotlib.org/api/_as_gen/matplotlib.pyplot.streamplot.html
 
     Parameters
     ----------
@@ -213,11 +214,11 @@ def streamplot(
     streamplot_kwargs: dict, optional
       Optional dictionary containing keyword arguments for the quiver method.
       This argument is passed to
-      See the quiver_doc_ matplotlib's documentation.
+      See the `streamplot_doc`_ matplotlib's documentation.
 
     Other parameters
     ----------------
-    See :func:`pysteps.motionfields.motion_plot`.
+    See :py:func:`pysteps.visualization.motionfields.motion_plot`.
 
     Returns
     -------

--- a/pysteps/visualization/motionfields.py
+++ b/pysteps/visualization/motionfields.py
@@ -123,11 +123,8 @@ def motion_plot(
     x_grid = x_grid[skip]
     y_grid = y_grid[skip]
 
-    # The following functions, assume that the yorigin is the bottom left corner since
-    # the x and y grids are constructed using that convention.
-    # If we have yorigin"="upper" we flip the y axes.
+    # If we have yorigin"="upper" we flip the y axes for the motion field in the y axis.
     if geodata is None or geodata["yorigin"] == "upper":
-        y_grid = np.flipud(y_grid)
         dy *= -1
 
     if plot_type.lower() == "quiver":

--- a/pysteps/visualization/precipfields.py
+++ b/pysteps/visualization/precipfields.py
@@ -166,9 +166,6 @@ def plot_precip_field(
     if len(precip.shape) != 2:
         raise ValueError("The input is not two-dimensional array")
 
-    # get colormap and color levels
-    cmap, norm, clevs, clevsStr = get_colormap(ptype, units, colorscale)
-
     # Assumes the input dimensions are lat/lon
     nlat, nlon = precip.shape
 
@@ -181,18 +178,18 @@ def plot_precip_field(
     precip = np.ma.masked_invalid(precip)
     # plot rainfield
     if regular_grid:
-        im = _plot_field(
-            precip, ax, ptype, units, colorscale, extent=extent, origin=origin
-        )
+        im = _plot_field(precip, ax, ptype, units, colorscale, extent, origin=origin)
     else:
         im = _plot_field(
-            precip, ax, ptype, units, colorscale, x_grid=x_grid, y_grid=y_grid
+            precip, ax, ptype, units, colorscale, extent, x_grid=x_grid, y_grid=y_grid
         )
 
     plt.title(title)
 
     # add colorbar
     if colorbar:
+        # get colormap and color levels
+        _, _, clevs, clevs_str = get_colormap(ptype, units, colorscale)
         if ptype in ["intensity", "depth"]:
             extend = "max"
         else:
@@ -200,8 +197,8 @@ def plot_precip_field(
         cbar = plt.colorbar(
             im, ticks=clevs, spacing="uniform", extend=extend, shrink=0.8, cax=cax
         )
-        if clevsStr is not None:
-            cbar.ax.set_yticklabels(clevsStr)
+        if clevs_str is not None:
+            cbar.ax.set_yticklabels(clevs_str)
 
         if ptype == "intensity":
             cbar.ax.set_title(units, fontsize=10)

--- a/pysteps/visualization/precipfields.py
+++ b/pysteps/visualization/precipfields.py
@@ -220,16 +220,6 @@ def _plot_field(
     # Get colormap and color levels
     cmap, norm, _, _ = get_colormap(ptype, units, colorscale)
 
-    # Plot precipitation field
-    # transparent where no precipitation or the probability is zero
-    if ptype in ["intensity", "depth"]:
-        if units in ["mm/h", "mm"]:
-            precip[precip < 0.1] = -100
-        elif units == "dBZ":
-            precip[precip < 10] = -100
-    else:
-        precip[precip < 1e-3] = -100
-
     if (x_grid is None) or (y_grid is None):
         im = ax.imshow(
             precip,
@@ -307,7 +297,12 @@ def get_colormap(ptype, units="mm/h", colorscale="pysteps"):
     if ptype == "prob":
         cmap = copy.copy(plt.get_cmap("OrRd", 10))
         cmap.set_bad("gray", alpha=0.5)
-        return cmap, colors.Normalize(vmin=0, vmax=1), None, None
+        cmap.set_under("white", alpha=0)
+        clevs = np.linspace(0, 1, 11)
+        clevs[0] = 1e-3  # to set zeros to transparent
+        norm = colors.BoundaryNorm(clevs, cmap.N)
+        clevs_str = [f"{clev:.1f}" for clev in clevs]
+        return cmap, norm, clevs, clevs_str
 
     return cm.get_cmap("jet"), colors.Normalize(), None, None
 

--- a/pysteps/visualization/precipfields.py
+++ b/pysteps/visualization/precipfields.py
@@ -11,6 +11,7 @@ Methods for plotting precipitation fields.
     plot_precip_field
     get_colormap
 """
+import copy
 import warnings
 
 import matplotlib.pylab as plt
@@ -304,7 +305,8 @@ def get_colormap(ptype, units="mm/h", colorscale="pysteps"):
         return cmap, norm, clevs, clevs_str
 
     if ptype == "prob":
-        cmap = plt.get_cmap("OrRd", 10)
+        cmap = copy.copy(plt.get_cmap("OrRd", 10))
+        cmap.set_bad("gray", alpha=0.5)
         return cmap, colors.Normalize(vmin=0, vmax=1), None, None
 
     return cm.get_cmap("jet"), colors.Normalize(), None, None

--- a/pysteps/visualization/precipfields.py
+++ b/pysteps/visualization/precipfields.py
@@ -11,10 +11,13 @@ Methods for plotting precipitation fields.
     plot_precip_field
     get_colormap
 """
+import warnings
 
 import matplotlib.pylab as plt
 from matplotlib import cm, colors  # , gridspec
 import numpy as np
+
+from .utils import get_geogrid, get_basemap_axis
 
 try:
     import pyproj
@@ -27,10 +30,19 @@ from pysteps.exceptions import MissingOptionalDependency, UnsupportedSomercProje
 from . import basemaps
 from . import utils
 
+PRECIP_VALID_TYPES = ("intensity", "depth", "prob")
+PRECIP_VALID_UNITS = ("mm/h", "mm", "dBZ")
+
+
+############################
+# precipitation plots zorder
+# - precipitation: 10
+
 
 def plot_precip_field(
-    R,
-    type="intensity",
+    precip,
+    ptype="intensity",
+    ax=None,
     geodata=None,
     units="mm/h",
     bbox=None,
@@ -41,6 +53,7 @@ def plot_precip_field(
     axis="on",
     cax=None,
     map_kwargs=None,
+    **kwargs,
 ):
     """
     Function to plot a precipitation intensity or probability field with a
@@ -52,10 +65,10 @@ def plot_precip_field(
 
     Parameters
     ----------
-    R: array-like
+    precip: array-like
         Two-dimensional array containing the input precipitation field or an
         exceedance probability map.
-    type: {'intensity', 'depth', 'prob'}, optional
+    ptype: {'intensity', 'depth', 'prob'}, optional
         Type of the map to plot: 'intensity' = precipitation intensity field,
         'depth' = precipitation depth (accumulation) field,
         'prob' = exceedance probability field.
@@ -89,7 +102,7 @@ def plot_precip_field(
         |                 | 'upper' = upper border, 'lower' = lower border    |
         +-----------------+---------------------------------------------------+
     units : {'mm/h', 'mm', 'dBZ'}, optional
-        Units of the input array. If type is 'prob', this specifies the unit of
+        Units of the input array. If ptype is 'prob', this specifies the unit of
         the intensity threshold.
     bbox : tuple, optional
         Four-element tuple specifying the coordinates of the bounding box. Use
@@ -102,7 +115,7 @@ def plot_precip_field(
     probthr : float, optional
         Intensity threshold to show in the color bar of the exceedance
         probability map.
-        Required if type is "prob" and colorbar is True.
+        Required if ptype is "prob" and colorbar is True.
     title : str, optional
         If not None, print the title on top of the plot.
     colorbar : bool, optional
@@ -128,98 +141,64 @@ def plot_precip_field(
     if map_kwargs is None:
         map_kwargs = {}
 
-    if type not in ["intensity", "depth", "prob"]:
-        raise ValueError(
-            "invalid type '%s', must be " + "'intensity', 'depth' or 'prob'" % type
+    if "type" in kwargs:
+        warnings.warn(
+            "The 'type' keyword use to indicate the type of plot will be "
+            "deprecated in version 1.6. Use ptype instead."
         )
-    if units not in ["mm/h", "mm", "dBZ"]:
+        ptype = kwargs.get("ptype")
+
+    if ptype not in PRECIP_VALID_TYPES:
         raise ValueError(
-            "invalid units '%s', must be " + "'mm/h', 'mm' or 'dBZ'" % units
+            f"Invalid precipitation ptype '{ptype}'."
+            f"Supported: {str(PRECIP_VALID_TYPES)}"
         )
-    if type == "prob" and colorbar and probthr is None:
-        raise ValueError("type='prob' but probthr not specified")
-    if len(R.shape) != 2:
-        raise ValueError("the input is not two-dimensional array")
+
+    if units not in PRECIP_VALID_UNITS:
+        raise ValueError(
+            f"Invalid precipitation units '{units}."
+            f"Supported: {str(PRECIP_VALID_UNITS)}"
+        )
+
+    if ptype == "prob" and colorbar and probthr is None:
+        raise ValueError("ptype='prob' but probthr not specified")
+
+    if len(precip.shape) != 2:
+        raise ValueError("The input is not two-dimensional array")
 
     # get colormap and color levels
-    cmap, norm, clevs, clevsStr = get_colormap(type, units, colorscale)
+    cmap, norm, clevs, clevsStr = get_colormap(ptype, units, colorscale)
 
-    # extract extent and origin
-    if geodata is not None:
-        field_extent = (geodata["x1"], geodata["x2"], geodata["y1"], geodata["y2"])
-        if bbox is None:
-            bm_extent = field_extent
-        else:
-            if not PYPROJ_IMPORTED:
-                raise MissingOptionalDependency(
-                    "pyproj package is required to plot "
-                    "georeferenced precipitation fields "
-                    "but it is not installed"
-                )
-            pr = pyproj.Proj(geodata["projection"])
-            x1, y1 = pr(bbox[0], bbox[1])
-            x2, y2 = pr(bbox[2], bbox[3])
-            bm_extent = (x1, x2, y1, y2)
-        origin = geodata["yorigin"]
-    else:
-        field_extent = (0, R.shape[1] - 1, 0, R.shape[0] - 1)
-        origin = "upper"
+    # Assumes the input dimensions are lat/lon
+    nlat, nlon = precip.shape
 
-    # plot geography
-    if geodata is not None:
-        try:
-            ax = basemaps.plot_geography(geodata["projection"], bm_extent, **map_kwargs)
-            regular_grid = True
-        except MissingOptionalDependency as e:
-            # Cartopy is not installed
-            print(f"{e.__class__}: {e}")
-            ax = plt.gca()
-            regular_grid = True
-        except UnsupportedSomercProjection:
-            # Define default fall-back projection for Swiss data(EPSG:3035)
-            # This will work reasonably well for Europe only.
-            t_proj4str = "+proj=laea +lat_0=52 +lon_0=10 "
-            t_proj4str += "+x_0=4321000 +y_0=3210000 +ellps=GRS80 "
-            t_proj4str += "+units=m +no_defs"
-            geodata = utils.reproject_geodata(
-                geodata, t_proj4str, return_grid="quadmesh"
-            )
-            bm_extent = (geodata["x1"], geodata["x2"], geodata["y1"], geodata["y2"])
-            X, Y = geodata["X_grid"], geodata["Y_grid"]
-            regular_grid = geodata["regular_grid"]
+    x_grid, y_grid, extent, regular_grid, origin = get_geogrid(
+        nlat, nlon, geodata=geodata
+    )
 
-            ax = basemaps.plot_geography(geodata["projection"], bm_extent, **map_kwargs)
-
-    else:
-        ax = plt.gca()
-        regular_grid = True
-
-    if bbox is not None and geodata is not None:
-        x1, y1 = pr(geodata["x1"], geodata["y1"], inverse=True)
-        x2, y2 = pr(geodata["x2"], geodata["y2"], inverse=True)
-        x1, y1 = pr(x1, y1)
-        x2, y2 = pr(x2, y2)
-        field_extent = (x1, x2, y1, y2)
+    ax = get_basemap_axis(extent, ax=ax, geodata=geodata, map_kwargs=map_kwargs)
 
     # plot rainfield
     if regular_grid:
         im = _plot_field(
-            R, ax, type, units, colorscale, extent=field_extent, origin=origin
+            precip, ax, ptype, units, colorscale, extent=extent, origin=origin
         )
     else:
         if origin == "upper":
-            Y = np.flipud(Y)
-        im = _plot_field_pcolormesh(X, Y, R, ax, type, units, colorscale)
+            y_grid = np.flipud(y_grid)
+        im = _plot_field_pcolormesh(
+            x_grid, y_grid, precip, ax, ptype, units, colorscale
+        )
 
     # plot radar domain mask
-    mask = np.ones(R.shape)
-    mask[~np.isnan(R)] = np.nan  # Fully transparent within the radar domain
+    mask = np.ones(precip.shape)
+    mask[~np.isnan(precip)] = np.nan  # Fully transparent within the radar domain
     ax.imshow(
         mask,
         cmap=colors.ListedColormap(["gray"]),
         alpha=0.5,
-        zorder=1e6,
-        extent=field_extent,
+        zorder=10,
+        extent=extent,
         origin=origin,
     )
 
@@ -228,12 +207,11 @@ def plot_precip_field(
     #               alpha=0.5, zorder=1e6)
     # TODO: pcolormesh doesn't work properly with the alpha parameter
 
-    if title is not None:
-        plt.title(title)
+    plt.title(title)
 
     # add colorbar
     if colorbar:
-        if type in ["intensity", "depth"]:
+        if ptype in ["intensity", "depth"]:
             extend = "max"
         else:
             extend = "neither"
@@ -243,10 +221,10 @@ def plot_precip_field(
         if clevsStr is not None:
             cbar.ax.set_yticklabels(clevsStr)
 
-        if type == "intensity":
+        if ptype == "intensity":
             cbar.ax.set_title(units, fontsize=10)
             cbar.set_label("Precipitation intensity")
-        elif type == "depth":
+        elif ptype == "depth":
             cbar.ax.set_title(units, fontsize=10)
             cbar.set_label("Precipitation depth")
         else:
@@ -265,69 +243,71 @@ def plot_precip_field(
     return ax
 
 
-def _plot_field(R, ax, type, units, colorscale, extent, origin=None):
-    R = R.copy()
+def _plot_field(precip, ax, ptype, units, colorscale, extent, origin=None):
+    precip = precip.copy()
 
     # Get colormap and color levels
-    cmap, norm, clevs, clevsStr = get_colormap(type, units, colorscale)
+    cmap, norm, clevs, clevsStr = get_colormap(ptype, units, colorscale)
 
     # Plot precipitation field
     # transparent where no precipitation or the probability is zero
-    if type in ["intensity", "depth"]:
+    if ptype in ["intensity", "depth"]:
         if units in ["mm/h", "mm"]:
-            R[R < 0.1] = np.nan
+            precip[precip < 0.1] = np.nan
         elif units == "dBZ":
-            R[R < 10] = np.nan
+            precip[precip < 10] = np.nan
     else:
-        R[R < 1e-3] = np.nan
+        precip[precip < 1e-3] = np.nan
 
     im = ax.imshow(
-        R,
+        precip,
         cmap=cmap,
         norm=norm,
         extent=extent,
         interpolation="nearest",
         origin=origin,
-        zorder=1,
+        zorder=10,
     )
 
     return im
 
 
-def _plot_field_pcolormesh(X, Y, R, ax, type, units, colorscale):
-    R = R.copy()
+def _plot_field_pcolormesh(x_grid, y_grid, precip, ax, ptype, units, colorscale):
+    precip = precip.copy()
 
     # Get colormap and color levels
-    cmap, norm, clevs, clevsStr = get_colormap(type, units, colorscale)
+    cmap, norm, clevs, clevsStr = get_colormap(ptype, units, colorscale)
 
     # Plot precipitation field
     # transparent where no precipitation or the probability is zero
-    if type in ["intensity", "depth"]:
+    if ptype in ["intensity", "depth"]:
         if units in ["mm/h", "mm"]:
-            R[R < 0.1] = np.nan
+            precip[precip < 0.1] = np.nan
         elif units == "dBZ":
-            R[R < 10] = np.nan
+            precip[precip < 10] = np.nan
     else:
-        R[R < 1e-3] = np.nan
+        precip[precip < 1e-3] = np.nan
 
-    vmin, vmax = [None, None] if type in ["intensity", "depth"] else [0.0, 1.0]
+    vmin, vmax = [None, None] if ptype in ["intensity", "depth"] else [0.0, 1.0]
 
-    im = ax.pcolormesh(X, Y, R, cmap=cmap, norm=norm, vmin=vmin, vmax=vmax, zorder=1)
+    im = ax.pcolormesh(
+        x_grid, y_grid, precip, cmap=cmap, norm=norm, vmin=vmin, vmax=vmax, zorder=10
+    )
 
     return im
 
 
-def get_colormap(type, units="mm/h", colorscale="pysteps"):
+def get_colormap(ptype, units="mm/h", colorscale="pysteps"):
     """Function to generate a colormap (cmap) and norm.
 
     Parameters
     ----------
-    type : {'intensity', 'depth', 'prob'}, optional
+    ptype : {'intensity', 'depth', 'prob'}, optional
         Type of the map to plot: 'intensity' = precipitation intensity field,
         'depth' = precipitation depth (accumulation) field,
         'prob' = exceedance probability field.
     units : {'mm/h', 'mm', 'dBZ'}, optional
-        Units of the input array. If type is 'prob', this specifies the unit of
+        Units of the input array. If ptype is 'prob', this specifies the unit of
         the intensity threshold.
     colorscale : {'pysteps', 'STEPS-BE', 'BOM-RF3'}, optional
         Which colorscale to use. Applicable if units is 'mm/h', 'mm' or 'dBZ'.
@@ -345,7 +325,7 @@ def get_colormap(type, units="mm/h", colorscale="pysteps"):
         number of decimals).
 
     """
-    if type in ["intensity", "depth"]:
+    if ptype in ["intensity", "depth"]:
         # Get list of colors
         color_list, clevs, clevsStr = _get_colorlist(units, colorscale)
 
@@ -363,7 +343,7 @@ def get_colormap(type, units="mm/h", colorscale="pysteps"):
 
         return cmap, norm, clevs, clevsStr
 
-    elif type == "prob":
+    elif ptype == "prob":
         cmap = plt.get_cmap("OrRd", 10)
         return cmap, colors.Normalize(vmin=0, vmax=1), None, None
     else:

--- a/pysteps/visualization/precipfields.py
+++ b/pysteps/visualization/precipfields.py
@@ -146,7 +146,7 @@ def plot_precip_field(
             "The 'type' keyword use to indicate the type of plot will be "
             "deprecated in version 1.6. Use ptype instead."
         )
-        ptype = kwargs.get("ptype")
+        ptype = kwargs.get("type")
 
     if ptype not in PRECIP_VALID_TYPES:
         raise ValueError(

--- a/pysteps/visualization/precipfields.py
+++ b/pysteps/visualization/precipfields.py
@@ -240,8 +240,6 @@ def _plot_field(
             zorder=10,
         )
     else:
-        if origin == "upper":
-            y_grid = np.flipud(y_grid)
         vmin, vmax = [None, None] if ptype in ["intensity", "depth"] else [0.0, 1.0]
         im = ax.pcolormesh(
             x_grid,

--- a/pysteps/visualization/precipfields.py
+++ b/pysteps/visualization/precipfields.py
@@ -231,15 +231,12 @@ def _plot_field(
             zorder=10,
         )
     else:
-        vmin, vmax = [None, None] if ptype in ["intensity", "depth"] else [0.0, 1.0]
         im = ax.pcolormesh(
             x_grid,
             y_grid,
             precip,
             cmap=cmap,
             norm=norm,
-            vmin=vmin,
-            vmax=vmax,
             zorder=10,
         )
 
@@ -290,14 +287,14 @@ def get_colormap(ptype, units="mm/h", colorscale="pysteps"):
         norm = colors.BoundaryNorm(clevs, cmap.N)
 
         cmap.set_bad("gray", alpha=0.5)
-        cmap.set_under("white", alpha=0)
+        cmap.set_under("none")
 
         return cmap, norm, clevs, clevs_str
 
     if ptype == "prob":
         cmap = copy.copy(plt.get_cmap("OrRd", 10))
         cmap.set_bad("gray", alpha=0.5)
-        cmap.set_under("white", alpha=0)
+        cmap.set_under("none")
         clevs = np.linspace(0, 1, 11)
         clevs[0] = 1e-3  # to set zeros to transparent
         norm = colors.BoundaryNorm(clevs, cmap.N)

--- a/pysteps/visualization/spectral.py
+++ b/pysteps/visualization/spectral.py
@@ -58,14 +58,12 @@ def plot_spectrum1d(
     ax: Axes
         Plot axes
     """
-
     # Check input dimensions
     n_freq = len(fft_freq)
     n_pow = len(fft_power)
     if n_freq != n_pow:
         raise ValueError(
-            "Dimensions of the 1d input arrays must be equal. "
-            + "%s vs %s" % (n_freq, n_pow)
+            f"Dimensions of the 1d input arrays must be equal. {n_freq} vs {n_pow}"
         )
 
     if ax is None:
@@ -73,8 +71,8 @@ def plot_spectrum1d(
 
     # Plot spectrum in log-log scale
     ax.plot(
-        10.0 * np.log10(fft_freq),
-        10.0 * np.log10(fft_power),
+        10 * np.log10(fft_freq),
+        10 * np.log10(fft_power),
         color=color,
         linewidth=lw,
         label=label,
@@ -84,19 +82,19 @@ def plot_spectrum1d(
     # X-axis
     if wavelength_ticks is not None:
         wavelength_ticks = np.array(wavelength_ticks)
-        freq_ticks = 1.0 / wavelength_ticks
-        ax.set_xticks(10.0 * np.log10(freq_ticks))
+        freq_ticks = 1 / wavelength_ticks
+        ax.set_xticks(10 * np.log10(freq_ticks))
         ax.set_xticklabels(wavelength_ticks)
         if x_units is not None:
-            ax.set_xlabel("Wavelength [" + x_units + "]")
+            ax.set_xlabel(f"Wavelength [{x_units}]")
     else:
         if x_units is not None:
-            ax.set_xlabel("Frequency [1/" + x_units + "]")
+            ax.set_xlabel(f"Frequency [1/{x_units}]")
 
     # Y-axis
     if y_units is not None:
-        ax.set_ylabel(
-            r"Power [10log$_{10}(\frac{" + y_units + "^2}{" + x_units + "})$]"
-        )
+        # { -> {{ with f-strings
+        power_units = fr"$10log_{{ 10 }}(\frac{{ {y_units}^2 }}{{ {x_units} }})$"
+        ax.set_ylabel(f"Power {power_units}")
 
     return ax

--- a/pysteps/visualization/thunderstorms.py
+++ b/pysteps/visualization/thunderstorms.py
@@ -110,6 +110,8 @@ def _pix2coord_factory(geodata, ref_shape):
             return x, y
 
     else:
+        if ref_shape is None:
+            raise ValueError("'ref_shape' can't be None when not geodata is available.")
         # Default pix2coord function when no geographical information is present.
         def pix2coord(x_input, y_input):
             # yorigin is "upper" by default

--- a/pysteps/visualization/thunderstorms.py
+++ b/pysteps/visualization/thunderstorms.py
@@ -98,7 +98,6 @@ def plot_cart_contour(contours, geodata=None, ref_shape=None):
 
 def _pix2coord_factory(geodata, ref_shape):
     """Construct the pix2coord transformation function."""
-
     if geodata is not None:
 
         def pix2coord(x_input, y_input):

--- a/pysteps/visualization/thunderstorms.py
+++ b/pysteps/visualization/thunderstorms.py
@@ -111,6 +111,7 @@ def _pix2coord_factory(geodata, ref_shape):
     else:
         if ref_shape is None:
             raise ValueError("'ref_shape' can't be None when not geodata is available.")
+
         # Default pix2coord function when no geographical information is present.
         def pix2coord(x_input, y_input):
             # yorigin is "upper" by default

--- a/pysteps/visualization/thunderstorms.py
+++ b/pysteps/visualization/thunderstorms.py
@@ -19,6 +19,10 @@ Created on Wed Nov  4 11:09:44 2020
 import matplotlib.pyplot as plt
 import numpy as np
 
+################################
+# track and contour plots zorder
+# - precipitation: 40
+
 
 def plot_track(track_list, geodata=None, ref_shape=None):
     """
@@ -51,7 +55,7 @@ def plot_track(track_list, geodata=None, ref_shape=None):
     color = iter(plt.cm.spring(np.linspace(0, 1, len(track_list))))
     for track in track_list:
         cen_x, cen_y = pix2coord(track.cen_x, track.cen_y)
-        ax.plot(cen_x, cen_y, c=next(color), zorder=80)
+        ax.plot(cen_x, cen_y, c=next(color), zorder=40)
     return ax
 
 
@@ -88,7 +92,7 @@ def plot_cart_contour(contours, geodata=None, ref_shape=None):
     for contour in contours:
         for c in contour:
             x, y = pix2coord(c[:, 1], c[:, 0])
-            ax.plot(x, y, color="black", zorder=90)
+            ax.plot(x, y, color="black", zorder=40)
     return ax
 
 

--- a/pysteps/visualization/thunderstorms.py
+++ b/pysteps/visualization/thunderstorms.py
@@ -15,26 +15,9 @@ Created on Wed Nov  4 11:09:44 2020
     plot_track
     plot_cart_contour
 """
-import warnings
 
 import matplotlib.pyplot as plt
 import numpy as np
-
-try:
-    from cartopy.mpl.geoaxes import GeoAxesSubplot
-
-    CARTOPY_IMPORTED = True
-except ImportError:
-    CARTOPY_IMPORTED = False
-    PYPROJ_PROJECTION_TO_CARTOPY = dict()
-    GeoAxesSubplot = None
-
-try:
-    import pyproj
-
-    PYPROJ_IMPORTED = True
-except ImportError:
-    PYPROJ_IMPORTED = False
 
 
 def plot_track(track_list, geodata=None, ref_shape=None):

--- a/pysteps/visualization/utils.py
+++ b/pysteps/visualization/utils.py
@@ -10,7 +10,11 @@ Miscellaneous utility functions for the visualization module.
     parse_proj4_string
     proj4_to_cartopy
     reproject_geodata
+    get_geogrid
+    get_basemap_axis
 """
+import warnings
+
 import numpy as np
 from cartopy.mpl.geoaxes import GeoAxesSubplot
 
@@ -264,6 +268,57 @@ def get_geogrid(nlat, nlon, geodata=None):
 
     However, the origin of the x and y grids corresponds to the bottom left of the
     domain. That is, x and y are sorted in ascending order.
+
+    Parameters
+    ----------
+    nlat: int
+        Number of grid points along the latitude axis
+    nlon: int
+        Number of grid points along the longitude axis
+    geodata:
+        geodata: dictionary or None
+        Optional dictionary containing geographical information about
+        the field.
+
+        If geodata is not None, it must contain the following key-value pairs:
+
+        .. tabularcolumns:: |p{1.5cm}|L|
+
+        +----------------+----------------------------------------------------+
+        |        Key     |                  Value                             |
+        +================+====================================================+
+        |   projection   | PROJ.4-compatible projection definition            |
+        +----------------+----------------------------------------------------+
+        |    x1          | x-coordinate of the lower-left corner of the data  |
+        |                | raster                                             |
+        +----------------+----------------------------------------------------+
+        |    y1          | y-coordinate of the lower-left corner of the data  |
+        |                | raster                                             |
+        +----------------+----------------------------------------------------+
+        |    x2          | x-coordinate of the upper-right corner of the data |
+        |                | raster                                             |
+        +----------------+----------------------------------------------------+
+        |    y2          | y-coordinate of the upper-right corner of the data |
+        |                | raster                                             |
+        +----------------+----------------------------------------------------+
+        |    yorigin     | a string specifying the location of the first      |
+        |                | element in the data raster w.r.t. y-axis:          |
+        |                | 'upper' = upper border, 'lower' = lower border     |
+        +----------------+----------------------------------------------------+
+
+    Returns
+    -------
+    x_grid: 2D array
+    y_grid: 2D array
+    extent: tuple
+        Four-element tuple specifying the extent of the domain according to
+        (lower left x, upper right x, lower left y, upper right y).
+    regular_grid: bool
+        True is the grid is regular. False otherwise.
+    origin: str
+        Place the [0, 0] index of the array to plot in the upper left or lower left
+        corner of the axes. Note that the vertical axes points upward for 'lower' but
+        downward for 'upper'.
     """
     if geodata is not None:
         regular_grid = geodata.get("regular_grid", True)
@@ -309,11 +364,54 @@ def get_basemap_axis(extent, geodata=None, ax=None, map_kwargs=None):
     """
     Safely get a basemap axis. If ax is None, the current axis is returned.
 
-    If geodata is not None and ax is not a cartopy axis already, create a basemap axis
-    and return it.   Safely get a basemap axis. If ax is None, the current axis is returned.
+    If geodata is not None and ax is not a cartopy axis already, it creates a basemap
+    axis and return it.
 
-    If geodata is not None and ax is not a cartopy axis already, create a basemap axis
-    and return it.
+    Parameters
+    ----------
+    extent: tuple
+        Four-element tuple specifying the extent of the domain according to
+        (lower left x, upper right x, lower left y, upper right y).
+    geodata:
+        geodata: dictionary or None
+        Optional dictionary containing geographical information about
+        the field.
+
+        If geodata is not None, it must contain the following key-value pairs:
+
+        .. tabularcolumns:: |p{1.5cm}|L|
+
+        +----------------+----------------------------------------------------+
+        |        Key     |                  Value                             |
+        +================+====================================================+
+        |   projection   | PROJ.4-compatible projection definition            |
+        +----------------+----------------------------------------------------+
+        |    x1          | x-coordinate of the lower-left corner of the data  |
+        |                | raster                                             |
+        +----------------+----------------------------------------------------+
+        |    y1          | y-coordinate of the lower-left corner of the data  |
+        |                | raster                                             |
+        +----------------+----------------------------------------------------+
+        |    x2          | x-coordinate of the upper-right corner of the data |
+        |                | raster                                             |
+        +----------------+----------------------------------------------------+
+        |    y2          | y-coordinate of the upper-right corner of the data |
+        |                | raster                                             |
+        +----------------+----------------------------------------------------+
+        |    yorigin     | a string specifying the location of the first      |
+        |                | element in the data raster w.r.t. y-axis:          |
+        |                | 'upper' = upper border, 'lower' = lower border     |
+        +----------------+----------------------------------------------------+
+
+    ax: axis object
+        Optional axis object to use for plotting.
+    map_kwargs: dict
+        Optional parameters that need to be passed to
+        :py:func:`pysteps.visualization.basemaps.plot_geography`.
+
+    Returns
+    -------
+    ax: axis object
     """
 
     if map_kwargs is None:

--- a/pysteps/visualization/utils.py
+++ b/pysteps/visualization/utils.py
@@ -37,7 +37,7 @@ try:
 except ImportError:
     PYPROJ_IMPORTED = False
 
-CARTOPY_PROJ_KWRDS_TO_PYPROJ = {
+PYPROJ_PROJ_KWRDS_TO_CARTOPY = {
     "lon_0": "central_longitude",
     "lat_0": "central_latitude",
     "lat_ts": "true_scale_latitude",
@@ -46,9 +46,6 @@ CARTOPY_PROJ_KWRDS_TO_PYPROJ = {
     "k": "scale_factor",
     "zone": "zone",
 }
-
-# Invert the CARTOPY_PROJ_KWRDS_TO_PYPROJ dict
-PYPROJ_PROJ_KWRDS_TO_CARTOPY = {v: k for k, v in CARTOPY_PROJ_KWRDS_TO_PYPROJ.items()}
 
 PYPROJ_GLOB_KWRDS_TO_CARTOPY = {
     "a": "semimajor_axis",

--- a/pysteps/visualization/utils.py
+++ b/pysteps/visualization/utils.py
@@ -15,21 +15,37 @@ Miscellaneous utility functions for the visualization module.
 """
 import warnings
 
+import matplotlib.pylab as plt
 import numpy as np
-from cartopy.mpl.geoaxes import GeoAxesSubplot
 
 from pysteps.exceptions import MissingOptionalDependency
 from pysteps.exceptions import UnsupportedSomercProjection
-import matplotlib.pylab as plt
-
 from pysteps.visualization import basemaps
 
 try:
     import cartopy.crs as ccrs
+    from cartopy.mpl.geoaxes import GeoAxesSubplot
+
+    PYPROJ_PROJECTION_TO_CARTOPY = dict(
+        tmerc=ccrs.TransverseMercator,
+        laea=ccrs.LambertAzimuthalEqualArea,
+        lcc=ccrs.LambertConformal,
+        merc=ccrs.Mercator,
+        utm=ccrs.UTM,
+        stere=ccrs.Stereographic,
+        aea=ccrs.AlbersEqualArea,
+        aeqd=ccrs.AzimuthalEquidistant,
+        # Note: ccrs.epsg(2056) doesn't work because the projection
+        # limits are too strict.
+        # We'll use the Stereographic projection as an alternative.
+        somerc=ccrs.Stereographic,
+        geos=ccrs.Geostationary,
+    )
 
     CARTOPY_IMPORTED = True
 except ImportError:
     CARTOPY_IMPORTED = False
+    PYPROJ_PROJECTION_TO_CARTOPY = dict()
 try:
     import pyproj
 
@@ -55,22 +71,6 @@ PYPROJ_GLOB_KWRDS_TO_CARTOPY = {
     "f": "flattening",
     "rf": "inverse_flattening",
 }
-
-PYPROJ_PROJECTION_TO_CARTOPY = dict(
-    tmerc=ccrs.TransverseMercator,
-    laea=ccrs.LambertAzimuthalEqualArea,
-    lcc=ccrs.LambertConformal,
-    merc=ccrs.Mercator,
-    utm=ccrs.UTM,
-    stere=ccrs.Stereographic,
-    aea=ccrs.AlbersEqualArea,
-    aeqd=ccrs.AzimuthalEquidistant,
-    # Note: ccrs.epsg(2056) doesn't work because the projection
-    # limits are too strict.
-    # We'll use the Stereographic projection as an alternative.
-    somerc=ccrs.Stereographic,
-    geos=ccrs.Geostationary,
-)
 
 
 def parse_proj4_string(proj4str):

--- a/pysteps/visualization/utils.py
+++ b/pysteps/visualization/utils.py
@@ -330,17 +330,23 @@ def get_geogrid(nlat, nlon, geodata=None):
 
     if geodata is not None:
         regular_grid = geodata.get("regular_grid", True)
-        x = np.linspace(geodata["x1"], geodata["x2"], nlon)
+
+        x_lims = sorted((geodata["x1"], geodata["x2"]))
+        x = np.linspace(x_lims[0], x_lims[1], nlon)
         xpixelsize = np.abs(x[1] - x[0])
         x += xpixelsize / 2.0
 
-        y = np.linspace(geodata["y1"], geodata["y2"], nlat)
+        y_lims = sorted((geodata["y1"], geodata["y2"]))
+        y = np.linspace(y_lims[0], y_lims[1], nlat)
         ypixelsize = np.abs(y[1] - y[0])
         y += ypixelsize / 2.0
 
         extent = (geodata["x1"], geodata["x2"], geodata["y1"], geodata["y2"])
 
         x_grid, y_grid = np.meshgrid(x, y)
+
+        if geodata["yorigin"] == "upper":
+            y_grid = np.flipud(y_grid)
 
         return x_grid, y_grid, extent, regular_grid, geodata["yorigin"]
 
@@ -351,9 +357,6 @@ def get_geogrid(nlat, nlon, geodata=None):
     extent = (0, nlon - 1, 0, nlat - 1)
     regular_grid = True
     return x_grid, y_grid, extent, regular_grid, "upper"
-
-    # Default behavior
-    return default_regular_grid()
 
 
 def get_basemap_axis(extent, geodata=None, ax=None, map_kwargs=None):

--- a/pysteps/visualization/utils.py
+++ b/pysteps/visualization/utils.py
@@ -235,11 +235,15 @@ def reproject_geodata(geodata, t_proj4str, return_grid=None):
         else:
             raise ValueError("unknown return_grid value %s" % return_grid)
 
-        X, Y = np.meshgrid(x_coord, y_coord)
+        x_grid, y_grid = np.meshgrid(x_coord, y_coord)
 
-        X, Y = pyproj.transform(s_srs, t_srs, X.flatten(), Y.flatten())
-        X = X.reshape((y_coord.size, x_coord.size))
-        Y = Y.reshape((y_coord.size, x_coord.size))
+        x_grid, y_grid = pyproj.transform(
+            s_srs, t_srs, x_grid.flatten(), y_grid.flatten()
+        )
+        x_grid = x_grid.reshape((y_coord.size, x_coord.size))
+        y_grid = y_grid.reshape((y_coord.size, x_coord.size))
+        geodata["X_grid"] = x_grid
+        geodata["Y_grid"] = y_grid
 
     # Reproject extent on fall-back projection
     x1, y1 = pyproj.transform(s_srs, t_srs, x1, y1)
@@ -254,8 +258,6 @@ def reproject_geodata(geodata, t_proj4str, return_grid=None):
     geodata["regular_grid"] = False
     geodata["xpixelsize"] = None
     geodata["ypixelsize"] = None
-    geodata["X_grid"] = X
-    geodata["Y_grid"] = Y
 
     return geodata
 

--- a/pysteps/visualization/utils.py
+++ b/pysteps/visualization/utils.py
@@ -52,15 +52,19 @@ def parse_proj4_string(proj4str):
       Dictionary, where keys and values are parsed from the projection
       parameter tokens beginning with '+'.
     """
-    tokens = proj4str.split("+")
 
-    result = {}
-    for t in tokens[1:]:
-        if "=" in t:
-            k, v = t.split("=")
-            result[k] = v.strip()
+    if not PYPROJ_IMPORTED:
+        raise MissingOptionalDependency(
+            "pyproj package is required for parse_proj4_string function utility "
+            "but it is not installed"
+        )
 
-    return result
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=UserWarning)
+        # Ignore the warning raised by to_dict() about lossing information.
+        proj_dict = pyproj.Proj(proj4str).crs.to_dict()
+
+    return proj_dict
 
 
 def proj4_to_cartopy(proj4str):


### PR DESCRIPTION
# Refactor the visualization module

## 1) Refactor visualization.utils functions 

- parse_proj4_string: A more robust implementation of this function is implemented in pyproj. The refactored implementation uses a direct call to the pyproj function.
- proj4_to_cartopy: Refactor the proj4_to_cartopy function
  - Use the parse_proj4_string to construct a dictionary with the proj definitions
  - Simplify the function code by using additional dictionaries to relate the Pyproj and Cartopy parameters. 
  - Add support for additional cartopy keywords defined in the Proj4 definitions.
- Add two plotting utility functions to avoid code duplication and to improve the axis handling:
  - get_basemap_axis: This function safely gets a basemap axis. If the current axis is not a cartopy axis, it creates a basemap. Otherwise, the current axis is returned.
  - get_geogrid: Returns the x,y grid used in the plots along with additional metadata. 
-  Solves issue #197.

## 2) Refactor plotting functions

- Refactor the plotting functions to use the new plotting utils
- Merge `_plot_field_pcolormesh` and `_plot_field` in a single function.
- Avoid plotting the no-data mask separately. Instead, plot it in the `_plot_field` function. 
- Merge `quiver` and `streamplots` functions into a single one called `plot_motion` for avoiding code duplication.
The `quiver` and `streamplot` functions are now wrappers for `plot_motion`.
- **IMPORTANT**
  - Rename the `type` keyword in  `plot_precip_field` to `ptype` to avoid shadowing the built-in function with the same name. Add the corresponding deprecation warning.

## 3) Define a unique zorder for each type of plot

- Basemap features zorder
  - ocean: 0
  - land: 0
  - lakes: 0
  - rivers_lake_centerlines: 0
  - coastline: 15
  - cultural: 15
  - reefs: 15
  - minor_islands: 15
- precipitation: 10
- quiver: 20
- stream function: 30
- tracks and contours: 40