### PR TITLE
[ERAD] Add test cleansing error is raise when input has nans

### DIFF
--- a/pysteps/tests/test_utils_cleansing.py
+++ b/pysteps/tests/test_utils_cleansing.py
@@ -174,3 +174,12 @@ def test_detect_outlier_multivariate_local():
     V[-1] = (-3, 3)
     outliers = cleansing.detect_outliers(V, 4, coord=X, k=50)
     assert outliers.sum() == 2
+
+def test_value_error_is_raise_when_input_has_nan():
+    cor = np.ones((3, 1))
+    iarr = np.ones((3, 1))
+    scale = 20
+
+    iarr[1,0] = np.nan
+    with pytest.raises(ValueError):
+        cleansing.decluster(cor, iarr, scale)


### PR DESCRIPTION
This PR adds a test for the cleansing function that checks that an error is raised when input has nans.