### PR TITLE
Fix for projections using a spherical earth

### DIFF
--- a/pysteps/visualization/utils.py
+++ b/pysteps/visualization/utils.py
@@ -170,6 +170,9 @@ def proj4_to_cartopy(proj4str):
             proj_dict["lat_1"],
             proj_dict["lat_2"],
         )
+    if "R" in proj_dict.keys():
+        globe_kwargs["semimajor_axis"] = proj_dict["R"]
+        globe_kwargs["semiminor_axis"] = proj_dict["R"]
 
     if globe_kwargs:
         globe = ccrs.Globe(**globe_kwargs)


### PR DESCRIPTION
Some projections use a spherical earth. This is indicated in the proj4-string by either  
the `+R=...` identifier or   
by setting the `+a=` and `+b=` equal. 

In both cases the `parse_proj4_string` returns a dict with the `R`-key, but this key is not checked by `proj4_to_cartopy` resulting in the default WGS84 globe for the cartopy CRS, giving small differences in the locations of the gridpoints.

This is now fixed by explicitly checking for the `R`-key in `proj4_to_cartopy` and defining the correct globe keywords.

I needed this to take advantage of the plot_precip_fields function for plotting precipitation coming from the ALARO NWP model.
