### PR TITLE
Test for dimensionality of input in extrapolation routine

### DIFF
--- a/pysteps/tests/test_extrapolation_semilagrangian.py
+++ b/pysteps/tests/test_extrapolation_semilagrangian.py
@@ -19,3 +19,23 @@ def test_semilagrangian():
     # result
     result = extrapolate(precip, velocity, num_timesteps)
     assert_array_almost_equal(result, expected)
+
+
+def test_wrong_input_dimensions():
+    p_1d = np.ones(8)
+    p_2d = np.ones((8, 8))
+    p_3d = np.ones((8, 8, 2))
+    v_2d = np.ones((8, 8))
+    v_3d = np.stack([v_2d, v_2d])
+
+    num_timesteps = 1
+
+    invalid_inputs = [
+        (p_1d, v_3d),
+        (p_2d, v_2d),
+        (p_3d, v_2d),
+        (p_3d, v_3d),
+    ]
+    for precip, velocity in invalid_inputs:
+        with pytest.raises(ValueError):
+            extrapolate(precip, velocity, num_timesteps)


### PR DESCRIPTION
in this branch we added a test to check input whether wrong dimensions of precipitation and velocity fields raise errors