### PR TITLE
Spatial aggregation fix

### DIFF
--- a/pysteps/tests/test_utils_dimension.py
+++ b/pysteps/tests/test_utils_dimension.py
@@ -150,7 +150,7 @@ test_data = [
         {"unit": "mm", "xpixelsize": 1, "ypixelsize": 1},
         2,
         False,
-        4 * np.ones((1, 5, 5)),
+        np.ones((1, 5, 5)),
     ),
     (
         np.ones((1, 10, 10)),

--- a/pysteps/utils/dimension.py
+++ b/pysteps/utils/dimension.py
@@ -197,10 +197,8 @@ def aggregate_fields_space(R, metadata, space_window, ignore_nan=False):
 
     # specify the operator to be used to aggregate the values
     # within the space window
-    if unit == "mm/h":
+    if unit == "mm/h" or unit == "mm":
         method = "mean"
-    elif unit == "mm":
-        method = "sum"
     else:
         raise ValueError(
             "can only aggregate units of 'mm/h' or 'mm' " + "not %s" % unit


### PR DESCRIPTION
Although `utils.dimension` will be deprecated in pysteps-v2 (#223), I'm proposing a small update of its `aggregate_fields_space` function to fix a potential error.

The snippet below is currently used in both `aggregate_fields_time` and `aggregate_fields_space` to select the appropriate aggregation method based on the precipitation unit.
```
if unit == "mm/h":
    method = "mean"
elif unit == "mm":
    method = "sum"
else:
    raise ValueError(
        "can only aggregate units of 'mm/h' or 'mm' " + "not %s" % unit
    )
```
While this is indeed the correct approach for the temporal aggregation, it leads to unexpected results* for the spatial counterpart. Hence, I'm suggesting to update `aggregate_fields_space` to use 'mean' aggregation for both 'mm/h' and 'mm' units, as per this PR.

---
 (*) illustration: corresponding example from pystep's test suite
Assuming grid cell dimensions in meter and 1 mm = 1 L/m², the total rainfall _volume_ over the complete field is:
* 10 * 10 *  1 m² * 1 L/m² = 100 L before aggregation (10x10 grid of 1x1 cells with value 1 mm)
*  5 * 5 * 4 m² * 4 L/m² = 400 L after aggregation (5x5 grid of 2x2 cells with value 4 mm)

while this value is expected to remain unaffected by the aggregation.