### PR TITLE
Migrate to setup-micromamba

### DIFF
--- a/.github/workflows/test_pysteps.yml
+++ b/.github/workflows/test_pysteps.yml
@@ -34,11 +34,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install mamba and create environment
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: ci/ci_test_env.yml
           environment-name: test_environment
-          extra-specs: python=${{ matrix.python-version }}
+          create-args: python=${{ matrix.python-version }}
 
       - name: Install pygrib (not win)
         if: matrix.os != 'windows-latest'


### PR DESCRIPTION
The `provision-with-micromamba` project is deprecated: https://github.com/mamba-org/provision-with-micromamba

This PR migrates our CI pipeline to the new `setup-micromamba` action: https://github.com/mamba-org/setup-micromamba