### PR TITLE
Replace miniconda by micromamba in CI

### DIFF
--- a/.github/workflows/test_pysteps.yml
+++ b/.github/workflows/test_pysteps.yml
@@ -1,10 +1,5 @@
 name: Test Pysteps
 
-env:
-  MINIMAL_DEPENDENCIES: cython numpy jsmin jsonschema matplotlib netCDF4 opencv pillow pyproj scipy dask
-  OPTIONAL_DEPENDENCIES: pyfftw cartopy h5py PyWavelets pandas scikit-image
-  TEST_DEPENDENCIES: pytest pytest-cov
-
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
@@ -34,26 +29,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2.0.0
+      - name: Install mamba and create environment
+        uses: mamba-org/provision-with-micromamba@main
         with:
-          python-version: ${{ matrix.python-version }}
-          mamba-version: "*"
-          auto-update-conda: true
-          channels: conda-forge
-          channel-priority: flexible
-          activate-environment: test-environment
+          environment-file: ci/ci_test_env.yml
+          environment-name: test_environment
+          extra-specs: python=${{ matrix.python-version }}
 
-      - name: Install dependencies
-        env:
-          PACKAGES: ${{env.MINIMAL_DEPENDENCIES}} ${{env.OPTIONAL_DEPENDENCIES}} ${{env.TEST_DEPENDENCIES}}
-        run: |
-          if [ "$RUNNER_OS" == "Windows" ]; then
-            mamba.bat install --quiet ${{env.PACKAGES}}
-          else
-            mamba install --quiet ${{env.PACKAGES}}
-          fi
-          pip install -U cookiecutter
+      - name: Install pygrib (not win)
+        if: matrix.os != 'windows-latest'
+        run: conda install --quiet pygrib
 
       - name: Install pysteps for MacOS
         if: matrix.os == 'macos-latest'
@@ -69,10 +54,6 @@ jobs:
           gcc-9 --version || brew install gcc@9
           pip install .
 
-      - name: Install pygrib (not win)
-        if: matrix.os != 'windows-latest'
-        run: conda install --quiet pygrib
-
       - name: Install pysteps
         if: matrix.os != 'macos-latest'
         working-directory: ${{github.workspace}}
@@ -87,6 +68,7 @@ jobs:
       - name: Check imports
         working-directory: ${{github.workspace}}/pysteps_data
         run: |
+          python --version
           python -c "import pysteps; print(pysteps.__file__)"
           python -c "from pysteps import motion"
           python -c "from pysteps.motion import vet"

--- a/.github/workflows/test_pysteps.yml
+++ b/.github/workflows/test_pysteps.yml
@@ -40,7 +40,7 @@ jobs:
         if: matrix.os != 'windows-latest'
         run: mamba install --quiet pygrib
 
-      - name: Install gcc9 in OSX
+      - name: Install pysteps for MacOS
         if: matrix.os == 'macos-latest'
         working-directory: ${{github.workspace}}
         env:
@@ -51,9 +51,11 @@ jobs:
         run: |
           brew update-reset
           brew update
-          gcc-9 --version || brew install gcc@9          
+          gcc-9 --version || brew install gcc@9
+          pip install .
 
       - name: Install pysteps
+        if: matrix.os != 'macos-latest'
         working-directory: ${{github.workspace}}
         run: pip install .
 

--- a/.github/workflows/test_pysteps.yml
+++ b/.github/workflows/test_pysteps.yml
@@ -40,7 +40,7 @@ jobs:
         if: matrix.os != 'windows-latest'
         run: mamba install --quiet pygrib
 
-      - name: Install pysteps for MacOS
+      - name: Install gcc9 in MacOS
         if: matrix.os == 'macos-latest'
         working-directory: ${{github.workspace}}
         env:
@@ -51,11 +51,9 @@ jobs:
         run: |
           brew update-reset
           brew update
-          gcc-9 --version || brew install gcc@9
-          pip install .
+          gcc-9 --version || brew install gcc@9          
 
       - name: Install pysteps
-        if: matrix.os != 'macos-latest'
         working-directory: ${{github.workspace}}
         run: pip install .
 

--- a/.github/workflows/test_pysteps.yml
+++ b/.github/workflows/test_pysteps.yml
@@ -3,7 +3,7 @@ name: Test Pysteps
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ master ]
+    branches: [ master, use_mamba_gh_actions ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/test_pysteps.yml
+++ b/.github/workflows/test_pysteps.yml
@@ -1,9 +1,9 @@
 name: Test Pysteps
 
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
+  # Triggers the workflow on push or pull request events to the master branch
   push:
-    branches: [ master, use_mamba_gh_actions ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 
@@ -40,7 +40,7 @@ jobs:
         if: matrix.os != 'windows-latest'
         run: mamba install --quiet pygrib
 
-      - name: Install gcc9 in MacOS
+      - name: Install gcc9 in OSX
         if: matrix.os == 'macos-latest'
         working-directory: ${{github.workspace}}
         env:

--- a/.github/workflows/test_pysteps.yml
+++ b/.github/workflows/test_pysteps.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install pygrib (not win)
         if: matrix.os != 'windows-latest'
-        run: conda install --quiet pygrib
+        run: mamba install --quiet pygrib
 
       - name: Install pysteps for MacOS
         if: matrix.os == 'macos-latest'

--- a/ci/ci_test_env.yml
+++ b/ci/ci_test_env.yml
@@ -1,0 +1,32 @@
+# pysteps development environment
+name: test_environment
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python>=3.7
+  - pip
+  # Minimal dependencies
+  - numpy
+  - cython
+  - jsmin
+  - jsonschema
+  - matplotlib
+  - netCDF4
+  - opencv
+  - pillow
+  - pyproj
+  - scipy
+  # Optional dependencies
+  - dask
+  - pyfftw
+  - cartopy
+  - h5py
+  - PyWavelets
+  - pandas
+  - scikit-image
+  # Test dependencies
+  - pytest
+  - pytest-cov
+  - pip:
+      cookiecutter

--- a/ci/ci_test_env.yml
+++ b/ci/ci_test_env.yml
@@ -29,4 +29,4 @@ dependencies:
   - pytest
   - pytest-cov
   - pip:
-      cookiecutter
+      - cookiecutter

--- a/ci/ci_test_env.yml
+++ b/ci/ci_test_env.yml
@@ -6,6 +6,7 @@ channels:
 dependencies:
   - python>=3.7
   - pip
+  - mamba
   # Minimal dependencies
   - numpy
   - cython


### PR DESCRIPTION
This PR takes #256 one step further using the `mamba-org/provision-with-micromamba@main` action to create the environment, instead of `conda-incubator/setup-miniconda@v2`

Although the computational time saved is minimal (a minute at the most), it simplifies a little bit the workflow specification, condensing the previous "miniconda installation" and "environment creation" task into a single one. 

More information on micromamba: https://github.com/mamba-org/mamba#micromamba