### PR TITLE
Cascade scale fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 21.7b0
+    rev: 22.3.0
     hooks:
     - id: black
       language_version: python3

--- a/pysteps/cascade/bandpass_filters.py
+++ b/pysteps/cascade/bandpass_filters.py
@@ -104,7 +104,7 @@ def filter_gaussian(
         between successive spatial scales is constant. This value is
         l_0 = (0.5 * l)**(1 / (n-1)).
     gauss_scale: float
-        Optional scaling prameter. Proportional to the standard deviation of
+        Optional scaling parameter. Proportional to the standard deviation of
         the Gaussian weight functions.
     gauss_scale_0: float
         Optional scaling parameter for the Gaussian function corresponding to

--- a/pysteps/cascade/bandpass_filters.py
+++ b/pysteps/cascade/bandpass_filters.py
@@ -89,7 +89,14 @@ def filter_uniform(shape, n):
 
 
 def filter_gaussian(
-    shape, n, l_0=None, gauss_scale=0.5, gauss_scale_0=0.5, d=1.0, normalize=True
+    shape,
+    n,
+    l_0=None,
+    gauss_scale=0.5,
+    gauss_scale_0=0.5,
+    d=1.0,
+    normalize=True,
+    return_weight_funcs=False,
 ):
     """
     Implements a set of Gaussian bandpass filters in logarithmic frequency
@@ -118,6 +125,9 @@ def filter_gaussian(
     normalize: bool
         If True, normalize the weights so that for any given wavenumber
         they sum to one.
+    return_weight_funcs: bool
+        If True, add callable weight functions to the output dictionary with
+        the key 'weight_funcs'.
 
     Returns
     -------
@@ -188,6 +198,9 @@ def filter_gaussian(
     central_freqs[-1] = 0.5  # Nyquist freq
     central_freqs = 1.0 * d * central_freqs
     out["central_freqs"] = central_freqs
+
+    if return_weight_funcs:
+        out["weight_funcs"] = wfs
 
     return out
 

--- a/pysteps/cascade/bandpass_filters.py
+++ b/pysteps/cascade/bandpass_filters.py
@@ -63,6 +63,10 @@ def filter_uniform(shape, n):
     n: int
         Not used. Needed for compatibility with the filter interface.
 
+    Returns
+    -------
+    out: dict
+        A dictionary containing the filter.
     """
     del n  # Unused
 

--- a/pysteps/cascade/bandpass_filters.py
+++ b/pysteps/cascade/bandpass_filters.py
@@ -181,9 +181,11 @@ def filter_gaussian(
 
     for i in range(len(wfs)):
         if i == 0 and include_mean:
-            continue
-        weights_1d[i, 0] = 0.0
-        weights_2d[i, 0, 0] = 0.0
+            weights_1d[i, 0] = 1.0
+            weights_2d[i, 0, 0] = 1.0
+        else:
+            weights_1d[i, 0] = 0.0
+            weights_2d[i, 0, 0] = 0.0
 
     out = {"weights_1d": weights_1d, "weights_2d": weights_2d}
     out["shape"] = shape

--- a/pysteps/cascade/bandpass_filters.py
+++ b/pysteps/cascade/bandpass_filters.py
@@ -102,7 +102,7 @@ def filter_gaussian(
         Central frequency of the second band (the first band is always centered
         at zero). If set to None, l_0 is chosen automatically so that the ratio
         between successive spatial scales is constant. This value is
-        l_0 = (0.5 * l)**(1 / (n-1)).
+        l_0 = (0.5 * max(shape[0], shape[1])) ** (1 / (n-1)).
     gauss_scale: float
         Optional scaling parameter. Proportional to the standard deviation of
         the Gaussian weight functions.

--- a/pysteps/cascade/bandpass_filters.py
+++ b/pysteps/cascade/bandpass_filters.py
@@ -134,8 +134,10 @@ def filter_gaussian(
     except TypeError:
         height, width = (shape, shape)
 
+    max_length = max(width, height)
+
     if l_0 is None:
-        l_0 = (0.5 * np.min(shape)) ** (1 / (n - 1))
+        l_0 = (0.5 * max_length) ** (1 / (n - 1))
 
     rx = np.s_[: int(width / 2) + 1]
 
@@ -148,8 +150,6 @@ def filter_gaussian(
     dy = int(height / 2) if height % 2 == 0 else int(height / 2) + 1
 
     r_2d = np.roll(np.sqrt(x_grid * x_grid + y_grid * y_grid), dy, axis=0)
-
-    max_length = max(width, height)
 
     r_max = int(max_length / 2) + 1
     r_1d = np.arange(r_max)

--- a/pysteps/cascade/bandpass_filters.py
+++ b/pysteps/cascade/bandpass_filters.py
@@ -180,7 +180,7 @@ def filter_gaussian(
             weights_2d[k, :, :] /= weights_2d_sum
 
     for i in range(len(wfs)):
-        if include_mean:
+        if i == 0 and include_mean:
             continue
         weights_1d[i, 0] = 0.0
         weights_2d[i, 0, 0] = 0.0

--- a/pysteps/cascade/bandpass_filters.py
+++ b/pysteps/cascade/bandpass_filters.py
@@ -95,6 +95,7 @@ def filter_gaussian(
     d=1.0,
     normalize=True,
     return_weight_funcs=False,
+    include_mean=True,
 ):
     """
     Implements a set of Gaussian bandpass filters in logarithmic frequency
@@ -118,18 +119,15 @@ def filter_gaussian(
     return_weight_funcs: bool
         If True, add callable weight functions to the output dictionary with
         the key 'weight_funcs'.
+    include_mean: bool
+        If True, include the first Fourier wavenumber (corresponding to the
+        field mean) to the first filter.
 
     Returns
     -------
     out: dict
         A dictionary containing the bandpass filters corresponding to the
         specified frequency bands.
-
-    Notes
-    -----
-    The fist Fourier frequency is not included in the filters. So it needs to
-    be treated separately if these filters are used for decomposing an input
-    field.
 
     References
     ----------
@@ -182,6 +180,8 @@ def filter_gaussian(
             weights_2d[k, :, :] /= weights_2d_sum
 
     for i in range(len(wfs)):
+        if include_mean:
+            continue
         weights_1d[i, 0] = 0.0
         weights_2d[i, 0, 0] = 0.0
 

--- a/pysteps/cascade/bandpass_filters.py
+++ b/pysteps/cascade/bandpass_filters.py
@@ -66,7 +66,7 @@ def filter_uniform(shape, n):
     """
     del n  # Unused
 
-    result = {}
+    out = {}
 
     try:
         height, width = shape
@@ -75,13 +75,13 @@ def filter_uniform(shape, n):
 
     r_max = int(max(width, height) / 2) + 1
 
-    result["weights_1d"] = np.ones((1, r_max))
-    result["weights_2d"] = np.ones((1, height, int(width / 2) + 1))
-    result["central_freqs"] = None
-    result["central_wavenumbers"] = None
-    result["shape"] = shape
+    out["weights_1d"] = np.ones((1, r_max))
+    out["weights_2d"] = np.ones((1, height, int(width / 2) + 1))
+    out["central_freqs"] = None
+    out["central_wavenumbers"] = None
+    out["shape"] = shape
 
-    return result
+    return out
 
 
 def filter_gaussian(
@@ -172,20 +172,20 @@ def filter_gaussian(
             weights_1d[k, :] /= weights_1d_sum
             weights_2d[k, :, :] /= weights_2d_sum
 
-    result = {"weights_1d": weights_1d, "weights_2d": weights_2d}
-    result["shape"] = shape
+    out = {"weights_1d": weights_1d, "weights_2d": weights_2d}
+    out["shape"] = shape
 
     central_wavenumbers = np.array(central_wavenumbers)
-    result["central_wavenumbers"] = central_wavenumbers
+    out["central_wavenumbers"] = central_wavenumbers
 
     # Compute frequencies
     central_freqs = 1.0 * central_wavenumbers / max_length
     central_freqs[0] = 1.0 / max_length
     central_freqs[-1] = 0.5  # Nyquist freq
     central_freqs = 1.0 * d * central_freqs
-    result["central_freqs"] = central_freqs
+    out["central_freqs"] = central_freqs
 
-    return result
+    return out
 
 
 def _gaussweights_1d(l, n, l_0=None, gauss_scale=0.5, gauss_scale_0=0.5):

--- a/pysteps/cascade/bandpass_filters.py
+++ b/pysteps/cascade/bandpass_filters.py
@@ -172,9 +172,7 @@ def filter_gaussian(
 
     for i, wf in enumerate(wfs):
         weights_1d[i, :] = wf(r_1d)
-        weights_1d[i, 0] = 0.0
         weights_2d[i, :, :] = wf(r_2d)
-        weights_2d[i, 0, 0] = 0.0
 
     if normalize:
         weights_1d_sum = np.sum(weights_1d, axis=0)
@@ -182,6 +180,10 @@ def filter_gaussian(
         for k in range(weights_2d.shape[0]):
             weights_1d[k, :] /= weights_1d_sum
             weights_2d[k, :, :] /= weights_2d_sum
+
+    for i in range(len(wfs)):
+        weights_1d[i, 0] = 0.0
+        weights_2d[i, 0, 0] = 0.0
 
     out = {"weights_1d": weights_1d, "weights_2d": weights_2d}
     out["shape"] = shape

--- a/pysteps/cascade/bandpass_filters.py
+++ b/pysteps/cascade/bandpass_filters.py
@@ -85,7 +85,7 @@ def filter_uniform(shape, n):
 
 
 def filter_gaussian(
-    shape, n, l_0=3, gauss_scale=0.5, gauss_scale_0=0.5, d=1.0, normalize=True
+    shape, n, l_0=None, gauss_scale=0.5, gauss_scale_0=0.5, d=1.0, normalize=True
 ):
     """
     Implements a set of Gaussian bandpass filters in logarithmic frequency
@@ -100,7 +100,9 @@ def filter_gaussian(
         The number of frequency bands to use. Must be greater than 2.
     l_0: int
         Central frequency of the second band (the first band is always centered
-        at zero).
+        at zero). If set to None, l_0 is chosen automatically so that the ratio
+        between successive spatial scales is constant. This value is
+        l_0 = (0.5 * l)**(1 / (n-1)).
     gauss_scale: float
         Optional scaling prameter. Proportional to the standard deviation of
         the Gaussian weight functions.
@@ -131,6 +133,9 @@ def filter_gaussian(
         height, width = shape
     except TypeError:
         height, width = (shape, shape)
+
+    if l_0 is None:
+        l_0 = (0.5 * np.min(shape)) ** (1 / (n - 1))
 
     rx = np.s_[: int(width / 2) + 1]
 
@@ -183,7 +188,7 @@ def filter_gaussian(
     return result
 
 
-def _gaussweights_1d(l, n, l_0=3, gauss_scale=0.5, gauss_scale_0=0.5):
+def _gaussweights_1d(l, n, l_0=None, gauss_scale=0.5, gauss_scale_0=0.5):
     e = pow(0.5 * l / l_0, 1.0 / (n - 2))
     r = [(l_0 * pow(e, k - 1), l_0 * pow(e, k)) for k in range(1, n - 1)]
 

--- a/pysteps/cascade/bandpass_filters.py
+++ b/pysteps/cascade/bandpass_filters.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 pysteps.cascade.bandpass_filters
 ================================

--- a/pysteps/cascade/bandpass_filters.py
+++ b/pysteps/cascade/bandpass_filters.py
@@ -125,6 +125,12 @@ def filter_gaussian(
         A dictionary containing the bandpass filters corresponding to the
         specified frequency bands.
 
+    Notes
+    -----
+    The fist Fourier frequency is not included in the filters. So it needs to
+    be treated separately if these filters are used for decomposing an input
+    field.
+
     References
     ----------
     :cite:`PCH2018`
@@ -166,7 +172,9 @@ def filter_gaussian(
 
     for i, wf in enumerate(wfs):
         weights_1d[i, :] = wf(r_1d)
+        weights_1d[i, 0] = 0.0
         weights_2d[i, :, :] = wf(r_2d)
+        weights_2d[i, 0, 0] = 0.0
 
     if normalize:
         weights_1d_sum = np.sum(weights_1d, axis=0)

--- a/pysteps/cascade/decomposition.py
+++ b/pysteps/cascade/decomposition.py
@@ -121,7 +121,7 @@ def decomposition_fft(field, bp_filter, **kwargs):
     subtract_mean: bool
         If set to True, subtract the mean value before the decomposition and
         store it to the output dictionary. Applicable if input_domain is
-        "spatial". Defaults to True.
+        "spatial". Defaults to False.
 
     Returns
     -------
@@ -140,7 +140,7 @@ def decomposition_fft(field, bp_filter, **kwargs):
     output_domain = kwargs.get("output_domain", "spatial")
     compute_stats = kwargs.get("compute_stats", True)
     compact_output = kwargs.get("compact_output", False)
-    subtract_mean = kwargs.get("subtract_mean", True)
+    subtract_mean = kwargs.get("subtract_mean", False)
 
     if normalize and not compute_stats:
         compute_stats = True

--- a/pysteps/cascade/decomposition.py
+++ b/pysteps/cascade/decomposition.py
@@ -140,7 +140,7 @@ def decomposition_fft(field, bp_filter, **kwargs):
     output_domain = kwargs.get("output_domain", "spatial")
     compute_stats = kwargs.get("compute_stats", True)
     compact_output = kwargs.get("compact_output", False)
-    subtract_mean = kwargs.get("subtract_mean", False)
+    subtract_mean = kwargs.get("subtract_mean", True)
 
     if normalize and not compute_stats:
         compute_stats = True

--- a/pysteps/cascade/decomposition.py
+++ b/pysteps/cascade/decomposition.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 pysteps.cascade.decomposition
 =============================

--- a/pysteps/cascade/interface.py
+++ b/pysteps/cascade/interface.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 pysteps.cascade.interface
 =========================

--- a/pysteps/tests/test_nowcasts_steps.py
+++ b/pysteps/tests/test_nowcasts_steps.py
@@ -24,9 +24,9 @@ steps_arg_names = (
 steps_arg_values = [
     (5, 6, 2, None, None, "spatial", 3, 1.30),
     (5, 6, 2, None, None, "spatial", [3], 1.30),
-    (5, 6, 2, "incremental", None, "spatial", 3, 7.25),
-    (5, 6, 2, "sprog", None, "spatial", 3, 8.35),
-    (5, 6, 2, "obs", None, "spatial", 3, 8.30),
+    (5, 6, 2, "incremental", None, "spatial", 3, 7.31),
+    (5, 6, 2, "sprog", None, "spatial", 3, 8.4),
+    (5, 6, 2, "obs", None, "spatial", 3, 8.37),
     (5, 6, 2, None, "cdf", "spatial", 3, 0.60),
     (5, 6, 2, None, "mean", "spatial", 3, 1.35),
     (5, 6, 2, "incremental", "cdf", "spectral", 3, 0.60),


### PR DESCRIPTION
It was pointed out in Issue #276 by that when using the cascade decomposition with the default parameters, the ratio between successive scales is not constant. There was a gap between the first scale and the remaining ones. However, this can be simply fixed by setting

l_0 = (0.5 * l) ** (1 / (n - 1))

So, I made this the new default value in `cascade.bandpass_filters.filter_gaussian`.