### PR TITLE
Add importer for RMI NWP data

### DIFF
--- a/pysteps/io/nwp_importers.py
+++ b/pysteps/io/nwp_importers.py
@@ -69,7 +69,8 @@ Available Importers
 .. autosummary::
     :toctree: ../generated/
 
-    import_bom_nwp
+    import_bom_nwp_xr
+    import_rmi_nwp_xr
 """
 
 import numpy as np
@@ -88,7 +89,7 @@ except ImportError:
 
 @postprocess_import()
 def import_bom_nwp_xr(filename, **kwargs):
-    """Import a NetCDF with NWP rainfall forecasts regrided to a BoM Rainfields3
+    """Import a NetCDF with NWP rainfall forecasts regridded to a BoM Rainfields3
     using xarray.
 
     Parameters
@@ -107,7 +108,7 @@ def import_bom_nwp_xr(filename, **kwargs):
 
     if not NETCDF4_IMPORTED:
         raise MissingOptionalDependency(
-            "netCDF4 package is required to import BoM NWP regrided rainfall "
+            "netCDF4 package is required to import BoM NWP regridded rainfall "
             "products but it is not installed"
         )
 
@@ -124,7 +125,7 @@ def import_bom_nwp_xr(filename, **kwargs):
     # so it needs to be disagregated by time step
     varname = kwargs.get("varname", "accum_prcp")
     if varname == "accum_prcp":
-        print("Rainfall values are accumulated. Disagreagating by time step")
+        print("Rainfall values are accumulated. Disaggregating by time step")
         accum_prcp = ds_meta[varname]
         precipitation = accum_prcp - accum_prcp.shift({varname_time: 1})
         precipitation = precipitation.dropna(varname_time, "all")
@@ -294,7 +295,7 @@ def import_rmi_nwp_xr(filename, **kwargs):
     # so it needs to be disagregated by time step
     varname = kwargs.get("varname", "precipitation")
     if varname == "accum_prcp":
-        print("Rainfall values are accumulated. Disagreagating by time step")
+        print("Rainfall values are accumulated. Disaggregating by time step")
         accum_prcp = ds_meta[varname]
         precipitation = accum_prcp - accum_prcp.shift({varname_time: 1})
         precipitation = precipitation.dropna(varname_time, "all")
@@ -417,7 +418,7 @@ def _import_rmi_nwp_geodata_xr(
 
 def _get_threshold_value(precip):
     """
-    Get the the rain/no rain threshold with the same unit, transformation and
+    Get the rain/no rain threshold with the same unit, transformation and
     accutime of the data.
     If all the values are NaNs, the returned value is `np.nan`.
     Otherwise, np.min(precip[precip > precip.min()]) is returned.

