### PR TITLE
BUG: Fix T-DaTing labels when continuing tracking

### DIFF
--- a/pysteps/tests/test_tracking_tdating.py
+++ b/pysteps/tests/test_tracking_tdating.py
@@ -15,6 +15,54 @@ arg_values = [
     ("mch", True),
 ]
 
+arg_names_multistep = ("source", "len_timesteps")
+arg_values_multistep = [
+    ("mch", 6),
+]
+
+
+@pytest.mark.parametrize(arg_names_multistep, arg_values_multistep)
+def test_tracking_tdating_dating_multistep(source, len_timesteps):
+    pytest.importorskip("skimage")
+
+    input, metadata = get_precipitation_fields(
+        0, len_timesteps, True, True, 4000, source
+    )
+    input, __ = to_reflectivity(input, metadata)
+
+    timelist = metadata["timestamps"]
+
+    # First half of timesteps
+    tracks_1, cells, labels = dating(
+        input[0 : len_timesteps // 2], timelist[0 : len_timesteps // 2], mintrack=1
+    )
+    # Second half of timesteps
+    tracks_2, cells, _ = dating(
+        input[len_timesteps // 2 - 2 :],
+        timelist[len_timesteps // 2 - 2 :],
+        mintrack=1,
+        start=2,
+        cell_list=cells,
+        label_list=labels,
+    )
+
+    # Since we are adding cells, number of tracks should increase
+    assert len(tracks_1) <= len(tracks_2)
+
+    # Tracks should be continuous in time so time difference should not exceed timestep
+    max_track_step = max([t.time.diff().max().seconds for t in tracks_2 if len(t) > 1])
+    timestep = np.diff(timelist).max().seconds
+    assert max_track_step <= timestep
+
+    # IDs of unmatched cells should increase in every timestep
+    for prev_df, cur_df in zip(cells[:-1], cells[1:]):
+        prev_ids = set(prev_df.ID)
+        cur_ids = set(cur_df.ID)
+        new_ids = list(cur_ids - prev_ids)
+        prev_unmatched = list(prev_ids - cur_ids)
+        if len(prev_unmatched):
+            assert np.all(np.array(new_ids) > max(prev_unmatched))
+
 
 @pytest.mark.parametrize(arg_names, arg_values)
 def test_tracking_tdating_dating(source, dry_input):

--- a/pysteps/tests/test_tracking_tdating.py
+++ b/pysteps/tests/test_tracking_tdating.py
@@ -25,20 +25,22 @@ arg_values_multistep = [
 def test_tracking_tdating_dating_multistep(source, len_timesteps):
     pytest.importorskip("skimage")
 
-    input, metadata = get_precipitation_fields(
+    input_fields, metadata = get_precipitation_fields(
         0, len_timesteps, True, True, 4000, source
     )
-    input, __ = to_reflectivity(input, metadata)
+    input_fields, __ = to_reflectivity(input_fields, metadata)
 
     timelist = metadata["timestamps"]
 
     # First half of timesteps
     tracks_1, cells, labels = dating(
-        input[0 : len_timesteps // 2], timelist[0 : len_timesteps // 2], mintrack=1
+        input_fields[0 : len_timesteps // 2],
+        timelist[0 : len_timesteps // 2],
+        mintrack=1,
     )
     # Second half of timesteps
     tracks_2, cells, _ = dating(
-        input[len_timesteps // 2 - 2 :],
+        input_fields[len_timesteps // 2 - 2 :],
         timelist[len_timesteps // 2 - 2 :],
         mintrack=1,
         start=2,

--- a/pysteps/tracking/tdating.py
+++ b/pysteps/tracking/tdating.py
@@ -152,7 +152,10 @@ def dating(
         raise ValueError("start > len(timelist)")
 
     oflow_method = motion.get_method("LK")
-    max_ID = 0
+    if len(label_list) == 0:
+        max_ID = 0
+    else:
+        max_ID = np.nanmax([np.nanmax(np.unique(label_list)), 0])
     for t in range(start, len(timelist)):
         cells_id, labels = tstorm_detect.detection(
             input_video[t, :, :],


### PR DESCRIPTION
Hi! We came across this bug when trying to use the tracking functions. When continuing the tracking from previously tracked list, the tracks were weird, for example when tracking 3 x 20-minute intervals:

![Track](https://user-images.githubusercontent.com/11709270/164752692-bf896a42-ccb3-4f37-8f06-59ca63f5b239.png)

This is because when setting the unique IDs for the tracks, the IDs of the previous cells are not considered. This PR fixes that. Here are the tracks with this fix:

![Track_fixed](https://user-images.githubusercontent.com/11709270/164752878-de16e629-ea04-42b0-9494-eeb64c019fa9.png)