### PR TITLE
Remove deprecated plotting options

### DIFF
--- a/.github/workflows/test_pysteps.yml
+++ b/.github/workflows/test_pysteps.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
+        os: [ "ubuntu-latest", "macos-latest", "windows-2019" ]
         python-version: [ "3.7", "3.9" ]
       max-parallel: 6
 

--- a/.github/workflows/test_pysteps.yml
+++ b/.github/workflows/test_pysteps.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-latest", "macos-latest", "windows-2019" ]
+        os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
         python-version: [ "3.7", "3.9" ]
       max-parallel: 6
 
@@ -32,6 +32,7 @@ jobs:
       - name: Install mamba and create environment
         uses: mamba-org/provision-with-micromamba@main
         with:
+          micromamba-version: 0.20.0
           environment-file: ci/ci_test_env.yml
           environment-name: test_environment
           extra-specs: python=${{ matrix.python-version }}

--- a/pysteps/tests/test_plt_animate.py
+++ b/pysteps/tests/test_plt_animate.py
@@ -24,6 +24,10 @@ VALID_ARGS = (
     ([PRECIP], {"timestamps_obs": METADATA["timestamps"]}),
     ([PRECIP], {"geodata": METADATA, "map_kwargs": {"plot_map": None}}),
     ([PRECIP], {"motion_field": np.ones((2, *PRECIP.shape[1:]))}),
+    (
+        [PRECIP],
+        {"precip_kwargs": {"units": "mm/h", "colorbar": True, "colorscale": "pysteps"}},
+    ),
     ([PRECIP, PRECIP], {}),
     ([PRECIP, PRECIP], {"title": "title"}),
     ([PRECIP, PRECIP], {"timestamps_obs": METADATA["timestamps"]}),
@@ -40,19 +44,32 @@ def test_animate(anim_args, anim_kwargs):
         animate(*anim_args, **anim_kwargs)
 
 
-WRONG_ARGS = (
+VALUEERROR_ARGS = (
     ([PRECIP], {"timestamps_obs": METADATA["timestamps"][:2]}),
     ([PRECIP], {"motion_plot": "test"}),
-    ([PRECIP, PRECIP], {"ptype": "prob"}),
-    ([PRECIP, PRECIP], {"ptype": "prob"}),
-    ([PRECIP, PRECIP], {"ptype": "prob"}),
     ([PRECIP, PRECIP], {"ptype": "prob"}),
 )
 
 
-@pytest.mark.parametrize(["anim_args", "anim_kwargs"], WRONG_ARGS)
-def test_animate_wrong_args(anim_args, anim_kwargs):
+@pytest.mark.parametrize(["anim_args", "anim_kwargs"], VALUEERROR_ARGS)
+def test_animate_valueerrors(anim_args, anim_kwargs):
     with pytest.raises(ValueError):
+        animate(*anim_args, **anim_kwargs)
+
+
+TYPEERROR_ARGS = (
+    ([PRECIP], {"timestamps": METADATA["timestamps"]}),
+    ([PRECIP], {"plotanimation": True}),
+    ([PRECIP], {"units": "mm/h"}),
+    ([PRECIP], {"colorbar": True}),
+    ([PRECIP], {"colorscale": "pysteps"}),
+    ([PRECIP, PRECIP], {"type": "ensemble"}),
+)
+
+
+@pytest.mark.parametrize(["anim_args", "anim_kwargs"], TYPEERROR_ARGS)
+def test_animate_typeerrors(anim_args, anim_kwargs):
+    with pytest.raises(TypeError):
         animate(*anim_args, **anim_kwargs)
 
 

--- a/pysteps/visualization/animations.py
+++ b/pysteps/visualization/animations.py
@@ -18,11 +18,6 @@ import matplotlib.pylab as plt
 import pysteps as st
 
 PRECIP_VALID_TYPES = ("ensemble", "mean", "prob")
-PRECIP_DEPRECATED_ARGUMENTS = (
-    "units",
-    "colorbar",
-    "colorscale",
-)  # TODO: remove in version >= 1.6
 MOTION_VALID_METHODS = ("quiver", "streamplot")
 
 
@@ -47,7 +42,6 @@ def animate(
     precip_kwargs=None,
     motion_kwargs=None,
     map_kwargs=None,
-    **kwargs,
 ):
     """
     Function to animate observations and forecasts in pysteps.
@@ -180,39 +174,6 @@ def animate(
             f"Invalid precipitation type '{ptype}'."
             f"Supported: {str(PRECIP_VALID_TYPES)}"
         )
-
-    # TODO: remove in version >= 1.6
-    if "type" in kwargs:
-        warnings.warn(
-            "The 'type' keyword will be deprecated in version 1.6. "
-            "Use 'ptype' instead."
-        )
-        ptype = kwargs.get("type")
-
-    # TODO: remove in version >= 1.6
-    if "timestamps" in kwargs:
-        warnings.warn(
-            "The 'timestamps' keyword will be deprecated in version 1.6. "
-            "Use 'timestamps_obs' instead."
-        )
-        timestamps_obs = kwargs.get("timestamps")
-
-    # TODO: remove in version >= 1.6
-    if "plotanimation" in kwargs:
-        warnings.warn(
-            "The 'plotanimation' keyword will be deprecated in version 1.6. "
-            "Use 'display_animation' instead."
-        )
-        display_animation = kwargs.get("timestamps")
-
-    # TODO: remove in version >= 1.6
-    for depr_key in PRECIP_DEPRECATED_ARGUMENTS:
-        if depr_key in kwargs:
-            warnings.warn(
-                f"The {depr_key} argument will be deprecated in version 1.6. "
-                "Add it to 'precip_kwargs' instead."
-            )
-            precip_kwargs[depr_key] = kwargs.get(depr_key)
 
     if timestamps_obs is not None:
         if len(timestamps_obs) != precip_obs.shape[0]:

--- a/pysteps/visualization/precipfields.py
+++ b/pysteps/visualization/precipfields.py
@@ -43,7 +43,6 @@ def plot_precip_field(
     axis="on",
     cax=None,
     map_kwargs=None,
-    **kwargs,
 ):
     """
     Function to plot a precipitation intensity or probability field with a
@@ -130,13 +129,6 @@ def plot_precip_field(
 
     if map_kwargs is None:
         map_kwargs = {}
-
-    if "type" in kwargs:
-        warnings.warn(
-            "The 'type' keyword use to indicate the type of plot will be "
-            "deprecated in version 1.6. Use 'ptype' instead."
-        )
-        ptype = kwargs.get("type")
 
     if ptype not in PRECIP_VALID_TYPES:
         raise ValueError(


### PR DESCRIPTION
This PR introduces two main changes in the visualization module and its tests, namely:

- Mock pyplot.show during tests to avoid opening interactive windows
- Apply pre-warned deprecation of keyword arguments for v1.6 (see below).

## Deprecated arguments

concerns keyword arguments to:
- `visualization.animations.animate()`
- `visualization.precipfields.plot_precip_field()`

### Must be passed to `precip_kwargs` instead:
- `units`
- `colorbar`
- `colorscale`

### Renamed:
- `type` -> `ptype`
- `timestamps` -> `timestamps_obs`
- `plotanimation`-> `display_animation`

