### PR TITLE
Fixes following pandas 2

### DIFF
--- a/pysteps/blending/steps.py
+++ b/pysteps/blending/steps.py
@@ -46,7 +46,7 @@ consists of the following main steps:
 import time
 
 import numpy as np
-import scipy.ndimage
+from scipy.ndimage import binary_dilation, generate_binary_structure, iterate_structure
 
 from pysteps import cascade
 from pysteps import extrapolation
@@ -1599,13 +1599,13 @@ def _compute_incremental_mask(Rbin, kr, r):
 
     # buffer observation mask
     Rbin = np.ndarray.astype(Rbin.copy(), "uint8")
-    Rd = scipy.ndimage.morphology.binary_dilation(Rbin, kr)
+    Rd = binary_dilation(Rbin, kr)
 
     # add grayscale rim
-    kr1 = scipy.ndimage.generate_binary_structure(2, 1)
+    kr1 = generate_binary_structure(2, 1)
     mask = Rd.astype(float)
     for n in range(r):
-        Rd = scipy.ndimage.morphology.binary_dilation(Rd, kr1)
+        Rd = sbinary_dilation(Rd, kr1)
         mask += Rd
     # normalize between 0 and 1
     return mask / mask.max()
@@ -1995,10 +1995,10 @@ def _prepare_forecast_loop(
         mask_rim = mask_kwargs.get("mask_rim", 10)
         mask_f = mask_kwargs.get("mask_f", 1.0)
         # initialize the structuring element
-        struct = scipy.ndimage.generate_binary_structure(2, 1)
+        struct = generate_binary_structure(2, 1)
         # iterate it to expand it nxn
         n = mask_f * timestep / kmperpixel
-        struct = scipy.ndimage.iterate_structure(struct, int((n - 1) / 2.0))
+        struct = iterate_structure(struct, int((n - 1) / 2.0))
     else:
         mask_rim, struct = None, None
 

--- a/pysteps/blending/steps.py
+++ b/pysteps/blending/steps.py
@@ -1605,7 +1605,7 @@ def _compute_incremental_mask(Rbin, kr, r):
     kr1 = generate_binary_structure(2, 1)
     mask = Rd.astype(float)
     for n in range(r):
-        Rd = sbinary_dilation(Rd, kr1)
+        Rd = binary_dilation(Rd, kr1)
         mask += Rd
     # normalize between 0 and 1
     return mask / mask.max()

--- a/pysteps/extrapolation/semilagrangian.py
+++ b/pysteps/extrapolation/semilagrangian.py
@@ -15,7 +15,7 @@ import time
 import warnings
 
 import numpy as np
-import scipy.ndimage.interpolation as ip
+from scipy.ndimage import map_coordinates
 
 
 def extrapolate(
@@ -182,10 +182,10 @@ def extrapolate(
         coords_warped = xy_coords + displacement
         coords_warped = [coords_warped[1, :, :], coords_warped[0, :, :]]
 
-        velocity_inc_x = ip.map_coordinates(
+        velocity_inc_x = map_coordinates(
             velocity[0, :, :], coords_warped, mode="nearest", order=1, prefilter=False
         )
-        velocity_inc_y = ip.map_coordinates(
+        velocity_inc_y = map_coordinates(
             velocity[1, :, :], coords_warped, mode="nearest", order=1, prefilter=False
         )
 
@@ -222,7 +222,7 @@ def extrapolate(
         coords_warped = [coords_warped[1, :, :], coords_warped[0, :, :]]
 
         if precip is not None:
-            precip_warped = ip.map_coordinates(
+            precip_warped = map_coordinates(
                 precip,
                 coords_warped,
                 mode=map_coordinates_mode,
@@ -232,7 +232,7 @@ def extrapolate(
             )
 
             if interp_order > 1:
-                mask_warped = ip.map_coordinates(
+                mask_warped = map_coordinates(
                     mask_min,
                     coords_warped,
                     mode=map_coordinates_mode,
@@ -242,7 +242,7 @@ def extrapolate(
                 )
                 precip_warped[mask_warped < 0.5] = minval
 
-                mask_warped = ip.map_coordinates(
+                mask_warped = map_coordinates(
                     mask_finite,
                     coords_warped,
                     mode=map_coordinates_mode,

--- a/pysteps/feature/tstorm.py
+++ b/pysteps/feature/tstorm.py
@@ -233,26 +233,33 @@ def get_profile(areas, binary, ref, loc_max, time, minref):
     cells = areas * binary
     cell_labels = cells[loc_max]
     labels = np.zeros(cells.shape)
+    cells_id = []
+    for n, cell_label in enumerate(cell_labels):
+        this_id = n + 1
+        x = np.where(cells == cell_label)[1]
+        y = np.where(cells == cell_label)[0]
+        cell_unique = np.zeros(cells.shape)
+        cell_unique[cells == cell_label] = 1
+        maxref = np.nanmax(ref[y, x])
+        contours = skime.find_contours(cell_unique, 0.8)
+        cells_id.append(
+            {
+                "ID": this_id,
+                "time": time,
+                "x": x,
+                "y": y,
+                "cen_x": np.round(np.nanmean(x)).astype(int),
+                "cen_y": np.round(np.nanmean(y)).astype(int),
+                "max_ref": maxref,
+                "cont": contours,
+                "area": len(x),
+            }
+        )
+        labels[cells == cell_labels[n]] = this_id
     cells_id = pd.DataFrame(
-        data=None,
+        data=cells_id,
         index=range(len(cell_labels)),
         columns=["ID", "time", "x", "y", "cen_x", "cen_y", "max_ref", "cont", "area"],
     )
-    cells_id.time = time
-    for n in range(len(cell_labels)):
-        ID = n + 1
-        cells_id.ID.iloc[n] = ID
-        cells_id.x.iloc[n] = np.where(cells == cell_labels[n])[1]
-        cells_id.y.iloc[n] = np.where(cells == cell_labels[n])[0]
-        cell_unique = np.zeros(cells.shape)
-        cell_unique[cells == cell_labels[n]] = 1
-        maxref = np.nanmax(ref[cells_id.y[n], cells_id.x[n]])
-        contours = skime.find_contours(cell_unique, 0.8)
-        cells_id.cont.iloc[n] = contours
-        cells_id.cen_x.iloc[n] = np.round(np.nanmean(cells_id.x[n])).astype(int)
-        cells_id.cen_y.iloc[n] = np.round(np.nanmean(cells_id.y[n])).astype(int)
-        cells_id.max_ref.iloc[n] = maxref
-        cells_id.area.iloc[n] = len(cells_id.x.iloc[n])
-        labels[cells == cell_labels[n]] = ID
 
     return cells_id, labels

--- a/pysteps/motion/constant.py
+++ b/pysteps/motion/constant.py
@@ -13,8 +13,8 @@ correlation between two images.
 """
 
 import numpy as np
-import scipy.ndimage.interpolation as ip
 import scipy.optimize as op
+from scipy.ndimage import map_coordinates
 
 
 def constant(R, **kwargs):
@@ -40,7 +40,7 @@ def constant(R, **kwargs):
 
     def f(v):
         XYW = [Y + v[1], X + v[0]]
-        R_w = ip.map_coordinates(
+        R_w = map_coordinates(
             R[-2, :, :], XYW, mode="constant", cval=np.nan, order=0, prefilter=False
         )
 

--- a/pysteps/motion/vet.py
+++ b/pysteps/motion/vet.py
@@ -36,7 +36,7 @@ for performance.
 
 import numpy
 from numpy.ma.core import MaskedArray
-from scipy.ndimage.interpolation import zoom
+from scipy.ndimage import zoom
 from scipy.optimize import minimize
 
 from pysteps.decorators import check_input_frames

--- a/pysteps/nowcasts/sseps.py
+++ b/pysteps/nowcasts/sseps.py
@@ -19,8 +19,9 @@ size.
 """
 
 import numpy as np
-import scipy.ndimage
 import time
+from scipy.ndimage import generate_binary_structure, iterate_structure
+
 
 from pysteps import cascade
 from pysteps import extrapolation
@@ -342,10 +343,10 @@ def forecast(
         mask_rim = mask_kwargs.get("mask_rim", 10)
         mask_f = mask_kwargs.get("mask_f", 1.0)
         # initialize the structuring element
-        struct = scipy.ndimage.generate_binary_structure(2, 1)
+        struct = generate_binary_structure(2, 1)
         # iterate it to expand it nxn
         n = mask_f * timestep / kmperpixel
-        struct = scipy.ndimage.iterate_structure(struct, int((n - 1) / 2.0))
+        struct = iterate_structure(struct, int((n - 1) / 2.0))
 
     noise_kwargs.update(
         {
@@ -491,7 +492,6 @@ def forecast(
             rc_ = []
             mm_ = []
             for n in range(n_windows_N):
-
                 # compute indices of local window
                 idxm[0] = int(np.max((m * win_size[0] - overlap * win_size[0], 0)))
                 idxm[1] = int(
@@ -513,7 +513,6 @@ def forecast(
                     np.sum(precip_[-1, :, :] >= precip_thr) / precip_[-1, :, :].size
                 )
                 if war[m, n] > war_thr:
-
                     # estimate local parameters
                     pars = estimator(precip, parsglob, idxm, idxn)
                     ff_.append(pars["filter"])
@@ -627,7 +626,6 @@ def forecast(
 
         # iterate each ensemble member
         def worker(j):
-
             # first the global step
 
             if noise_method is not None:
@@ -683,7 +681,6 @@ def forecast(
                 M_s = np.zeros((M, N), dtype=float)
                 for m in range(n_windows_M):
                     for n in range(n_windows_N):
-
                         # compute indices of local window
                         idxm[0] = int(
                             np.max((m * win_size[0] - overlap * win_size[0], 0))
@@ -707,7 +704,6 @@ def forecast(
 
                         # skip if dry
                         if war[m, n] > war_thr:
-
                             precip_cascades = rc[m][n][j].copy()
                             if precip_cascades.shape[1] >= ar_order:
                                 precip_cascades = precip_cascades[:, -ar_order:, :, :]
@@ -971,7 +967,6 @@ def _build_2D_tapering_function(win_size, win_type="flat-hanning"):
         w1dc = np.hanning(win_size[1])
 
     elif win_type == "flat-hanning":
-
         T = win_size[0] / 4.0
         W = win_size[0] / 2.0
         B = np.linspace(-W, W, int(2 * W))
@@ -991,7 +986,6 @@ def _build_2D_tapering_function(win_size, win_type="flat-hanning"):
         w1dc = A
 
     elif win_type == "rectangular":
-
         w1dr = np.ones(win_size[0])
         w1dc = np.ones(win_size[1])
 

--- a/pysteps/nowcasts/steps.py
+++ b/pysteps/nowcasts/steps.py
@@ -12,7 +12,7 @@ Implementation of the STEPS stochastic nowcasting method as described in
 """
 
 import numpy as np
-import scipy.ndimage
+from scipy.ndimage import generate_binary_structure, iterate_structure
 import time
 
 from pysteps import cascade
@@ -598,10 +598,10 @@ def forecast(
             mask_rim = mask_kwargs.get("mask_rim", 10)
             mask_f = mask_kwargs.get("mask_f", 1.0)
             # initialize the structuring element
-            struct = scipy.ndimage.generate_binary_structure(2, 1)
+            struct = generate_binary_structure(2, 1)
             # iterate it to expand it nxn
             n = mask_f * timestep / kmperpixel
-            struct = scipy.ndimage.iterate_structure(struct, int((n - 1) / 2.0))
+            struct = iterate_structure(struct, int((n - 1) / 2.0))
             # initialize precip mask for each member
             mask_prec = nowcast_utils.compute_dilated_mask(mask_prec, struct, mask_rim)
             mask_prec = [mask_prec.copy() for _ in range(n_ens_members)]

--- a/pysteps/nowcasts/utils.py
+++ b/pysteps/nowcasts/utils.py
@@ -18,7 +18,8 @@ Module with common utilities used by nowcasts methods.
 
 import time
 import numpy as np
-import scipy.ndimage
+from scipy.ndimage import binary_dilation, generate_binary_structure
+
 from pysteps import extrapolation
 
 
@@ -85,13 +86,13 @@ def compute_dilated_mask(input_mask, kr, r):
     """
     # buffer the input mask
     input_mask = np.ndarray.astype(input_mask.copy(), "uint8")
-    mask_dilated = scipy.ndimage.morphology.binary_dilation(input_mask, kr)
+    mask_dilated = binary_dilation(input_mask, kr)
 
     # add grayscale rim
-    kr1 = scipy.ndimage.generate_binary_structure(2, 1)
+    kr1 = generate_binary_structure(2, 1)
     mask = mask_dilated.astype(float)
     for _ in range(r):
-        mask_dilated = scipy.ndimage.morphology.binary_dilation(mask_dilated, kr1)
+        mask_dilated = binary_dilation(mask_dilated, kr1)
         mask += mask_dilated
 
     # normalize between 0 and 1

--- a/pysteps/tracking/tdating.py
+++ b/pysteps/tracking/tdating.py
@@ -311,7 +311,7 @@ def couple_track(cell_list, max_ID, mintrack):
         for t in range(len(cell_list)):
             mytime = cell_list[t]
             mycell = mytime[mytime.ID == n]
-            cell_track = cell_track.append(mycell)
+            cell_track = pd.concat([cell_track, mycell], ignore_index=True)
 
         if len(cell_track) < mintrack:
             continue

--- a/pysteps/tracking/tdating.py
+++ b/pysteps/tracking/tdating.py
@@ -308,10 +308,11 @@ def couple_track(cell_list, max_ID, mintrack):
             index=None,
             columns=["ID", "time", "x", "y", "cen_x", "cen_y", "max_ref", "cont"],
         )
+        cell_track = []
         for t in range(len(cell_list)):
             mytime = cell_list[t]
-            mycell = mytime[mytime.ID == n]
-            cell_track = pd.concat([cell_track, mycell], ignore_index=True)
+            cell_track.append(mytime[mytime.ID == n])
+        cell_track = pd.concat(cell_track, axis=0)
 
         if len(cell_track) < mintrack:
             continue

--- a/pysteps/tracking/tdating.py
+++ b/pysteps/tracking/tdating.py
@@ -200,7 +200,7 @@ def tracking(cells_id, cells_id_prev, labels, V1, max_ID):
     cells_ad = advect(cells_id_prev, labels, V1)
     cells_ov, labels = match(cells_ad, labels)
     newlabels = np.zeros(labels.shape)
-    for ID, cell in cells_id_new.iterrows():
+    for index, cell in cells_id_new.iterrows():
         if cell.ID == 0 or np.isnan(cell.ID):
             continue
         new_ID = cells_ov[cells_ov.t_ID == cell.ID].ID.values
@@ -211,12 +211,12 @@ def tracking(cells_id, cells_id_prev, labels, V1, max_ID):
                 size.append(len(x))
             biggest = np.argmax(size)
             new_ID = new_ID[biggest]
-            cells_id_new.ID.iloc[ID] = new_ID
+            cells_id_new.loc[index, "ID"] = new_ID
         else:
             max_ID += 1
             new_ID = max_ID
-            cells_id_new.ID.iloc[ID] = new_ID
-        newlabels[labels == ID + 1] = new_ID
+            cells_id_new.loc[index, "ID"] = new_ID
+        newlabels[labels == index + 1] = new_ID
         del new_ID
     return cells_id_new, max_ID, newlabels
 

--- a/pysteps/verification/salscores.py
+++ b/pysteps/verification/salscores.py
@@ -159,7 +159,7 @@ def sal_structure(
     observation_volume = _sal_scaled_volume(observation_objects).sum()
     nom = prediction_volume - observation_volume
     denom = prediction_volume + observation_volume
-    return nom / (0.5 * denom)
+    return np.divide(nom, (0.5 * denom))
 
 
 def sal_amplitude(prediction, observation):

--- a/pysteps/verification/salscores.py
+++ b/pysteps/verification/salscores.py
@@ -16,7 +16,7 @@ The Spatial-Amplitude-Location (SAL) score by :cite:`WPHF2008`.
 from math import sqrt, hypot
 
 import numpy as np
-from scipy.ndimage.measurements import center_of_mass
+from scipy.ndimage import center_of_mass
 
 from pysteps.exceptions import MissingOptionalDependency
 from pysteps.feature import tstorm as tstorm_detect

--- a/pysteps/verification/spatialscores.py
+++ b/pysteps/verification/spatialscores.py
@@ -27,7 +27,7 @@ Skill scores for spatial forecasts.
 
 import collections
 import numpy as np
-from scipy.ndimage.filters import uniform_filter
+from scipy.ndimage import uniform_filter
 
 from pysteps.exceptions import MissingOptionalDependency
 from pysteps.verification.salscores import sal  # make SAL accessible from this module


### PR DESCRIPTION
Minor adjustments following the release of pandas 2:

* in `tdating.py` use `pd.concat` instead of `pd.DataFrame().append` which was effectively removed ([ref](https://pandas.pydata.org/docs/whatsnew/v2.0.0.html#deprecations)).
* in `salscores.py`: Division by zero returns `-inf`, `nan`, or `inf` depending on the numerator, instead of raising (but I wasn't able to understand exactly the root cause of this breaking change...)

Additionally,
* Fix scipy.ndimage's DeprecationWarnings 
* Fix pandas' SettingWithCopyWarnings