### PR TITLE
Fix weights in nested noise

### DIFF
--- a/pysteps/noise/fftgenerators.py
+++ b/pysteps/noise/fftgenerators.py
@@ -691,7 +691,9 @@ def initialize_nonparam_2d_nested_filter(field, gridres=1.0, **kwargs):
                     x0 = (
                         Idxinext[n, 1] - Idxinext[n, 0]
                     ) / 2.0  # TODO: consider y dimension, too
-                    merge_weights = 1 / (1 + np.exp(-k * (1 / freq_grid - x0)))
+                    merge_weights = 1 / (
+                        1 + np.exp(-k * (1 / freq_grid - x0 * gridres))
+                    )
                     newfilter *= 1 - merge_weights
 
                     # perform the weighted average of previous and new fourier filters

--- a/pysteps/tests/test_noise_fftgenerators.py
+++ b/pysteps/tests/test_noise_fftgenerators.py
@@ -51,3 +51,16 @@ def test_noise_nonparam_2d_ssft_filter():
 
     assert isinstance(out, np.ndarray)
     assert out.shape == PRECIP.shape
+
+
+def test_noise_nonparam_2d_nested_filter():
+
+    fft_filter = fftgenerators.initialize_nonparam_2d_nested_filter(PRECIP)
+
+    assert isinstance(fft_filter, dict)
+    assert all([key in fft_filter for key in ["field", "input_shape"]])
+
+    out = fftgenerators.generate_noise_2d_ssft_filter(fft_filter)
+
+    assert isinstance(out, np.ndarray)
+    assert out.shape == PRECIP.shape


### PR DESCRIPTION
Following a feedback from Yuan Liu on Nov 28th 2022 on our slack channel:

> Hello pysteps team, I am writing about the "initialize_nonparam_2d_nested_filter" function. I don't quite understand the role of the logistic function that defines the weights of each local FFT. The function is something like "1 / (1 + np.exp(-k * (1 / freq_grid - x0)))." But it seems not clear why we calculate "1 / freq_grid - x0." I think the former has a unit of "km" and the latter is just represent an index of the nested window.
In general, I get the idea of nesting, but I am not clear about how the weight is assigned. Thanks! 

