### PR TITLE
Improve documentation of rainfarm downscaling

### DIFF
--- a/examples/rainfarm_downscale.py
+++ b/examples/rainfarm_downscale.py
@@ -57,11 +57,15 @@ precip[~np.isfinite(precip)] = metadata["zerovalue"]
 # -----------------
 #
 # To test our downscaling method, we first need to upscale the original field to
-# a lower resolution. We are going to use an upscaling factor of 16 x.
+# a lower resolution. This is only for demo purposes, as we need to artificially
+# create a lower resolution field to apply our downscaling method.
+# We are going to use a factor of 16 x.
 
-upscaling_factor = 16
-upscale_to = metadata["xpixelsize"] * upscaling_factor  # upscaling factor : 16 x
-precip_lr, metadata_lr = aggregate_fields_space(precip, metadata, upscale_to)
+downscaling_factor = 16
+upscaled_resolution = (
+    metadata["xpixelsize"] * downscaling_factor
+)  # upscaled resolution : 16 km
+precip_lr, metadata_lr = aggregate_fields_space(precip, metadata, upscaled_resolution)
 
 # Plot the upscaled rainfall field
 plt.figure()
@@ -81,14 +85,14 @@ num_realizations = 5
 # Per realization, generate a stochastically downscaled precipitation field
 # and plot it.
 # The first time, the spectral slope alpha needs to be estimated. To illustrate
-# the sensitity of this parameter, we are going to plot some realizations with
+# the sensitivity of this parameter, we are going to plot some realizations with
 # half or double the estimated slope.
 alpha = None
 for n in range(num_realizations):
 
     # Spectral slope estimated from the upscaled field
     precip_hr, alpha = rainfarm.downscale(
-        precip_lr, ds_factor=upscaling_factor, alpha=alpha, return_alpha=True
+        precip_lr, ds_factor=downscaling_factor, alpha=alpha, return_alpha=True
     )
     plt.subplot(num_realizations, 3, n * 3 + 2)
     plot_precip_field(precip_hr, geodata=metadata, axis="off", colorbar=False)
@@ -97,7 +101,7 @@ for n in range(num_realizations):
 
     # Half the estimated slope
     precip_hr = rainfarm.downscale(
-        precip_lr, ds_factor=upscaling_factor, alpha=alpha * 0.5
+        precip_lr, ds_factor=downscaling_factor, alpha=alpha * 0.5
     )
     plt.subplot(num_realizations, 3, n * 3 + 1)
     plot_precip_field(precip_hr, geodata=metadata, axis="off", colorbar=False)
@@ -106,7 +110,7 @@ for n in range(num_realizations):
 
     # Double the estimated slope
     precip_hr = rainfarm.downscale(
-        precip_lr, ds_factor=upscaling_factor, alpha=alpha * 2
+        precip_lr, ds_factor=downscaling_factor, alpha=alpha * 2
     )
     plt.subplot(num_realizations, 3, n * 3 + 3)
     plot_precip_field(precip_hr, geodata=metadata, axis="off", colorbar=False)

--- a/examples/rainfarm_downscale.py
+++ b/examples/rainfarm_downscale.py
@@ -88,7 +88,7 @@ for n in range(num_realizations):
 
     # Spectral slope estimated from the upscaled field
     precip_hr, alpha = rainfarm.downscale(
-        precip_lr, alpha=alpha, ds_factor=upscaling_factor, return_alpha=True
+        precip_lr, ds_factor=upscaling_factor, alpha=alpha, return_alpha=True
     )
     plt.subplot(num_realizations, 3, n * 3 + 2)
     plot_precip_field(precip_hr, geodata=metadata, axis="off", colorbar=False)
@@ -97,7 +97,7 @@ for n in range(num_realizations):
 
     # Half the estimated slope
     precip_hr = rainfarm.downscale(
-        precip_lr, alpha=alpha * 0.5, ds_factor=upscaling_factor
+        precip_lr, ds_factor=upscaling_factor, alpha=alpha * 0.5
     )
     plt.subplot(num_realizations, 3, n * 3 + 1)
     plot_precip_field(precip_hr, geodata=metadata, axis="off", colorbar=False)
@@ -106,7 +106,7 @@ for n in range(num_realizations):
 
     # Double the estimated slope
     precip_hr = rainfarm.downscale(
-        precip_lr, alpha=alpha * 2, ds_factor=upscaling_factor
+        precip_lr, ds_factor=upscaling_factor, alpha=alpha * 2
     )
     plt.subplot(num_realizations, 3, n * 3 + 3)
     plot_precip_field(precip_hr, geodata=metadata, axis="off", colorbar=False)

