### PR TITLE
Release 1.6

### DIFF
--- a/.github/workflows/test_pysteps.yml
+++ b/.github/workflows/test_pysteps.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
-        python-version: [ "3.7", "3.9" ]
+        python-version: [ "3.7", "3.8", "3.9" ]
       max-parallel: 6
 
     defaults:

--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.2
 Name: pysteps
-Version: 1.5.1
+Version: 1.6.0
 Summary: Python framework for short-term ensemble prediction systems
 Home-page: http://pypi.python.org/pypi/pysteps/
 License: LICENSE

--- a/README.rst
+++ b/README.rst
@@ -96,60 +96,43 @@ The pysteps library supports standard input/output file formats and implements s
 Quick start
 -----------
 
-Use pysteps to compute and plot an extrapolation nowcast in Google Colab with `this interactive notebook`__.
-
-__ https://colab.research.google.com/github/pySTEPS/pysteps/blob/master/examples/my_first_nowcast.ipynb
-
+Use pysteps to compute and plot a radar extrapolation nowcast in Google Colab with `this interactive notebook <https://colab.research.google.com/github/pySTEPS/pysteps/blob/master/examples/my_first_nowcast.ipynb>`_.
 
 Installation
 ============
 
-The recommended way to install pysteps is with Anaconda::
+The recommended way to install pysteps is with `conda <https://docs.conda.io/>`_ from the conda-forge channel::
 
     $ conda install -c conda-forge pysteps
 
-More details can be found in the `installation guide`__.
-
-__ https://pysteps.readthedocs.io/en/stable/user_guide/install_pysteps.html
+More details can be found in the `installation guide <https://pysteps.readthedocs.io/en/stable/user_guide/install_pysteps.html>`_.
 
 Usage
 =====
 
-You can have a look at the `gallery of examples`__ to get a better idea of how the library can be used.
+Have a look at the `gallery of examples <https://pysteps.readthedocs.io/en/stable/auto_examples/index.html>`__ to get a good overview of what pysteps can do.
 
-__ https://pysteps.readthedocs.io/en/stable/auto_examples/index.html
-
-For a more detailed description of the implemented functions, check the  `API reference`__ page.
-
-__ https://pysteps.readthedocs.io/en/stable/pysteps_reference/index.html
+For a more detailed description of all the available methods, check the  `API reference <https://pysteps.readthedocs.io/en/stable/pysteps_reference/index.html>`_ page.
 
 Example data
 ============
 
-A set of example radar data is available in a separate repository: `pysteps-data`__. More information on how to download and install them are available here__.
-
-__ https://github.com/pySTEPS/pysteps-data
-__ https://pysteps.readthedocs.io/en/stable/user_guide/example_data.html
+A set of example radar data is available in a separate repository: `pysteps-data <https://github.com/pySTEPS/pysteps-data>`_.
+More information on how to download and install them is available `here <https://pysteps.readthedocs.io/en/stable/user_guide/example_data.html>`_.
 
 Contributions
 =============
 
 We welcome contributions! For feedback, suggestions for developments, and bug reports 
-please use the dedicated `Issues page`__.
+please use the dedicated `issues page <https://github.com/pySTEPS/pysteps/issues>`_.
 
-__ https://github.com/pySTEPS/pysteps/issues
-
-More information dedicated to developers is available in the `contributors guidelines`__.
-
-__ https://pysteps.readthedocs.io/en/stable/developer_guide/contributors_guidelines.html
+More information dedicated to developers is available in the `contributors guidelines <https://pysteps.readthedocs.io/en/stable/developer_guide/contributors_guidelines.html>`_.
 
 Get in touch
 ============
 
-You can get in touch with the pysteps community on our `pysteps slack`__. To get access to it, you need to ask for an invitation or you can use the automatic invitation page `here`__. This invite page can sometimes take a while to load so please be patient.
-
-__ https://pysteps.slack.com/
-__ https://pysteps-slackin.herokuapp.com/
+You can get in touch with the pysteps community on our `pysteps slack <https://pysteps.slack.com/>`_.
+To get access to it, you need to ask for an invitation or you can use the automatic invitation page `here <https://pysteps-slackin.herokuapp.com/>`_.
 
 Reference publications
 ======================
