### PR TITLE
Support for matplotlib 3.5

### DIFF
--- a/examples/plot_cascade_decomposition.py
+++ b/examples/plot_cascade_decomposition.py
@@ -89,7 +89,7 @@ for k in range(num_cascade_levels):
         np.linspace(0, L / 2, len(filter["weights_1d"][k, :])),
         filter["weights_1d"][k, :],
         "k-",
-        basex=pow(0.5 * L / 3, 1.0 / (num_cascade_levels - 2)),
+        base=pow(0.5 * L / 3, 1.0 / (num_cascade_levels - 2)),
     )
 ax.set_xlim(1, L / 2)
 ax.set_ylim(0, 1)

--- a/pysteps/verification/plots.py
+++ b/pysteps/verification/plots.py
@@ -157,7 +157,7 @@ def plot_reldiag(reldiag, ax=None):
         color="gray",
         edgecolor="black",
     )
-    iax.set_yscale("log", basey=10)
+    iax.set_yscale("log", base=10)
     iax.set_xticks(reldiag["bin_edges"])
     iax.set_xticklabels(["%.1f" % max(v, 1e-6) for v in reldiag["bin_edges"]])
     yt_min = int(max(np.floor(np.log10(min(reldiag["sample_size"][:-1]))), 1))


### PR DESCRIPTION
Released on Nov 15, [matplotlib 3.5](https://matplotlib.org/stable/users/release_notes.html) introduced few breaking changes that affected us very marginally (but still broke our doc build...):

> semilogx, semilogy, loglog, LogScale, and SymmetricalLogScale used to take keyword arguments that depends on the axis orientation ("basex" vs "basey", "subsx" vs "subsy", "nonposx" vs "nonposy"); these parameter names have been removed in favor of "base", "subs", "nonpositive". This removal also affects e.g. ax.set_yscale("log", basey=...) which must now be spelled ax.set_yscale("log", base=...).

[Realease notes](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.5.0.html#stricter-validation-of-function-parameters)

This PR fixes them.