--- a/pysteps/io/nwp_importers.py
+++ b/pysteps/io/nwp_importers.py
@@ -253,6 +253,164 @@ def _import_bom_nwp_geodata_xr(ds_in,
     return ds_in
 
 
+@postprocess_import()
+def import_rmi_nwp_xr(filename, **kwargs):
+    """Import a NetCDF with NWP rainfall forecasts from RMI using xarray.
+
+    Parameters
+    ----------
+    filename: str
+        Name of the file to import.
+
+    {extra_kwargs_doc}
+
+    Returns
+    -------
+    out_da : xr.DataArray
+        A xarray DataArray containing forecast rainfall fields in mm/timestep
+        imported from a netcdf, and the metadata.
+    """
+
+    if not NETCDF4_IMPORTED:
+        raise MissingOptionalDependency(
+            "netCDF4 package is required to import RMI NWP rainfall "
+            "products but it is not installed"
+        )
+
+    ds = _import_rmi_nwp_data_xr(filename, **kwargs)
+    ds_meta = _import_rmi_nwp_geodata_xr(ds, **kwargs)
+
+    # rename varname_time (def: time) to t
+    varname_time = kwargs.get("varname_time", "time")
+    ds_meta = ds_meta.rename({varname_time: "t"})
+    varname_time = "t"
+
+    # if data variable is named accum_prcp
+    # it is assumed that NWP rainfall data is accumulated
+    # so it needs to be disagregated by time step
+    varname = kwargs.get("varname", "precipitation")
+    if varname == "accum_prcp":
+        print("Rainfall values are accumulated. Disagreagating by time step")
+        accum_prcp = ds_meta[varname]
+        precipitation = accum_prcp - accum_prcp.shift({varname_time: 1})
+        precipitation = precipitation.dropna(varname_time, "all")
+        # update/copy attributes
+        precipitation.name = "precipitation"
+        # copy attributes
+        precipitation.attrs.update({**accum_prcp.attrs})
+        # update attributes
+        precipitation.attrs.update({"standard_name": "precipitation_amount"})
+    else:
+        precipitation = ds_meta[varname]
+
+    return precipitation
+
+
+def _import_rmi_nwp_data_xr(filename, **kwargs):
+
+    varname_time = kwargs.get("varname_time", "time")
+    chunks = kwargs.get("chunks", {varname_time: 1})
+
+    ds_rainfall = xr.open_mfdataset(
+        filename,
+        combine="nested",
+        concat_dim=varname_time,
+        chunks=chunks,
+        lock=False,
+        parallel=True,
+    )
+
+    return ds_rainfall
+
+
+def _import_rmi_nwp_geodata_xr(
+    ds_in,
+    **kwargs,
+):
+
+    varname = kwargs.get("varname", "precipitation")
+    varname_time = kwargs.get("varname_time", "time")
+    projdef = None
+    if "proj4string" in ds_in.attrs:
+        projdef = ds_in.proj4string
+
+    # get the accumulation period
+    time = ds_in[varname_time]
+    # shift the array to calculate the time step
+    delta_time = time - time.shift({varname_time: 1})
+    # assuming first valid delta_time is representative of all time steps
+    time_step = delta_time[1]
+    time_step = time_step.values.astype("timedelta64[m]")
+
+    # get the units of precipitation
+    units = None
+    if "units" in ds_in[varname].attrs:
+        units = ds_in[varname].units
+        if units in ("kg m-2", "mm"):
+            units = "mm"
+            ds_in[varname].attrs.update({"units": units})
+    # get spatial boundaries and pixelsize
+    # move to meters if coordinates in kilometers
+    if "units" in ds_in.x.attrs:
+        if ds_in.x.units == "km":
+            ds_in["x"] = ds_in.x * 1000.0
+            ds_in.x.attrs.update({"units": "m"})
+            ds_in["y"] = ds_in.y * 1000.0
+            ds_in.y.attrs.update({"units": "m"})
+
+    xmin = ds_in.x.min().values
+    xmax = ds_in.x.max().values
+    ymin = ds_in.y.min().values
+    ymax = ds_in.y.max().values
+    xpixelsize = abs(ds_in.x[1] - ds_in.x[0])
+    ypixelsize = abs(ds_in.y[1] - ds_in.y[0])
+
+    cartesian_unit = ds_in.x.units
+
+    # Add metadata needed by pySTEPS as attrs in X and Y variables
+
+    ds_in.x.attrs.update(
+        {
+            # TODO: Remove before final 2.0 version
+            "x1": xmin,
+            "x2": xmax,
+            "cartesian_unit": cartesian_unit,
+        }
+    )
+
+    ds_in.y.attrs.update(
+        {
+            # TODO: Remove before final 2.0 version
+            "y1": ymin,
+            "y2": ymax,
+            "cartesian_unit": cartesian_unit,
+        }
+    )
+
+    # Add metadata needed by pySTEPS as attrs in rainfall variable
+    da_rainfall = ds_in[varname].isel({varname_time: 0})
+
+    ds_in[varname].attrs.update(
+        {
+            "transform": None,
+            "unit": units,  # copy 'units' in 'unit' for legacy reasons
+            "projection": projdef,
+            "accutime": time_step,
+            "zr_a": None,
+            "zr_b": None,
+            "zerovalue": np.nanmin(da_rainfall),
+            "institution": "Royal Meteorological Institute of Belgium",
+            "threshold": _get_threshold_value(da_rainfall.values),
+            # TODO(_import_bom_rf3_geodata_xr): Remove before final 2.0 version
+            "yorigin": "upper",
+            "xpixelsize": xpixelsize.values,
+            "ypixelsize": ypixelsize.values,
+        }
+    )
+
+    return ds_in
+
+
 def _get_threshold_value(precip):
     """
     Get the the rain/no rain threshold with the same unit, transformation and

--- a/pysteps/pystepsrc
+++ b/pysteps/pystepsrc
@@ -99,6 +99,17 @@
             "timestep": 10,
             "importer_kwargs": {
                 "gzipped": true
+	    }
+        },
+        "rmi_nwp": {
+            "root_path": "./nwp/rmi",
+            "path_fmt": "%Y/%m/%d",
+            "fn_pattern": "ao13_%Y%m%d%H_native_5min",
+            "fn_ext": "nc",
+            "importer": "rmi_nwp",
+            "timestep": 5,
+            "importer_kwargs": {
+                "gzipped": true
             }
         }
     }

--- a/pysteps/tests/helpers.py
+++ b/pysteps/tests/helpers.py
@@ -37,76 +37,76 @@ def get_precipitation_fields(
     **importer_kwargs,
 ):
     """
-    Get a precipitation field from the archive to be used as reference.
+        Get a precipitation field from the archive to be used as reference.
 
-    Source: bom
-    Reference time: 2018/06/16 10000 UTC
+        Source: bom
+        Reference time: 2018/06/16 10000 UTC
 
-    Source: fmi
-    Reference time: 2016/09/28 1600 UTC
+        Source: fmi
+        Reference time: 2016/09/28 1600 UTC
 
-    Source: knmi
-    Reference time: 2010/08/26 0000 UTC
+        Source: knmi
+        Reference time: 2010/08/26 0000 UTC
 
-    Source: mch
-    Reference time: 2015/05/15 1630 UTC
+        Source: mch
+        Reference time: 2015/05/15 1630 UTC
 
-    Source: opera
-    Reference time: 2018/08/24 1800 UTC
+        Source: opera
+        Reference time: 2018/08/24 1800 UTC
 
-    Source: saf
-    Reference time: 2018/06/01 0700 UTC
+        Source: saf
+        Reference time: 2018/06/01 0700 UTC
 
-    Source: mrms
-    Reference time: 2019/06/10 0000 UTC
+        Source: mrms
+        Reference time: 2019/06/10 0000 UTC
 
-    Parameters
-    ----------
+        Parameters
+        ----------
 
-    num_prev_files: int, optional
-        Number of previous times (files) to return with respect to the
-        reference time.
+        num_prev_files: int, optional
+            Number of previous times (files) to return with respect to the
+            reference time.
 
-    num_next_files: int, optional
-        Number of future times (files) to return with respect to the
-        reference time.
+        num_next_files: int, optional
+            Number of future times (files) to return with respect to the
+            reference time.
 
-    return_raw: bool, optional
-        Do not preprocess the precipitation fields. False by default.
-        The pre-processing steps are: 1) Convert to mm/h,
-        2) Mask invalid values, 3) Log-transform the data [dBR].
+        return_raw: bool, optional
+            Do not preprocess the precipitation fields. False by default.
+            The pre-processing steps are: 1) Convert to mm/h,
+            2) Mask invalid values, 3) Log-transform the data [dBR].
 
