### PR TITLE
Minor exporters adjustment

### DIFF
--- a/pysteps/io/exporters.py
+++ b/pysteps/io/exporters.py
@@ -804,7 +804,7 @@ def _export_netcdf(field, exporter):
         if exporter["num_ens_members"] > 1:
             var_f[:, var_f.shape[1], :, :] = field
         else:
-            var_f[var_f.shape[1], :, :] = field
+            var_f[var_f.shape[0], :, :] = field
         var_time = exporter["var_time"]
         var_time[len(var_time) - 1] = len(var_time) * exporter["timestep"] * 60
     else:


### PR DESCRIPTION
For a deterministic run (n_ens_mem = 1), the shape of var_f is [n_timesteps, y, x]. The exporter assumed a shape of [n_ens_members, n_timesteps, y, x], which is no longer the case (changed a few releases ago). Hence, the indexation was incorrect (returning the shape of y instead of n_timesteps).