### PR TITLE
Update install docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -66,17 +66,9 @@ environments on your local computer.
 Before continuing, Mac OSX users also need to install a more recent compiler.
 See instructions here: :ref:`OSX users <install_osx_users>`.
 
-The developer environment can be installed in two different ways. In case of installation
-or import errors, try both approaches. The first approach starts by creating an empty
-python environment::
-
-    conda create -n pysteps_dev python=3.8
-
-Pip will take care to install the necessary dependencies in this environment (see below).
-
-The second approach creates the environment from
+The developer environment can be created from the file
 `environment_dev.yml <https://github.com/pySTEPS/pysteps/blob/master/environment_dev.yml>`_
-file in the project's root directory running the command::
+in the project's root directory by running the command::
 
     conda env create -f environment_dev.yml
 
@@ -90,9 +82,15 @@ but yet is still editable from the source tree::
 
     pip install -e <path to local pysteps repo>
 
-If starting from an empty environment, pip will install the necessary dependencies.
 To test if the installation went fine, you can try launching Python and importing
 pysteps :ref:`Import pysteps <_import_pysteps>`.
+
+**Note**: In case of installation or import errors, you can remove the pysteps_dev environment
+and try starting from an empty environment (adapt the Python version as needed)::
+
+    conda create -n pysteps_dev python=3.8
+
+You can then activate it and install pysteps with pip as exaplained above.
 
 Fork the repository
 ~~~~~~~~~~~~~~~~~~~

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -63,7 +63,18 @@ Conda quickly installs, runs and updates packages and their dependencies.
 It also allows to easily create, save, load and switch between different
 environments on your local computer.
 
-The developer environment can be created using the
+Before continuing, Mac OSX users also need to install a more recent compiler.
+See instructions here: :ref:`OSX users <install_osx_users>`.
+
+The developer environment can be installed in two different ways. In case of installation
+or import errors, try both approaches. The first approach starts by creating an empty
+python environment::
+
+    conda create -n pysteps_dev python=3.8
+
+Pip will take care to install the necessary dependencies in this environment (see below).
+
+The second approach creates the environment from
 `environment_dev.yml <https://github.com/pySTEPS/pysteps/blob/master/environment_dev.yml>`_
 file in the project's root directory running the command::
 
@@ -73,12 +84,15 @@ This will create the **pysteps_dev** environment that can be activated using::
 
     conda activate pysteps_dev
 
-Once the environment is created, the package can be installed in development
-mode, in such a way that the project appears to be installed,
-but yet is still editable from the source tree.
-See instructions in the :ref:`Installing pysteps <development_mode_install>`
-section.
+Once the environment is activated, the latest version of pysteps can be installed
+in development mode, in such a way that the project appears to be installed,
+but yet is still editable from the source tree::
 
+    pip install -e <path to local pysteps repo>
+
+If starting from an empty environment, pip will install the necessary dependencies.
+To test if the installation went fine, you can try launching Python and importing
+pysteps :ref:`Import pysteps <_import_pysteps>`.
 
 Fork the repository
 ~~~~~~~~~~~~~~~~~~~

--- a/doc/source/user_guide/install_pysteps.rst
+++ b/doc/source/user_guide/install_pysteps.rst
@@ -38,7 +38,9 @@ Other optional dependencies include:
 * `pandas <https://pandas.pydata.org/>`_ and
   `scikit-image <https://scikit-image.org/>`_ (for more advanced feature tracking)
 
-
+**Important**: If you only want to use pysteps, you can continue reading below.
+But, if you want to contribute to pysteps or edit the package, you need to install
+pysteps in development mode: :ref:`Contributing to pysteps <contributor_guidelines>`.
 
 Anaconda install (recommended)
 ------------------------------
@@ -88,9 +90,10 @@ to adhere to the [PEP517 standards](https://www.python.org/dev/peps/pep-0517/).
 Using `pip` instead of `setup.py` guarantees that all the package dependencies
 are properly handled during the installation process.
 
+.. _install_osx_users:
 
-OSX users
-~~~~~~~~~
+OSX users: gcc compiler
+~~~~~~~~~~~~~~~~~~~~~~~
 
 pySTEPS uses Cython extensions that need to be compiled with multi-threading
 support enabled. The default Apple Clang compiler does not support OpenMP.
@@ -131,15 +134,15 @@ the homebrew installation. For example::
 
 Then, you can continue with the normal installation procedure described next.
 
-Installation
-~~~~~~~~~~~~
+Installation using pip
+~~~~~~~~~~~~~~~~~~~~~~
 
 The latest pysteps version in the repository can be installed using pip by
 simply running in a terminal::
 
     pip install git+https://github.com/pySTEPS/pysteps
 
-Or, from a local copy of the repo (global installation)::
+Or, from a local copy of the repo::
 
     git clone https://github.com/pySTEPS/pysteps
     cd pysteps
@@ -147,18 +150,6 @@ Or, from a local copy of the repo (global installation)::
 
 The above commands install the latest version of the **master** branch,
 which is continuously under development.
-
-.. _development_mode_install:
-
-Development mode
-################
-
-The latest version can also be installed in Development Mode, i.e.,
-in such a way that the project appears to be installed,
-but yet is still editable from the source tree::
-
-    pip install -e <path to local pysteps repo>
-
 
 Setting up the user-defined configuration file
 ----------------------------------------------
@@ -176,6 +167,24 @@ that can be accessed as attributes or as items.
 
     Set-up the user-defined configuration file <set_pystepsrc>
     Example pystepsrc file <pystepsrc_example>
+
+.. _import_pysteps:
+
+Final test: import pysteps in Python
+------------------------------------
+
+Activate the pysteps environment::
+
+    conda activate pysteps
+
+Launch Python and import pysteps::
+
+    python
+    >>> import pysteps
+
+**Important**: The Python interpreter must be launched outside of the pysteps directory.
+Otherwise, it confuses the name of the directory with the package name.
+See :ref:`Issue 40 <https://github.com/pySTEPS/pysteps/issues/40>`.
 
 
 


### PR DESCRIPTION
I created a pysteps environment from the yml file and installed pysteps in development mode (pip -e). 
When importing pysteps I got this error:
ValueError: numpy.ndarray size changed, may indicate binary incompatibility. Expected 88 from C header, got 80 from PyObject
As suggested by @dnerini, the error was solved by starting from an empty environment instead of the one from yml.
I took the opportunity to update the installation/contribution docs and add some information here and there.
