### PR TITLE
Fix l2 parameter in SAL verification #321

### DIFF
--- a/pysteps/verification/salscores.py
+++ b/pysteps/verification/salscores.py
@@ -302,10 +302,10 @@ def _sal_l2_param(prediction, observation, thr_factor, thr_quantile, tstorm_kwar
     )
     obs_r = (
         _sal_weighted_distance(observation, thr_factor, thr_quantile, tstorm_kwargs)
-    ) * (np.nanmean(observation))
+    )
     forc_r = (
         _sal_weighted_distance(prediction, thr_factor, thr_quantile, tstorm_kwargs)
-    ) * (np.nanmean(prediction))
+    ) 
     location_2 = 2 * ((abs(obs_r - forc_r)) / maximum_distance)
     return float(location_2)
 


### PR DESCRIPTION
Remove the multiplication factor in l2 parameter, see #321 