### PR TITLE
Add missing "bias" method to the interface of the verification module

### DIFF
--- a/pysteps/verification/interface.py
+++ b/pysteps/verification/interface.py
@@ -172,6 +172,7 @@ def get_method(name, type="deterministic"):
         # categorical
         if name in [
             "acc",
+            "bias",
             "csi",
             "f1",
             "fa",


### PR DESCRIPTION
The BIAS method was not available with the 'get method' function, because it was missing from the name list. Therefore I added it.