### PR TITLE
Ensure clim window has same size as skill today and place forecast_prev update at end of extrapolation loop

### DIFF
--- a/pysteps/blending/clim.py
+++ b/pysteps/blending/clim.py
@@ -60,8 +60,8 @@ def save_skill(
     current_skill,
     validtime,
     outdir_path,
-    n_models=1,
     window_length=30,
+    **kwargs,
 ):
     """
     Add the current NWP skill to update today's daily average skill. If the day
@@ -79,8 +79,6 @@ def save_skill(
     outdir_path: string
       Path to folder where the historical skill are stored. Defaults to
       path_workdir from rcparams.
-    n_models: int, optional
-      Number of NWP models. Defaults to 1.
     window_length: int, optional
       Length of window (in days) of daily skill that should be retained.
       Defaults to 30.
@@ -124,7 +122,7 @@ def save_skill(
         if (
             past_skill is not None
             and past_skill.shape[2] == n_cascade_levels
-            and past_skill.shape[1] == n_models
+            and past_skill.shape[1] == skill_today["mean_skill"].shape[0]
         ):
             past_skill = np.append(past_skill, [skill_today["mean_skill"]], axis=0)
         else:

--- a/pysteps/blending/steps.py
+++ b/pysteps/blending/steps.py
@@ -974,8 +974,6 @@ def forecast(
 
                     t_prev[j] = t_sub
 
-                forecast_prev[j] = precip_cascade[j]
-
             if len(R_f_ep_out) > 0:
                 R_f_ep_out = np.stack(R_f_ep_out)
                 Yn_ep_out = np.stack(Yn_ep_out)
@@ -1050,6 +1048,8 @@ def forecast(
                 )
 
                 t_prev[j] = t + 1
+
+            forecast_prev[j] = precip_cascade[j]
 
             # 8.5 Blend the cascades
             R_f_out = []


### PR DESCRIPTION
This PR makes two minor changes that impact the climatological skill calculation and the extrapolation loop in the steps blending code when subtimesteps are used. 

Changes:
- When the climatological skill window is saved, it first checks if the arrays have the same size as the skill that will be appended. Before, this resulted in an error when moving to the next day (skill clim window gets saved) when the new forecasts have a different number of ensemble members than the skill clim window. This has been solved now. 
- The update of "forecast_prev", the extrapolation and noise cascade that are fed into the extraplation loop, took place too early in the loop. This caused that the extrapolation loop already uses the next forecast when subtimesteps are used. This PR fixes this issue, too.  