@@ -157,11 +140,9 @@ Reference publications
 Pulkkinen, S., D. Nerini, A. Perez Hortal, C. Velasco-Forero, U. Germann,
 A. Seed, and L. Foresti, 2019:  Pysteps:  an open-source Python library for
 probabilistic precipitation nowcasting (v1.0). *Geosci. Model Dev.*, **12 (10)**,
-4185–4219, doi:10.5194/gmd-12-4185-2019. [source__]
-
-__ https://doi.org/10.5194/gmd-12-4185-2019
+4185–4219, `doi:10.5194/gmd-12-4185-2019 <https://doi.org/10.5194/gmd-12-4185-2019>`_.
 
 Pulkkinen, S., D. Nerini, A. Perez Hortal, C. Velasco-Forero, U. Germann, A. Seed, and
-L. Foresti, 2019: pysteps - a Community-Driven Open-Source Library for Precipitation Nowcasting. *Poster presented at the 3rd European Nowcasting Conference, Madrid, ES*, doi: 10.13140/RG.2.2.31368.67840. [source__]
-
-__ https://www.researchgate.net/publication/332781022_pysteps_-_a_Community-Driven_Open-Source_Library_for_Precipitation_Nowcasting
+L. Foresti, 2019: pysteps - a Community-Driven Open-Source Library for Precipitation Nowcasting.
+*Poster presented at the 3rd European Nowcasting Conference, Madrid, ES*,
+`doi:10.13140/RG.2.2.31368.67840 <https://doi.org/10.13140/RG.2.2.31368.67840>`.

--- a/README.rst
+++ b/README.rst
@@ -145,4 +145,4 @@ probabilistic precipitation nowcasting (v1.0). *Geosci. Model Dev.*, **12 (10)**
 Pulkkinen, S., D. Nerini, A. Perez Hortal, C. Velasco-Forero, U. Germann, A. Seed, and
 L. Foresti, 2019: pysteps - a Community-Driven Open-Source Library for Precipitation Nowcasting.
 *Poster presented at the 3rd European Nowcasting Conference, Madrid, ES*,
-`doi:10.13140/RG.2.2.31368.67840 <https://doi.org/10.13140/RG.2.2.31368.67840>`.
+`doi:10.13140/RG.2.2.31368.67840 <https://doi.org/10.13140/RG.2.2.31368.67840>`_.

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ pysteps - Python framework for short-term ensemble prediction systems
     :alt: Documentation Status
     :target: https://pysteps.readthedocs.io/
 
-.. |test| image:: https://github.com/pySTEPS/pysteps/workflows/Test%20Pysteps/badge.svg
+.. |test| image:: https://github.com/pySTEPS/pysteps/workflows/Test%20pysteps/badge.svg
     :alt: Test pysteps
     :target: https://github.com/pySTEPS/pysteps/actions?query=workflow%3A"Test+Pysteps"
 
@@ -67,7 +67,7 @@ pysteps - Python framework for short-term ensemble prediction systems
 
 .. |gallery| image:: https://img.shields.io/badge/example-gallery-blue.svg
     :alt: pysteps example gallery
-    :target: https://pysteps.readthedocs.io/en/latest/auto_examples/index.html
+    :target: https://pysteps.readthedocs.io/en/stable/auto_examples/index.html
     
 .. |stable| image:: https://img.shields.io/badge/docs-stable-blue.svg
     :alt: pysteps documentation
@@ -93,12 +93,55 @@ The aim of pysteps is to serve two different needs. The first is to provide a mo
 The pysteps library supports standard input/output file formats and implements several optical flow methods as well as advanced stochastic generators to produce ensemble nowcasts. In addition, it includes tools for visualizing and post-processing the nowcasts and methods for deterministic, probabilistic, and neighbourhood forecast verification.
 
 
-Run your first nowcast
-----------------------
+Quick start
+-----------
 
 Use pysteps to compute and plot an extrapolation nowcast in Google Colab with `this interactive notebook`__.
 
 __ https://colab.research.google.com/github/pySTEPS/pysteps/blob/master/examples/my_first_nowcast.ipynb