-<<<<<<< HEAD
-=======
-    metadata: bool, optional
-        If True, also return file metadata.
+    <<<<<<< HEAD
+    =======
+        metadata: bool, optional
+            If True, also return file metadata.
 
-    clip: scalars (left, right, bottom, top), optional
-        The extent of the bounding box in data coordinates to be used to clip
-        the data.
+        clip: scalars (left, right, bottom, top), optional
+            The extent of the bounding box in data coordinates to be used to clip
+            the data.
 
->>>>>>> master
-    upscale: float or None, optional
-        Upscale fields in space during the pre-processing steps.
-        If it is None, the precipitation field is not modified.
-        If it is a float, represents the length of the space window that is
-        used to upscale the fields.
+    >>>>>>> master
+        upscale: float or None, optional
+            Upscale fields in space during the pre-processing steps.
+            If it is None, the precipitation field is not modified.
+            If it is a float, represents the length of the space window that is
+            used to upscale the fields.
 
-    source: {"bom", "fmi" , "knmi", "mch", "opera", "saf", "mrms"}, optional
-        Name of the data source to be used.
+        source: {"bom", "fmi" , "knmi", "mch", "opera", "saf", "mrms"}, optional
+            Name of the data source to be used.
 
-    log_transform: bool
-        Whether to transform the output to dB.
+        log_transform: bool
+            Whether to transform the output to dB.
 
