### PR TITLE
Bug fix: ignore 0 in TDaTing cell match

### DIFF
--- a/pysteps/tracking/tdating.py
+++ b/pysteps/tracking/tdating.py
@@ -282,6 +282,11 @@ def match(cells_ad, labels):
         ID_vec = labels[cell_a.y, cell_a.x]
         IDs = np.unique(ID_vec)
         n_IDs = len(IDs)
+        if n_IDs == 1 and IDs[0] == 0:
+            cells_ov.t_ID[ID_a] = 0
+            continue
+        IDs = IDs[IDs != 0]
+        n_IDs = len(IDs)
         N = np.zeros(n_IDs)
         for n in range(n_IDs):
             N[n] = len(np.where(ID_vec == IDs[n])[0])


### PR DESCRIPTION
This PR fixes a bug in the `pysteps.tracking.tdating.match` function. As far as I can tell, in this bug the label 0 was included in possible match IDs, even though 0 denotes pixels that are not part of any cell. So there could be cases, where the advected cell would have e.g. 55% of 0 and 45% of some cell and it would not be matched to that cell. So this fix will first check if the advected cell contains only 0-labeled pixels, it is initiated as a new track. If not, then 0 is removed from the possible ID labels and the matching is done as previously. 