+
+
+Installation
+============
+
+The recommended way to install pysteps is with Anaconda::
+
+    $ conda install -c conda-forge pysteps
+
+More details can be found in the `installation guide`__.
+
+__ https://pysteps.readthedocs.io/en/stable/user_guide/install_pysteps.html
+
+Usage
+=====
+
+You can have a look at the `gallery of examples`__ to get a better idea of how the library can be used.
+
+__ https://pysteps.readthedocs.io/en/stable/auto_examples/index.html
+
+For a more detailed description of the implemented functions, check the  `API reference`__ page.
+
+__ https://pysteps.readthedocs.io/en/stable/pysteps_reference/index.html
+
+Example data
+============
+
+A set of example radar data is available in a separate repository: `pysteps-data`__. More information on how to download and install them are available here__.
+
+__ https://github.com/pySTEPS/pysteps-data
+__ https://pysteps.readthedocs.io/en/stable/user_guide/example_data.html
+
+Contributions
+=============
+
+We welcome contributions! For feedback, suggestions for developments, and bug reports 
+please use the dedicated `Issues page`__.
+
+__ https://github.com/pySTEPS/pysteps/issues
+
+More information dedicated to developers is available in the `contributors guidelines`__.
+
+__ https://pysteps.readthedocs.io/en/stable/developer_guide/contributors_guidelines.html
 
 Get in touch
 ============
@@ -107,45 +150,6 @@ You can get in touch with the pysteps community on our `pysteps slack`__. To get
 
 __ https://pysteps.slack.com/
 __ https://pysteps-slackin.herokuapp.com/
-
-Installation
-============
-
-To install pysteps please have a look at the `pysteps user guide`__.
-
-__ https://pysteps.readthedocs.io/en/latest/user_guide/index.html
-
-Use
-===
-
-You can have a look at the `gallery of examples`__ to get a better idea of how the library can be used.
-
-__ https://pysteps.readthedocs.io/en/latest/auto_examples/index.html
-
-For a more detailed description of the implemented functions, check the `pysteps reference page`__.
-
-__ https://pysteps.readthedocs.io/en/latest/pysteps_reference/index.html
-
-Example data
-============
-
-A set of example radar data is available in a separate repository: `pysteps-data`__. More information on how to download and install them are available here__.
-
-__ https://github.com/pySTEPS/pysteps-data
-__ https://pysteps.readthedocs.io/en/latest/user_guide/example_data.html#example-data
-
-Contributions
-=============
-
-We welcome contributions, feedback, suggestions for developments and bug reports.
-
-Feedback, suggestions for developments and bug reports can use the dedicated `Issues page`__.
-
-__ https://github.com/pySTEPS/pysteps/issues
-
-More information dedicated to developers is available in the `developer guide`__.
-
-__ https://pysteps.readthedocs.io/en/latest/developer_guide/index.html
 
 Reference publications
 ======================

--- a/README.rst
+++ b/README.rst
@@ -123,10 +123,11 @@ More information on how to download and install them is available `here <https:/
 Contributions
 =============
 
-We welcome contributions! For feedback, suggestions for developments, and bug reports 
-please use the dedicated `issues page <https://github.com/pySTEPS/pysteps/issues>`_.
+*We welcome contributions!*
 
-More information dedicated to developers is available in the `contributors guidelines <https://pysteps.readthedocs.io/en/stable/developer_guide/contributors_guidelines.html>`_.
+For feedback, suggestions for developments, and bug reports please use the dedicated `issues page <https://github.com/pySTEPS/pysteps/issues>`_.
+
+For more information, please read our `contributors guidelines <https://pysteps.readthedocs.io/en/stable/developer_guide/contributors_guidelines.html>`_.
 
 Get in touch
 ============

--- a/doc/source/user_guide/install_pysteps.rst
+++ b/doc/source/user_guide/install_pysteps.rst
@@ -8,7 +8,7 @@ Dependencies
 
 The pysteps package needs the following dependencies
 
-* `python >=3.7 <http://www.python.org/>`_ (lower versions may work but they are not officially supported).
+* `python >=3.7, <3.10 <http://www.python.org/>`_ (lower or higher versions may work but are not tested).
 * `jsonschema <https://pypi.org/project/jsonschema/>`_
 * `matplotlib <http://matplotlib.org/>`_
 * `netCDF4 <https://pypi.org/project/netCDF4/>`_

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ requirements = [
 
 setup(
     name="pysteps",
-    version="1.5.1",
+    version="1.6.0",
     author="PySteps developers",
     packages=find_packages(),
     license="LICENSE",


### PR DESCRIPTION
Preparation for release 1.6:
- Add test for python 3.8.
- Pin upper version for python (3.9).
- Bump up version to 1.6.0.
- Update README.