### PR TITLE
Fix wrong type when passing slope as float

### DIFF
--- a/pysteps/nowcasts/lagrangian_probability.py
+++ b/pysteps/nowcasts/lagrangian_probability.py
@@ -87,7 +87,7 @@ def forecast(
     # Compute exceedance probabilities using a neighborhood approach
     precip_forecast = (precip_forecast >= threshold).astype(float)
     for i, timestep in enumerate(timesteps):
-        scale = timestep * slope
+        scale = int(timestep * slope)
         if scale == 0:
             continue
         kernel = _get_kernel(scale)

--- a/pysteps/tests/test_nowcasts_lagrangian_probability.py
+++ b/pysteps/tests/test_nowcasts_lagrangian_probability.py
@@ -32,6 +32,25 @@ def test_numerical_example():
     assert np.allclose(fct, ref)
 
 
+def test_numerical_example_with_float_slope_and_float_list_timesteps():
+    """"""
+    precip = np.zeros((20, 20))
+    precip[5:10, 5:10] = 1
+    velocity = np.zeros((2, *precip.shape))
+    timesteps = [1.0, 2.0, 5.0, 12.0]
+    thr = 0.5
+    slope = 1.0  # pixels / timestep
+
+    # compute probability forecast
+    fct = forecast(precip, velocity, timesteps, thr, slope=slope)
+
+    assert fct.ndim == 3
+    assert fct.shape[0] == len(timesteps)
+    assert fct.shape[1:] == precip.shape
+    assert fct.max() <= 1.0
+    assert fct.min() >= 0.0
+
+
 def test_real_case():
     """"""
     pytest.importorskip("cv2")


### PR DESCRIPTION
This PR is trying to solve issue #307 by forcing **scale** to be an integer. A test (copy of a previous test) has been added with a float slope to show it is working and fixing the issue. Several other things could be addressed as the name of scale/size disagreement but I am not sure of the original purpose of these two different names so I am not changing that.