-    Other Parameters
-    ----------------
+        Other Parameters
+        ----------------
 
-    importer_kwargs : dict
-        Additional keyword arguments passed to the importer.
+        importer_kwargs : dict
+            Additional keyword arguments passed to the importer.
 
-    Returns
-    -------
-    data_array : xr.DataArray
+        Returns
+        -------
+        data_array : xr.DataArray
     """
 
     if source == "bom":

--- a/pysteps/tests/test_io_bom_nwp.py
+++ b/pysteps/tests/test_io_bom_nwp.py
@@ -16,9 +16,7 @@ rel_path = os.path.join("2020", "10", "31")
 filename = os.path.join(root_path, rel_path, "20201031_0000_regrid_short.nc")
 data_array_xr = pysteps.io.import_bom_nwp_xr(filename)
 
-expected_proj = (
-    "+proj=aea  +lon_0=153.240 +lat_0=-27.718 +lat_1=-26.200 +lat_2=-29.300"
-)
+expected_proj = "+proj=aea  +lon_0=153.240 +lat_0=-27.718 +lat_1=-26.200 +lat_2=-29.300"
 
 
 def test_io_import_bom_nwp_xarray():
@@ -38,7 +36,7 @@ test_attrs_xr = [
     ("transform", None, None),
     ("zerovalue", 0.0, 0.1),
     ("unit", "mm", None),
-    ("accutime", np.timedelta64(10, 'm'), None),
+    ("accutime", np.timedelta64(10, "m"), None),
     ("zr_a", None, None),
     ("zr_b", None, None),
     ("xpixelsize", 500.0, 0.1),
@@ -61,8 +59,7 @@ test_attrs_xr_coord_x = [
 ]
 
 
-@pytest.mark.parametrize("variable, expected, tolerance",
-                         test_attrs_xr_coord_x)
+@pytest.mark.parametrize("variable, expected, tolerance", test_attrs_xr_coord_x)
 def test_io_import_bom_nwp_xarray_attrs_coordx(variable, expected, tolerance):
     """Test the importer Bom NWP."""
     smart_assert(data_array_xr.x.attrs[variable], expected, tolerance)
@@ -75,8 +72,7 @@ test_attrs_xr_coord_y = [
 ]
 
 
-@pytest.mark.parametrize("variable, expected, tolerance",
-                         test_attrs_xr_coord_y)
+@pytest.mark.parametrize("variable, expected, tolerance", test_attrs_xr_coord_y)
 def test_io_import_bom_nwp_xarray_attrs_coordy(variable, expected, tolerance):
     """Test the importer Bom NWP."""
     smart_assert(data_array_xr.y.attrs[variable], expected, tolerance)

--- a/pysteps/tests/test_io_bom_rf3.py
+++ b/pysteps/tests/test_io_bom_rf3.py
@@ -65,8 +65,7 @@ def test_io_import_bom_rf3_geodata(variable, expected, tolerance):
     """Test the importer Bom RF3."""
     root_path = pysteps.rcparams.data_sources["bom"]["root_path"]
     rel_path = os.path.join("prcp-cscn", "2", "2018", "06", "16")
-    filename = os.path.join(root_path, rel_path,
-                            "2_20180616_100000.prcp-cscn.nc")
+    filename = os.path.join(root_path, rel_path, "2_20180616_100000.prcp-cscn.nc")
     geodata = pysteps.io.importers._import_bom_rf3_geodata(filename)
     smart_assert(geodata[variable], expected, tolerance)
 
@@ -92,7 +91,7 @@ test_attrs_xr = [
     ("transform", None, None),
     ("zerovalue", 0.0, 0.1),
     ("unit", "mm", None),
-    ("accutime", np.timedelta64(6,'m'), None),
+    ("accutime", np.timedelta64(6, "m"), None),
     ("zr_a", None, None),
     ("zr_b", None, None),
     ("xpixelsize", 500.0, 0.1),
@@ -115,8 +114,7 @@ test_attrs_xr_coord_x = [
 ]
 
 
-@pytest.mark.parametrize("variable, expected, tolerance",
-                         test_attrs_xr_coord_x)
+@pytest.mark.parametrize("variable, expected, tolerance", test_attrs_xr_coord_x)
 def test_io_import_bom_rf3_xarray_attrs_coordx(variable, expected, tolerance):
     """Test the importer Bom RF3."""
     smart_assert(data_array_xr.x.attrs[variable], expected, tolerance)
@@ -129,8 +127,7 @@ test_attrs_xr_coord_y = [
 ]
 
 
-@pytest.mark.parametrize("variable, expected, tolerance",
-                         test_attrs_xr_coord_y)
+@pytest.mark.parametrize("variable, expected, tolerance", test_attrs_xr_coord_y)
 def test_io_import_bom_rf3_xarray_attrs_coordy(variable, expected, tolerance):
     """Test the importer Bom RF3."""
     smart_assert(data_array_xr.y.attrs[variable], expected, tolerance)

--- a/pysteps/tests/test_io_rmi_nwp.py
+++ b/pysteps/tests/test_io_rmi_nwp.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 
+# Test the importer for NWP data from the Royal Meteorological Institute of
+# Belgium (ALARO/AROME data in netCDF output).
+
 import os
 import numpy as np
 
@@ -13,11 +16,10 @@ pytest.importorskip("netCDF4")
 
 root_path = pysteps.rcparams.data_sources["rmi_nwp"]["root_path"]
 rel_path = os.path.join("2021", "07", "04")
-filename = os.path.join(root_path, rel_path, "ao13_2021070412_radar512_5min.nc")
-print(filename)
+filename = os.path.join(root_path, rel_path, "ao13_2021070412_native_5min.nc")
 data_array_xr = pysteps.io.import_rmi_nwp_xr(filename)
 
-expected_proj = "+proj=stere +lon_0=4.368 +lat_0=90 +lon_ts=0 +lat_ts=50 +ellps=sphere +x_0=356406 +y_0=3698905"
+expected_proj = "+proj=lcc +lon_0=4.55 +lat_1=50.8 +lat_2=50.8 +a=6371229 +es=0 +lat_0=50.8 +x_0=365950 +y_0=-365950"
 
 
 def test_io_import_rmi_nwp_xarray():
@@ -28,7 +30,7 @@ def test_io_import_rmi_nwp_xarray():
 def test_io_import_rmi_nwp_xarray_shape():
     """Test the importer RMI NWP shape."""
     assert isinstance(data_array_xr, xr.DataArray)
-    assert data_array_xr.shape == (12, 512, 512)
+    assert data_array_xr.shape == (12, 564, 564)
 
 
 test_attrs_xr = [
@@ -40,8 +42,8 @@ test_attrs_xr = [
     ("accutime", np.timedelta64(5, "m"), None),
     ("zr_a", None, None),
     ("zr_b", None, None),
-    ("xpixelsize", 1058.0, 0.1),
-    ("ypixelsize", 1058.0, 0.1),
+    ("xpixelsize", 1300.0, 0.1),
+    ("ypixelsize", 1300.0, 0.1),
     ("units", "mm", None),
     ("yorigin", "upper", None),
 ]
@@ -56,7 +58,7 @@ def test_io_import_rmi_nwp_xarray_attrs(variable, expected, tolerance):
 test_attrs_xr_coord_x = [
     ("units", "m", None),
     ("x1", 0, 0.1),
-    ("x2", 540638.0, 0.1),
+    ("x2", 731900.0, 0.1),
 ]
 
 
@@ -68,7 +70,7 @@ def test_io_import_rmi_nwp_xarray_attrs_coordx(variable, expected, tolerance):
 
 test_attrs_xr_coord_y = [
     ("units", "m", None),
-    ("y1", -540638.0, 0.1),
+    ("y1", -731900.0, 0.1),
     ("y2", 0.0, 0.1),
 ]
 

--- a/pysteps/tests/test_io_rmi_nwp.py
+++ b/pysteps/tests/test_io_rmi_nwp.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+
+import os
+import numpy as np
+
+import xarray as xr
+import pytest
+
+import pysteps
+from pysteps.tests.helpers import smart_assert
+
+pytest.importorskip("netCDF4")
+
+root_path = pysteps.rcparams.data_sources["rmi_nwp"]["root_path"]
+rel_path = os.path.join("2021", "07", "04")
+filename = os.path.join(root_path, rel_path, "ao13_2021070412_radar512_5min.nc")
+print(filename)
+data_array_xr = pysteps.io.import_rmi_nwp_xr(filename)
+
+expected_proj = "+proj=stere +lon_0=4.368 +lat_0=90 +lon_ts=0 +lat_ts=50 +ellps=sphere +x_0=356406 +y_0=3698905"
+
+
+def test_io_import_rmi_nwp_xarray():
+    """Test the importer RMI NWP."""
+    assert isinstance(data_array_xr, xr.DataArray)
+
+
+def test_io_import_rmi_nwp_xarray_shape():
+    """Test the importer RMI NWP shape."""
+    assert isinstance(data_array_xr, xr.DataArray)
+    assert data_array_xr.shape == (12, 512, 512)
+
+
+test_attrs_xr = [
+    ("projection", expected_proj, None),
+    ("institution", "Royal Meteorological Institute of Belgium", None),
+    ("transform", None, None),
+    ("zerovalue", 0.0, 0.1),
+    ("unit", "mm", None),
+    ("accutime", np.timedelta64(5, "m"), None),
+    ("zr_a", None, None),
+    ("zr_b", None, None),
+    ("xpixelsize", 1058.0, 0.1),
+    ("ypixelsize", 1058.0, 0.1),
+    ("units", "mm", None),
+    ("yorigin", "upper", None),
+]
+
+
+@pytest.mark.parametrize("variable, expected, tolerance", test_attrs_xr)
+def test_io_import_rmi_nwp_xarray_attrs(variable, expected, tolerance):
+    """Test the importer RMI NWP."""
+    smart_assert(data_array_xr.attrs[variable], expected, tolerance)
+
+
+test_attrs_xr_coord_x = [
+    ("units", "m", None),
+    ("x1", 0, 0.1),
+    ("x2", 540638.0, 0.1),
+]
+
+
+@pytest.mark.parametrize("variable, expected, tolerance", test_attrs_xr_coord_x)
+def test_io_import_rmi_nwp_xarray_attrs_coordx(variable, expected, tolerance):
+    """Test the importer RMI NWP."""
+    smart_assert(data_array_xr.x.attrs[variable], expected, tolerance)
+
+
+test_attrs_xr_coord_y = [
+    ("units", "m", None),
+    ("y1", -540638.0, 0.1),
+    ("y2", 0.0, 0.1),
+]
+
+
+@pytest.mark.parametrize("variable, expected, tolerance", test_attrs_xr_coord_y)
+def test_io_import_rmi_nwp_xarray_attrs_coordy(variable, expected, tolerance):
+    """Test the importer RMI NWP."""
+    smart_assert(data_array_xr.y.attrs[variable], expected, tolerance)

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ requirements = [
     "matplotlib",
     "jsonschema",
     "xarray",
-    "bottleneck"
+    "bottleneck",
 ]
 
 setup(


### PR DESCRIPTION
Add importer for the RMI's NWP data. 
Add tests (for ALARO/AROME at native 1.3km grid for now)
Tests will not work without [PR4 in pysteps-data](https://github.com/pySTEPS/pysteps-data/pull/4)