--- a/examples/rainfarm_downscale.py
+++ b/examples/rainfarm_downscale.py
@@ -61,9 +61,9 @@ precip[~np.isfinite(precip)] = metadata["zerovalue"]
 # create a lower resolution field to apply our downscaling method.
 # We are going to use a factor of 16 x.
 
-downscaling_factor = 16
+scale_factor = 16
 upscaled_resolution = (
-    metadata["xpixelsize"] * downscaling_factor
+    metadata["xpixelsize"] * scale_factor
 )  # upscaled resolution : 16 km
 precip_lr, metadata_lr = aggregate_fields_space(precip, metadata, upscaled_resolution)
 
@@ -92,7 +92,7 @@ for n in range(num_realizations):
 
     # Spectral slope estimated from the upscaled field
     precip_hr, alpha = rainfarm.downscale(
-        precip_lr, ds_factor=downscaling_factor, alpha=alpha, return_alpha=True
+        precip_lr, ds_factor=scale_factor, alpha=alpha, return_alpha=True
     )
     plt.subplot(num_realizations, 3, n * 3 + 2)
     plot_precip_field(precip_hr, geodata=metadata, axis="off", colorbar=False)
@@ -100,18 +100,14 @@ for n in range(num_realizations):
         plt.title(f"alpha={alpha:.1f}")
 
     # Half the estimated slope
-    precip_hr = rainfarm.downscale(
-        precip_lr, ds_factor=downscaling_factor, alpha=alpha * 0.5
-    )
+    precip_hr = rainfarm.downscale(precip_lr, ds_factor=scale_factor, alpha=alpha * 0.5)
     plt.subplot(num_realizations, 3, n * 3 + 1)
     plot_precip_field(precip_hr, geodata=metadata, axis="off", colorbar=False)
     if n == 0:
         plt.title(f"alpha={alpha * 0.5:.1f}")
 
     # Double the estimated slope
-    precip_hr = rainfarm.downscale(
-        precip_lr, ds_factor=downscaling_factor, alpha=alpha * 2
-    )
+    precip_hr = rainfarm.downscale(precip_lr, ds_factor=scale_factor, alpha=alpha * 2)
     plt.subplot(num_realizations, 3, n * 3 + 3)
     plot_precip_field(precip_hr, geodata=metadata, axis="off", colorbar=False)
     if n == 0:

--- a/pysteps/downscaling/rainfarm.py
+++ b/pysteps/downscaling/rainfarm.py
@@ -6,6 +6,11 @@ pysteps.downscaling.rainfarm
 Implementation of the RainFARM stochastic downscaling method as described in
 :cite:`Rebora2006`.
 
+RainFARM is a downscaling algorithm for rainfall fields developed by Rebora et
+al. (2006). The method can represent the realistic small-scale variability of the
+downscaled precipitation field by means of Gaussian random fields.
+
+
 .. autosummary::
     :toctree: ../generated/
 

--- a/pysteps/downscaling/rainfarm.py
+++ b/pysteps/downscaling/rainfarm.py
@@ -41,36 +41,32 @@ def _balanced_spatial_average(x, k):
 
 def downscale(precip, alpha=None, ds_factor=16, threshold=None, return_alpha=False):
     """
-    Downscale a rainfall field by a given factor.
+    Downscale a rainfall field by increasing its spatial resolution by
+    a positive integer factor.
 
     Parameters
     ----------
-
-    precip: array_like
-        Array of shape (m,n) containing the input field.
+    precip: array-like
+        Array of shape (m, n) containing the input field.
         The input is expected to contain rain rate values.
-
     alpha: float, optional
-        Spectral slope. If none, the slope is estimated from
+        Spectral slope. If None, the slope is estimated from
         the input array.
-
-    ds_factor: int, optional
-        Downscaling factor.
-
+    ds_factor: positive int
+        Downscaling factor, it specifies by how many times
+        to increase the initial grid resolution.
     threshold: float, optional
         Set all values lower than the threshold to zero.
-
     return_alpha: bool, optional
-        Whether to return the estimated spectral slope `alpha`.
-
+        Whether to return the estimated spectral slope ``alpha``.
 
     Returns
     -------
-    r: array_like
-        Array of shape (m*ds_factor,n*ds_factor) containing
+    r: array-like
+        Array of shape (m * ds_factor, n * ds_factor) containing
         the downscaled field.
     alpha: float
-        Returned only when `return_alpha=True`.
+        Returned only when ``return_alpha=True``.
 
     Notes
     -----

--- a/pysteps/downscaling/rainfarm.py
+++ b/pysteps/downscaling/rainfarm.py
@@ -39,7 +39,7 @@ def _balanced_spatial_average(x, k):
     return convolve(x, k) / convolve(ones, k)
 
 
-def downscale(precip, alpha=None, ds_factor=16, threshold=None, return_alpha=False):
+def downscale(precip, ds_factor, alpha=None, threshold=None, return_alpha=False):
     """
     Downscale a rainfall field by increasing its spatial resolution by
     a positive integer factor.

