### PR TITLE
Geogrid fix

### DIFF
--- a/pysteps/visualization/utils.py
+++ b/pysteps/visualization/utils.py
@@ -237,8 +237,14 @@ def reproject_geodata(geodata, t_proj4str, return_grid=None):
     # Reproject grid on fall-back projection
     if return_grid is not None:
         if return_grid == "coords":
-            y_coord = np.linspace(y1, y2, shape[0]) + geodata["ypixelsize"] / 2.0
-            x_coord = np.linspace(x1, x2, shape[1]) + geodata["xpixelsize"] / 2.0
+            y_coord = (
+                np.linspace(y1, y2, shape[0], endpoint=False)
+                + geodata["ypixelsize"] / 2.0
+            )
+            x_coord = (
+                np.linspace(x1, x2, shape[1], endpoint=False)
+                + geodata["xpixelsize"] / 2.0
+            )
         elif return_grid == "quadmesh":
             y_coord = np.linspace(y1, y2, shape[0] + 1)
             x_coord = np.linspace(x1, x2, shape[1] + 1)

--- a/pysteps/visualization/utils.py
+++ b/pysteps/visualization/utils.py
@@ -337,13 +337,15 @@ def get_geogrid(nlat, nlon, geodata=None):
         regular_grid = geodata.get("regular_grid", True)
 
         x_lims = sorted((geodata["x1"], geodata["x2"]))
-        x = np.linspace(x_lims[0], x_lims[1], nlon)
-        xpixelsize = np.abs(x[1] - x[0])
+        x, xpixelsize = np.linspace(
+            x_lims[0], x_lims[1], nlon, endpoint=False, retstep=True
+        )
         x += xpixelsize / 2.0
 
         y_lims = sorted((geodata["y1"], geodata["y2"]))
-        y = np.linspace(y_lims[0], y_lims[1], nlat)
-        ypixelsize = np.abs(y[1] - y[0])
+        y, ypixelsize = np.linspace(
+            y_lims[0], y_lims[1], nlat, endpoint=False, retstep=True
+        )
         y += ypixelsize / 2.0
 
         extent = (geodata["x1"], geodata["x2"], geodata["y1"], geodata["y2"])

--- a/pysteps/visualization/utils.py
+++ b/pysteps/visualization/utils.py
@@ -327,7 +327,7 @@ def get_geogrid(nlat, nlon, geodata=None):
         Four-element tuple specifying the extent of the domain according to
         (lower left x, upper right x, lower left y, upper right y).
     regular_grid: bool
-        True is the grid is regular. False otherwise.
+        True if the grid is regular. False otherwise.
     origin: str
         Place the [0, 0] index of the array to plot in the upper left or lower left
         corner of the axes.


### PR DESCRIPTION
While only used for visualization, the `get_geogrid`  and `reproject_geodata` functions seem to be slightly off.

The functions use `np.linspace` to retrieve the lower boundary for each pixel based on the number of pixels and the extent of the image (e.g. `x1`, `x2`). In doing so, `x2` should be excluded from the interval as it represents the upper boundary of the image.

___
Illustration:

`np.linspace(3, 10, 7)` returns `3.,  4.16666667,  5.33333333,  6.5,  7.66666667, 8.83333333, 10.` while `3., 4., 5., 6., 7., 8., 9.` is expected. 

`np.linspace(3, 10, 7, endpoint=False)` does return the expected result.

___

Note that this has been accounted for correctly (yet with different approaches) in other pysteps functions:

https://github.com/pySTEPS/pysteps/blob/8dca14afbf74f47072a810317a8bddefa33e3e60/pysteps/utils/dimension.py#L410

https://github.com/pySTEPS/pysteps/blob/8dca14afbf74f47072a810317a8bddefa33e3e60/pysteps/io/exporters.py#L336