### PR TITLE
Consider splits and merges in tdating

### DIFF
--- a/examples/thunderstorm_detection_and_tracking.py
+++ b/examples/thunderstorm_detection_and_tracking.py
@@ -91,6 +91,17 @@ cells_id, labels = tstorm_detect.detection(input_image, time=time)
 print(cells_id.iloc[0])
 
 ###############################################################################
+# Optionally, one can also ask to consider splits and merges of thunderstorm cells.
+# A cell at time t is considered to split if it will verlap more than 10% with more than
+# one cell at time t+1. Conversely, a cell is considered to be a merge, if more
+# than one cells fron time t will overlap more than 10% with it.
+
+cells_id, labels = tstorm_detect.detection(
+    input_image, time=time, output_splits_merges=True
+)
+print(cells_id.iloc[0])
+
+###############################################################################
 # Example of thunderstorm tracking over a timeseries
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # The tstorm-dating function requires the entire pre-loaded time series.

--- a/pysteps/feature/tstorm.py
+++ b/pysteps/feature/tstorm.py
@@ -253,13 +253,36 @@ def get_profile(areas, binary, ref, loc_max, time, minref):
                 "max_ref": maxref,
                 "cont": contours,
                 "area": len(x),
+                "splitted": None,
+                "split_IDs": None,
+                "merged": None,
+                "merged_IDs": None,
+                "results_from_split": None,
+                "will_merge": None,
             }
         )
         labels[cells == cell_labels[n]] = this_id
     cells_id = pd.DataFrame(
         data=cells_id,
         index=range(len(cell_labels)),
-        columns=["ID", "time", "x", "y", "cen_x", "cen_y", "max_ref", "cont", "area"],
+        columns=[
+            "ID",
+            "time",
+            "x",
+            "y",
+            "cen_x",
+            "cen_y",
+            "max_ref",
+            "cont",
+            "area",
+            "splitted",
+            "split_IDs",
+            "merged",
+            "merged_IDs",
+            "results_from_split",
+            "will_merge",
+        ],
     )
-
+    cells_id["split_IDs"] = cells_id["split_IDs"].astype("object")
+    cells_id["merged_IDs"] = cells_id["merged_IDs"].astype("object")
     return cells_id, labels

--- a/pysteps/tests/test_feature_tstorm.py
+++ b/pysteps/tests/test_feature_tstorm.py
@@ -10,20 +10,29 @@ try:
 except ModuleNotFoundError:
     pass
 
-arg_names = ("source", "output_feat", "dry_input", "max_num_features")
+arg_names = (
+    "source",
+    "output_feat",
+    "dry_input",
+    "max_num_features",
+    "output_split_merge",
+)
 
 arg_values = [
-    ("mch", False, False, None),
-    ("mch", False, False, 5),
-    ("mch", True, False, None),
-    ("mch", True, False, 5),
-    ("mch", False, True, None),
-    ("mch", False, True, 5),
+    ("mch", False, False, None, False),
+    ("mch", False, False, 5, False),
+    ("mch", True, False, None, False),
+    ("mch", True, False, 5, False),
+    ("mch", False, True, None, False),
+    ("mch", False, True, 5, False),
+    ("mch", False, False, None, True),
 ]
 
 
 @pytest.mark.parametrize(arg_names, arg_values)
-def test_feature_tstorm_detection(source, output_feat, dry_input, max_num_features):
+def test_feature_tstorm_detection(
+    source, output_feat, dry_input, max_num_features, output_split_merge
+):
     pytest.importorskip("skimage")
     pytest.importorskip("pandas")
 