--- a/pysteps/downscaling/rainfarm.py
+++ b/pysteps/downscaling/rainfarm.py
@@ -54,6 +54,7 @@ def downscale(precip, ds_factor, alpha=None, threshold=None, return_alpha=False)
     precip: array-like
         Array of shape (m, n) containing the input field.
         The input is expected to contain rain rate values.
+        All values are required to be finite.
     alpha: float, optional
         Spectral slope. If None, the slope is estimated from
         the input array.

--- a/pysteps/tests/test_downscaling_rainfarm.py
+++ b/pysteps/tests/test_downscaling_rainfarm.py
@@ -7,30 +7,35 @@ from pysteps.tests.helpers import get_precipitation_fields
 from pysteps.utils import aggregate_fields_space, square_domain
 
 
-# load and preprocess input field
-precip, metadata = get_precipitation_fields(
-    num_prev_files=0, num_next_files=0, return_raw=False, metadata=True
-)
-precip = precip.filled()
-precip, metadata = square_domain(precip, metadata, "crop")
+@pytest.fixture(scope="module")
+def data():
+    precip, metadata = get_precipitation_fields(
+        num_prev_files=0, num_next_files=0, return_raw=False, metadata=True
+    )
+    precip = precip.filled()
+    precip, metadata = square_domain(precip, metadata, "crop")
+    return precip, metadata
 
 
 rainfarm_arg_names = ("alpha", "ds_factor", "threshold", "return_alpha")
-
-
 rainfarm_arg_values = [(1.0, 1, 0, False), (1, 2, 0, False), (1, 4, 0, False)]
 
 
 @pytest.mark.parametrize(rainfarm_arg_names, rainfarm_arg_values)
-def test_rainfarm_shape(alpha, ds_factor, threshold, return_alpha):
-    """Test that the output of rainfarm is consistent with the downscalnig factor."""
-
+def test_rainfarm_shape(data, alpha, ds_factor, threshold, return_alpha):
+    """Test that the output of rainfarm is consistent with the downscaling factor."""
+    precip, metadata = data
     window = metadata["xpixelsize"] * ds_factor
     precip_lr, __ = aggregate_fields_space(precip, metadata, window)
 
     rainfarm = downscaling.get_method("rainfarm")
-
-    precip_hr = rainfarm(precip_lr, alpha, ds_factor, threshold, return_alpha)
+    precip_hr = rainfarm(
+        precip_lr,
+        alpha=alpha,
+        ds_factor=ds_factor,
+        threshold=threshold,
+        return_alpha=return_alpha,
+    )
 
     assert precip_hr.ndim == precip.ndim
     assert precip_hr.shape[0] == precip.shape[0]
@@ -41,15 +46,20 @@ rainfarm_arg_values = [(1.0, 2, 0, True), (None, 2, 0, True)]
 
 
 @pytest.mark.parametrize(rainfarm_arg_names, rainfarm_arg_values)
-def test_rainfarm_alpha(alpha, ds_factor, threshold, return_alpha):
+def test_rainfarm_alpha(data, alpha, ds_factor, threshold, return_alpha):
     """Test that rainfarm computes and returns alpha."""
-
+    precip, metadata = data
     window = metadata["xpixelsize"] * ds_factor
     precip_lr, __ = aggregate_fields_space(precip, metadata, window)
 
     rainfarm = downscaling.get_method("rainfarm")
-
-    precip_hr = rainfarm(precip_lr, alpha, ds_factor, threshold, return_alpha)
+    precip_hr = rainfarm(
+        precip_lr,
+        alpha=alpha,
+        ds_factor=ds_factor,
+        threshold=threshold,
+        return_alpha=return_alpha,
+    )
 
     assert len(precip_hr) == 2
     if alpha is None:


### PR DESCRIPTION
Try to improve the documentation of the `pysteps.downscaling.rainfarm` module based on some recent feedback (see relative discussion on our pysteps slack channel).

### Breaking changes

- `pysteps.downscaling.rainfarm.downscale()`: keyword argument `ds_factor` becomes a positional argument without default value.