### PR TITLE
Adopt support for python 3.8-3.10

### DIFF
--- a/.github/workflows/check_black.yml
+++ b/.github/workflows/check_black.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install dependencies

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/test_pysteps.yml
+++ b/.github/workflows/test_pysteps.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
-        python-version: [ "3.7", "3.8", "3.9" ]
+        python-version: ["3.8", "3.10"]
       max-parallel: 6
 
     defaults:

--- a/.github/workflows/test_pysteps.yml
+++ b/.github/workflows/test_pysteps.yml
@@ -36,7 +36,6 @@ jobs:
       - name: Install mamba and create environment
         uses: mamba-org/provision-with-micromamba@main
         with:
-          micromamba-version: 0.24.0
           environment-file: ci/ci_test_env.yml
           environment-name: test_environment
           extra-specs: python=${{ matrix.python-version }}

--- a/.github/workflows/test_pysteps.yml
+++ b/.github/workflows/test_pysteps.yml
@@ -86,12 +86,12 @@ jobs:
 
       - name: Upload coverage to Codecov (Linux only)
         if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         env:
           OS: ${{ matrix.os }}
           PYTHON: ${{ matrix.python-version }}
         with:
-          file: ${{github.workspace}}/pysteps_data/coverage.xml
+          files: ${{github.workspace}}/pysteps_data/coverage.xml
           flags: unit_tests
           env_vars: OS,PYTHON
           fail_ci_if_error: true

--- a/.github/workflows/test_pysteps.yml
+++ b/.github/workflows/test_pysteps.yml
@@ -28,8 +28,8 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/doc/source/user_guide/install_pysteps.rst
+++ b/doc/source/user_guide/install_pysteps.rst
@@ -8,7 +8,7 @@ Dependencies
 
 The pysteps package needs the following dependencies
 
-* `python >=3.7, <3.10 <http://www.python.org/>`_ (lower or higher versions may work but are not tested).
+* `python >=3.8, <3.11 <http://www.python.org/>`_ (lower or higher versions may work but are not tested).
 * `jsonschema <https://pypi.org/project/jsonschema/>`_
 * `matplotlib <http://matplotlib.org/>`_
 * `netCDF4 <https://pypi.org/project/netCDF4/>`_

--- a/pysteps/noise/fftgenerators.py
+++ b/pysteps/noise/fftgenerators.py
@@ -507,8 +507,8 @@ def initialize_nonparam_2d_ssft_filter(field, **kwargs):
     # SSFT algorithm
 
     # prepare indices
-    idxi = np.zeros((2, 1), dtype=int)
-    idxj = np.zeros((2, 1), dtype=int)
+    idxi = np.zeros(2, dtype=int)
+    idxj = np.zeros(2, dtype=int)
 
     # number of windows
     num_windows_y = np.ceil(float(dim_y) / win_size[0]).astype(int)
@@ -793,8 +793,8 @@ def generate_noise_2d_ssft_filter(F, randstate=None, seed=None, **kwargs):
     cN = np.zeros(dim)
     sM = np.zeros(dim)
 
-    idxi = np.zeros((2, 1), dtype=int)
-    idxj = np.zeros((2, 1), dtype=int)
+    idxi = np.zeros(2, dtype=int)
+    idxj = np.zeros(2, dtype=int)
 
     # get the window size
     win_size = (float(dim_y) / F.shape[0], float(dim_x) / F.shape[1])

--- a/pysteps/nowcasts/sseps.py
+++ b/pysteps/nowcasts/sseps.py
@@ -466,8 +466,8 @@ def forecast(
     M, N = precip.shape[1:]
     n_windows_M = np.ceil(1.0 * M / win_size[0]).astype(int)
     n_windows_N = np.ceil(1.0 * N / win_size[1]).astype(int)
-    idxm = np.zeros((2, 1), dtype=int)
-    idxn = np.zeros((2, 1), dtype=int)
+    idxm = np.zeros(2, dtype=int)
+    idxn = np.zeros(2, dtype=int)
 
     if measure_time:
         starttime = time.time()
@@ -677,8 +677,8 @@ def forecast(
 
             # then the local steps
             if n_windows_M > 1 or n_windows_N > 1:
-                idxm = np.zeros((2, 1), dtype=int)
-                idxn = np.zeros((2, 1), dtype=int)
+                idxm = np.zeros(2, dtype=int)
+                idxn = np.zeros(2, dtype=int)
                 precip_l = np.zeros((M, N), dtype=float)
                 M_s = np.zeros((M, N), dtype=float)
                 for m in range(n_windows_M):


### PR DESCRIPTION
Follow [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html) policy for support to python versions.

Additionally:
- Unpin micromamba version
- Update workflows to Node 16 following the [deprecation of Node 12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) for GitHub actions.