@@ -36,7 +45,11 @@ def test_feature_tstorm_detection(source, output_feat, dry_input, max_num_featur
 
     time = "000"
     output = detection(
-        input, time=time, output_feat=output_feat, max_num_features=max_num_features
+        input,
+        time=time,
+        output_feat=output_feat,
+        max_num_features=max_num_features,
+        output_splits_merges=output_split_merge,
     )
 
     if output_feat:
@@ -45,6 +58,40 @@ def test_feature_tstorm_detection(source, output_feat, dry_input, max_num_featur
         assert output.shape[1] == 2
         if max_num_features is not None:
             assert output.shape[0] <= max_num_features
+    elif output_split_merge:
+        assert isinstance(output, tuple)
+        assert len(output) == 2
+        assert isinstance(output[0], DataFrame)
+        assert isinstance(output[1], np.ndarray)
+        if max_num_features is not None:
+            assert output[0].shape[0] <= max_num_features
+        assert output[0].shape[1] == 15
+        assert list(output[0].columns) == [
+            "ID",
+            "time",
+            "x",
+            "y",
+            "cen_x",
+            "cen_y",
+            "max_ref",
+            "cont",
+            "area",
+            "splitted",
+            "split_IDs",
+            "merged",
+            "merged_IDs",
+            "results_from_split",
+            "will_merge",
+        ]
+        assert (output[0].time == time).all()
+        assert output[1].ndim == 2
+        assert output[1].shape == input.shape
+        if not dry_input:
+            assert output[0].shape[0] > 0
+            assert sorted(list(output[0].ID)) == sorted(list(np.unique(output[1]))[1:])
+        else:
+            assert output[0].shape[0] == 0
+            assert output[1].sum() == 0
     else:
         assert isinstance(output, tuple)
         assert len(output) == 2

--- a/pysteps/tests/test_tracking_tdating.py
+++ b/pysteps/tests/test_tracking_tdating.py
@@ -7,22 +7,24 @@ from pysteps.tracking.tdating import dating
 from pysteps.utils import to_reflectivity
 from pysteps.tests.helpers import get_precipitation_fields
 
-arg_names = ("source", "dry_input")
+arg_names = ("source", "dry_input", "output_splits_merges")
 
 arg_values = [
-    ("mch", False),
-    ("mch", False),
-    ("mch", True),
+    ("mch", False, False),
+    ("mch", False, False),
+    ("mch", True, False),
+    ("mch", False, True),
 ]
 
-arg_names_multistep = ("source", "len_timesteps")
+arg_names_multistep = ("source", "len_timesteps", "output_splits_merges")
 arg_values_multistep = [
-    ("mch", 6),
+    ("mch", 6, False),
+    ("mch", 6, True),
 ]
 
 
 @pytest.mark.parametrize(arg_names_multistep, arg_values_multistep)
-def test_tracking_tdating_dating_multistep(source, len_timesteps):
+def test_tracking_tdating_dating_multistep(source, len_timesteps, output_splits_merges):
     pytest.importorskip("skimage")
 
     input_fields, metadata = get_precipitation_fields(
@@ -37,6 +39,7 @@ def test_tracking_tdating_dating_multistep(source, len_timesteps):
         input_fields[0 : len_timesteps // 2],
         timelist[0 : len_timesteps // 2],
         mintrack=1,
+        output_splits_merges=output_splits_merges,
     )
     # Second half of timesteps
     tracks_2, cells, _ = dating(
@@ -46,6 +49,7 @@ def test_tracking_tdating_dating_multistep(source, len_timesteps):
         start=2,
         cell_list=cells,
         label_list=labels,
+        output_splits_merges=output_splits_merges,
     )
 
     # Since we are adding cells, number of tracks should increase
@@ -67,7 +71,7 @@ def test_tracking_tdating_dating_multistep(source, len_timesteps):
 
 
 @pytest.mark.parametrize(arg_names, arg_values)
-def test_tracking_tdating_dating(source, dry_input):
+def test_tracking_tdating_dating(source, dry_input, output_splits_merges):
     pytest.importorskip("skimage")
     pandas = pytest.importorskip("pandas")
 
@@ -80,7 +84,13 @@ def test_tracking_tdating_dating(source, dry_input):
 
     timelist = metadata["timestamps"]
 
-    output = dating(input, timelist, mintrack=1)
+    cell_column_length = 9
+    if output_splits_merges:
+        cell_column_length = 15
+
+    output = dating(
+        input, timelist, mintrack=1, output_splits_merges=output_splits_merges
+    )
 
     # Check output format
     assert isinstance(output, tuple)
@@ -92,12 +102,12 @@ def test_tracking_tdating_dating(source, dry_input):
     assert len(output[2]) == input.shape[0]
     assert isinstance(output[1][0], pandas.DataFrame)
     assert isinstance(output[2][0], np.ndarray)
-    assert output[1][0].shape[1] == 9
+    assert output[1][0].shape[1] == cell_column_length
     assert output[2][0].shape == input.shape[1:]
     if not dry_input:
         assert len(output[0]) > 0
         assert isinstance(output[0][0], pandas.DataFrame)
-        assert output[0][0].shape[1] == 9
+        assert output[0][0].shape[1] == cell_column_length
     else:
         assert len(output[0]) == 0
         assert output[1][0].shape[0] == 0

--- a/pysteps/tracking/tdating.py
+++ b/pysteps/tracking/tdating.py
@@ -63,6 +63,9 @@ def dating(
     minmax=41,
     mindis=10,
     dyn_thresh=False,
+    match_frac=0.4,
+    split_frac=0.1,
+    merge_frac=0.1,
     output_splits_merges=False,
 ):
     """
@@ -114,6 +117,17 @@ def dating(
     mindis: float, optional
         Minimum distance between two maxima of identified objects. Objects with a
         smaller distance will be merged. The default is 10 km.
+    match_frac: float, optional
+        Minimum overlap fraction between two objects to be considered the same object.
+        Default is 0.4.
+    split_frac: float, optional
+        Minimum overlap fraction between two objects for the object at second timestep
+        to be considered possibly split from the object at the first timestep.
+        Default is 0.1.
+    merge_frac: float, optional
+        Minimum overlap fraction between two objects for the object at second timestep
+        to be considered possibly merged from the object at the first timestep.
+        Default is 0.1.
     output_splits_merges: bool, optional
         If True, the output will contain information about splits and merges.
         The provided columns are:
@@ -211,8 +225,12 @@ def dating(
                 labels,
                 flowfield,
                 max_ID,
+                match_frac=match_frac,
+                split_frac=split_frac,
+                merge_frac=merge_frac,
                 output_splits_merges=output_splits_merges,
             )
+
             if output_splits_merges:
                 # Assign splitted parameters for the previous timestep
                 for ID, split_cell in splitted_cells.iterrows():
@@ -257,6 +275,7 @@ def tracking(
     V1,
     max_ID,
     merge_frac=0.1,
+    split_frac=0.1,
     output_splits_merges=False,
 ):
     """
@@ -272,6 +291,8 @@ def tracking(
         cells_ad,
         labels,
         output_splits_merges=output_splits_merges,
+        split_frac=split_frac,
+        match_frac=merge_frac,
     )
 
     splitted_cells = None

--- a/pysteps/tracking/tdating.py
+++ b/pysteps/tracking/tdating.py
@@ -282,6 +282,11 @@ def match(cells_ad, labels):
         ID_vec = labels[cell_a.y, cell_a.x]
         IDs = np.unique(ID_vec)
         n_IDs = len(IDs)
+        if n_IDs == 1 and IDs[0] == 0:
+            cells_ov.t_ID[ID_a] = 0
+            continue
+        IDs = IDs[IDs != 0]
+        n_IDs = len(IDs)
         N = np.zeros(n_IDs)
         for n in range(n_IDs):
             N[n] = len(np.where(ID_vec == IDs[n])[0])

--- a/pysteps/tracking/tdating.py
+++ b/pysteps/tracking/tdating.py
@@ -233,7 +233,7 @@ def dating(
 
             if output_splits_merges:
                 # Assign splitted parameters for the previous timestep
-                for ID, split_cell in splitted_cells.iterrows():
+                for _, split_cell in splitted_cells.iterrows():
                     prev_list_id = cell_list[-1][
                         cell_list[-1].ID == split_cell.ID
                     ].index.item()
@@ -251,7 +251,7 @@ def dating(
                         cells_id.at[cur_list_id, "results_from_split"] = True
 
                 merged_cells = cells_id[cells_id.merged == True]
-                for i, cell in merged_cells.iterrows():
+                for _, cell in merged_cells.iterrows():
                     for merged_id in cell.merged_IDs:
                         prev_list_id = cell_list[-1][
                             cell_list[-1].ID == merged_id

--- a/pysteps/tracking/tdating.py
+++ b/pysteps/tracking/tdating.py
@@ -269,7 +269,7 @@ def advect(cells_id, labels, V1):
     return cells_ad
 
 
-def match(cells_ad, labels):
+def match(cells_ad, labels, match_frac=0.4, split_frac=0.1):
     """
     This function matches the advected cells of the previous timestep to the newly
     identified ones. A minimal overlap of 40% is required. In case of split of merge,
@@ -293,7 +293,7 @@ def match(cells_ad, labels):
         m = np.argmax(N)
         ID_match = IDs[m]
         ID_coverage = N[m] / len(ID_vec)
-        if ID_coverage >= 0.4:
+        if ID_coverage >= match_frac:
             cells_ov.t_ID[ID_a] = ID_match
         else:
             cells_ov.t_ID[ID_a] = 0

--- a/pysteps/tracking/tdating.py
+++ b/pysteps/tracking/tdating.py
@@ -380,16 +380,18 @@ def advect(cells_id, labels, V1, output_splits_merges=False):
         new_y[new_y < 0] = 0
         new_cen_x = cell.cen_x + ad_x
         new_cen_y = cell.cen_y + ad_y
-        cells_ad.x[ID] = new_x
-        cells_ad.y[ID] = new_y
-        cells_ad.flowx[ID] = ad_x
-        cells_ad.flowy[ID] = ad_y
-        cells_ad.cen_x[ID] = new_cen_x
-        cells_ad.cen_y[ID] = new_cen_y
-        cells_ad.ID[ID] = cell.ID
+
+        cells_ad.loc[ID, "x"] = new_x
+        cells_ad.loc[ID, "y"] = new_y
+        cells_ad.loc[ID, "flowx"] = ad_x
+        cells_ad.loc[ID, "flowy"] = ad_y
+        cells_ad.loc[ID, "cen_x"] = new_cen_x
+        cells_ad.loc[ID, "cen_y"] = new_cen_y
+        cells_ad.loc[ID, "ID"] = cell.ID
+
         cell_unique = np.zeros(labels.shape)
         cell_unique[new_y, new_x] = 1
-        cells_ad.cont[ID] = skime.find_contours(cell_unique, 0.8)
+        cells_ad.loc[ID, "cont"] = skime.find_contours(cell_unique, 0.8)
 
     return cells_ad
 
@@ -409,7 +411,7 @@ def match(cells_ad, labels, match_frac=0.4, split_frac=0.1, output_splits_merges
         IDs = np.unique(ID_vec)
         n_IDs = len(IDs)
         if n_IDs == 1 and IDs[0] == 0:
-            cells_ov.t_ID[ID_a] = 0
+            cells_ov.loc[ID_a, "t_ID"] = 0
             continue
         IDs = IDs[IDs != 0]
         n_IDs = len(IDs)
@@ -427,18 +429,18 @@ def match(cells_ad, labels, match_frac=0.4, split_frac=0.1, output_splits_merges
             # splits here
             if sum(valid_split_ids) > 1:
                 # Save split information
-                cells_ov.iloc[ID_a]["splitted"] = True
-                cells_ov.iloc[ID_a]["split_IDs"] = IDs[valid_split_ids]
-                cells_ov.iloc[ID_a]["split_fracs"] = N / len(ID_vec)
+                cells_ov.loc[ID_a, "splitted"] = True
+                cells_ov.loc[ID_a, "split_IDs"] = IDs[valid_split_ids]
+                cells_ov.loc[ID_a, "split_fracs"] = N / len(ID_vec)
 
         m = np.argmax(N)
         ID_match = IDs[m]
         ID_coverage = N[m] / len(ID_vec)
         if ID_coverage >= match_frac:
-            cells_ov.t_ID[ID_a] = ID_match
+            cells_ov.loc[ID_a, "t_ID"] = ID_match
         else:
-            cells_ov.t_ID[ID_a] = 0
-        cells_ov.frac[ID_a] = ID_coverage
+            cells_ov.loc[ID_a, "t_ID"] = 0
+        cells_ov.loc[ID_a, "frac"] = ID_coverage
     return cells_ov, labels, possible_merge_ids
 
 

--- a/pysteps/tracking/tdating.py
+++ b/pysteps/tracking/tdating.py
@@ -63,6 +63,7 @@ def dating(
     minmax=41,
     mindis=10,
     dyn_thresh=False,
+    output_splits_merges=False,
 ):
     """
     This function performs the thunderstorm detection and tracking DATing.
@@ -113,6 +114,32 @@ def dating(
     mindis: float, optional
         Minimum distance between two maxima of identified objects. Objects with a
         smaller distance will be merged. The default is 10 km.
+    output_splits_merges: bool, optional
+        If True, the output will contain information about splits and merges.
+        The provided columns are:
+
+        .. tabularcolumns:: |p{2cm}|L|
+
+        +-------------------+--------------------------------------------------------------+
+        | Attribute         | Description                                                  |
+        +===================+==============================================================+
+        | splitted          | Indicates if the cell is considered split into multiple cells|
+        +-------------------+--------------------------------------------------------------+
+        | split_IDs         | List of IDs at the next timestep that the cell split into    |
+        +-------------------+--------------------------------------------------------------+
+        | merged            | Indicates if the cell is considered a merge of multiple cells|
+        +-------------------+--------------------------------------------------------------+
+        | merged_IDs        | List of IDs from the previous timestep that merged into this |
+        |                   | cell                                                         |
+        +-------------------+--------------------------------------------------------------+
+        | results_from_split| True if the cell is a result of a split (i.e., the ID of the |
+        |                   | cell is present in the split_IDs of some cell at the previous|
+        |                   | timestep)                                                    |
+        +-------------------+--------------------------------------------------------------+
+        | will_merge        | True if the cell will merge at the next timestep (i.e., the  |
+        |                   | ID of the cell is present in the merge_IDs of some cell at   |
+        |                   | the next timestep; empty if the next timestep is not tracked)|
+        +-------------------+--------------------------------------------------------------+
 
     Returns
     -------
@@ -168,6 +195,7 @@ def dating(
             minmax=minmax,
             mindis=mindis,
             time=timelist[t],
+            output_splits_merges=output_splits_merges,
         )
         if len(cell_list) < 2:
             cell_list.append(cells_id)
@@ -177,29 +205,40 @@ def dating(
             continue
         if t >= 2:
             flowfield = oflow_method(input_video[t - 2 : t + 1, :, :])
-            cells_id, max_ID, newlabels, splitted_cells = tracking(cells_id, cell_list[-1], labels, flowfield, max_ID)
+            cells_id, max_ID, newlabels, splitted_cells = tracking(
+                cells_id,
+                cell_list[-1],
+                labels,
+                flowfield,
+                max_ID,
+                output_splits_merges=output_splits_merges,
+            )
+            if output_splits_merges:
+                # Assign splitted parameters for the previous timestep
+                for ID, split_cell in splitted_cells.iterrows():
+                    prev_list_id = cell_list[-1][
+                        cell_list[-1].ID == split_cell.ID
+                    ].index.item()
 
-            # Assign splitted parameters for the previous timestep
-            for ID, split_cell in splitted_cells.iterrows():
-                prev_list_id = cell_list[-1][cell_list[-1].ID == split_cell.ID].index.item()
+                    split_ids = split_cell.split_IDs
+                    split_ids_updated = []
+                    for sid in split_ids:
+                        split_ids_updated.append(newlabels[labels == sid][0])
 
-                split_ids = split_cell.split_IDs
-                split_ids_updated = []
-                for sid in split_ids:
-                    split_ids_updated.append(newlabels[labels == sid][0])
+                    cell_list[-1].at[prev_list_id, "splitted"] = True
+                    cell_list[-1].at[prev_list_id, "split_IDs"] = split_ids_updated
 
-                cell_list[-1].at[prev_list_id, "splitted"] = True
-                cell_list[-1].at[prev_list_id, "split_IDs"] = split_ids_updated
+                    for sid in split_ids_updated:
+                        cur_list_id = cells_id[cells_id.ID == sid].index.item()
+                        cells_id.at[cur_list_id, "results_from_split"] = True
 
-                for sid in split_ids_updated:
-                    cur_list_id = cells_id[cells_id.ID == sid].index.item()
-                    cells_id.at[cur_list_id, "results_from_split"] = True
-
-            merged_cells = cells_id[cells_id.merged == True]
-            for i, cell in merged_cells.iterrows():
-                for merged_id in cell.merged_IDs:
-                    prev_list_id = cell_list[-1][cell_list[-1].ID == merged_id].index.item()
-                    cell_list[-1].at[prev_list_id, "will_merge"] = True
+                merged_cells = cells_id[cells_id.merged == True]
+                for i, cell in merged_cells.iterrows():
+                    for merged_id in cell.merged_IDs:
+                        prev_list_id = cell_list[-1][
+                            cell_list[-1].ID == merged_id
+                        ].index.item()
+                        cell_list[-1].at[prev_list_id, "will_merge"] = True
 
             cid = np.unique(newlabels)
             # max_ID = np.nanmax([np.nanmax(cid), max_ID])
@@ -218,6 +257,7 @@ def tracking(
     V1,
     max_ID,
     merge_frac=0.1,
+    output_splits_merges=False,
 ):
     """
     This function performs the actual tracking procedure. First the cells are advected,
@@ -225,9 +265,18 @@ def tracking(
     is assigned.
     """
     cells_id_new = cells_id.copy()
-    cells_ad = advect(cells_id_prev, labels, V1)
-    cells_ov, labels, possible_merge_ids = match(cells_ad, labels)
-    splitted_cells = cells_ov[cells_ov.splitted == True]
+    cells_ad = advect(
+        cells_id_prev, labels, V1, output_splits_merges=output_splits_merges
+    )
+    cells_ov, labels, possible_merge_ids = match(
+        cells_ad,
+        labels,
+        output_splits_merges=output_splits_merges,
+    )
+
+    splitted_cells = None
+    if output_splits_merges:
+        splitted_cells = cells_ov[cells_ov.splitted == True]
 
     newlabels = np.zeros(labels.shape)
     possible_merge_ids_new = {}
@@ -250,49 +299,51 @@ def tracking(
         newlabels[labels == index + 1] = new_ID
         possible_merge_ids_new[new_ID] = possible_merge_ids[cell.ID]
         del new_ID
-    # Process possible merges
-    for target_id, possible_IDs in possible_merge_ids_new.items():
-        merge_ids = []
-        for p_id in possible_IDs:
-            cell_a = cells_ad[cells_ad.ID == p_id]
 
-            ID_vec = newlabels[cell_a.y.item(), cell_a.x.item()]
-            overlap = np.sum(ID_vec == target_id) / len(ID_vec)
-            if overlap > merge_frac:
-                merge_ids.append(p_id)
+    if output_splits_merges:
+        # Process possible merges
+        for target_id, possible_IDs in possible_merge_ids_new.items():
+            merge_ids = []
+            for p_id in possible_IDs:
+                cell_a = cells_ad[cells_ad.ID == p_id]
 
-        if len(merge_ids) > 1:
-            cell_id = cells_id_new[cells_id_new.ID == target_id].index.item()
-            # Merge cells
-            cells_id_new.at[cell_id, "merged"] = True
-            cells_id_new.at[cell_id, "merged_IDs"] = merge_ids
+                ID_vec = newlabels[cell_a.y.item(), cell_a.x.item()]
+                overlap = np.sum(ID_vec == target_id) / len(ID_vec)
+                if overlap > merge_frac:
+                    merge_ids.append(p_id)
+
+            if len(merge_ids) > 1:
+                cell_id = cells_id_new[cells_id_new.ID == target_id].index.item()
+                # Merge cells
+                cells_id_new.at[cell_id, "merged"] = True
+                cells_id_new.at[cell_id, "merged_IDs"] = merge_ids
 
     return cells_id_new, max_ID, newlabels, splitted_cells
 
 
-def advect(cells_id, labels, V1):
+def advect(cells_id, labels, V1, output_splits_merges=False):
     """
     This function advects all identified cells with the estimated flow.
     """
+    columns = [
+        "ID",
+        "x",
+        "y",
+        "cen_x",
+        "cen_y",
+        "max_ref",
+        "cont",
+        "t_ID",
+        "frac",
+        "flowx",
+        "flowy",
+    ]
+    if output_splits_merges:
+        columns.extend(["splitted", "split_IDs", "split_fracs"])
     cells_ad = pd.DataFrame(
         data=None,
         index=range(len(cells_id)),
-        columns=[
-            "ID",
-            "x",
-            "y",
-            "cen_x",
-            "cen_y",
-            "max_ref",
-            "cont",
-            "t_ID",
-            "frac",
-            "flowx",
-            "flowy",
-            "splitted",
-            "split_IDs",
-            "split_fracs",
-        ],
+        columns=columns,
     )
     for ID, cell in cells_id.iterrows():
         if cell.ID == 0 or np.isnan(cell.ID):
@@ -321,7 +372,7 @@ def advect(cells_id, labels, V1):
     return cells_ad
 
 
-def match(cells_ad, labels, match_frac=0.4, split_frac=0.1):
+def match(cells_ad, labels, match_frac=0.4, split_frac=0.1, output_splits_merges=False):
     """
     This function matches the advected cells of the previous timestep to the newly
     identified ones. A minimal overlap of 40% is required. In case of split of merge,
@@ -348,14 +399,15 @@ def match(cells_ad, labels, match_frac=0.4, split_frac=0.1):
         for n in range(n_IDs):
             N[n] = len(np.where(ID_vec == IDs[n])[0])
 
-        # Only consider possible split if overlap is large enough
-        valid_split_ids = (N / len(ID_vec)) > split_frac
-        # splits here
-        if sum(valid_split_ids) > 1:
-            # Save split information
-            cells_ov.iloc[ID_a]["splitted"] = True
-            cells_ov.iloc[ID_a]["split_IDs"] = IDs[valid_split_ids]
-            cells_ov.iloc[ID_a]["split_fracs"] = N / len(ID_vec)
+        if output_splits_merges:
+            # Only consider possible split if overlap is large enough
+            valid_split_ids = (N / len(ID_vec)) > split_frac
+            # splits here
+            if sum(valid_split_ids) > 1:
+                # Save split information
+                cells_ov.iloc[ID_a]["splitted"] = True
+                cells_ov.iloc[ID_a]["split_IDs"] = IDs[valid_split_ids]
+                cells_ov.iloc[ID_a]["split_fracs"] = N / len(ID_vec)
 
         m = np.argmax(N)
         ID_match = IDs[m]

--- a/pysteps/tracking/tdating.py
+++ b/pysteps/tracking/tdating.py
@@ -274,6 +274,7 @@ def tracking(
     labels,
     V1,
     max_ID,
+    match_frac=0.4,
     merge_frac=0.1,
     split_frac=0.1,
     output_splits_merges=False,
@@ -292,7 +293,7 @@ def tracking(
         labels,
         output_splits_merges=output_splits_merges,
         split_frac=split_frac,
-        match_frac=merge_frac,
+        match_frac=match_frac,
     )
 
     splitted_cells = None


### PR DESCRIPTION
Hi! I've been working on including information on splits and merges of storm cells in tdating. This is a somewhat working version of that. Here currently, 

* a cell at time t is considered to split, if the advected version of the cell overlaps more than 10% with more than one cell at time t+1
* a cell at time t is considered to be merged, if more than one advected cell (advected from t to t+1) overlaps more than 10% with it

The results are stored as additional columns in the cell dataframes:
* `splitted` (bool): cell is considered split
* `split_IDs` (list): list of IDs at next timestep that the cell split to
* `merged` (bool): cell is considered a merge of multiple cells
* `merged_IDs` (list): list of IDs from previous timestep that merged into this cell
* `results_from_split` (bool): convenience attribute that is True if the cell is a result of split (i.e. the ID of the cell is present in the `split_IDs` of some cell at previous timestep)
* `will_merge` (bool): convenience attribute that is True if the cell will merge at next timestep (i.e. the ID of the cell is present in the `merge_IDs` of some cell at next timestep). Will of course be empty, if the next timestep is not tracked

Additionally, this PR contains a bug fix in the `pysteps.tracking.tdating.match` function. As far as I can tell, in this bug the label `0` was included in possible match IDs, even though 0 denotes pixels that are not part of any cell. So there could be cases, where the advected cell would have e.g. 55% of `0` and 45% of some cell and it would not be matched to that cell. In my opinion, this bug needs to be fixed in the codebase even if the merge/split is not.

The code could probably be improved and e.g. it would benefit from some unit tests. But I'm creating this PR already for discussion especially for @pulkkins and @dnerini since this relates to my current work that you're involved in.