### PR TITLE
Place ensemble member number determination for blending inside forecast loop to prevent out of memory issues

### DIFF
--- a/pysteps/blending/steps.py
+++ b/pysteps/blending/steps.py
@@ -16,14 +16,13 @@ consists of the following main steps:
        method to decompose and store the NWP model fields whenever a new NWP model
        field is present, is present in pysteps.blending.utils.decompose_NWP.
     #. Estimate AR parameters for the extrapolation nowcast and noise cascade.
-    #. Before starting the forecast loop, determine which NWP models will be
-       combined with which nowcast ensemble members. The number of output ensemble
-       members equals the maximum number of (ensemble) members in the input, which
-       can be either the defined number of (nowcast) ensemble members or the number
-       of NWP models/members.
     #. Initialize all the random generators.
     #. Calculate the initial skill of the NWP model forecasts at t=0.
     #. Start the forecasting loop:
+        #. Determine which NWP models will be combined with which nowcast ensemble
+        member. The number of output ensemble members equals the maximum number of
+        (ensemble) members in the input, which can be either the defined number of
+        (nowcast) ensemble members or the number of NWP models/members.
         #. Determine the skill and weights of the forecasting components
            (extrapolation, NWP and noise) for that lead time.
         #. Regress the extrapolation and noise cascades separately to the subsequent

--- a/pysteps/blending/steps.py
+++ b/pysteps/blending/steps.py
@@ -20,9 +20,9 @@ consists of the following main steps:
     #. Calculate the initial skill of the NWP model forecasts at t=0.
     #. Start the forecasting loop:
         #. Determine which NWP models will be combined with which nowcast ensemble
-        member. The number of output ensemble members equals the maximum number of
-        (ensemble) members in the input, which can be either the defined number of
-        (nowcast) ensemble members or the number of NWP models/members.
+           member. The number of output ensemble members equals the maximum number
+           of (ensemble) members in the input, which can be either the defined
+           number of (nowcast) ensemble members or the number of NWP models/members.
         #. Determine the skill and weights of the forecasting components
            (extrapolation, NWP and noise) for that lead time.
         #. Regress the extrapolation and noise cascades separately to the subsequent

--- a/pysteps/tests/test_blending_steps.py
+++ b/pysteps/tests/test_blending_steps.py
@@ -31,9 +31,9 @@ steps_arg_values = [
     (1, 3, 4, 6, "incremental", "cdf", False, "bps", False, 4),
     (1, 3, 4, 9, "incremental", "cdf", False, "spn", True, 4),
     (2, 3, 10, 8, "incremental", "cdf", False, "spn", True, 10),
-    (5, 3, 4, 8, "incremental", "cdf", False, "spn", True, 5),
+    (5, 3, 5, 8, "incremental", "cdf", False, "spn", True, 5),
     (1, 10, 1, 8, "incremental", "cdf", False, "spn", True, 1),
-    (5, 3, 2, 8, "incremental", "cdf", True, "spn", True, 2),
+    (2, 3, 2, 8, "incremental", "cdf", True, "spn", True, 2),
 ]
 
 


### PR DESCRIPTION
In the recently posted release, the blending code determines which NWP models will be combined with which nowcast ensemble members. It does this at once and creates a variable that contains [n_ens_members, n_timesteps, n_cascade_levels, y, x]. For a large number of time steps and ensemble members, this variable can become too big too handle. 

To overcome this issue, this PR tries to implement this procedure within the forecast loop (so per time step instead of all at once), which highly reduces the memory requirements. 