### PR TITLE
Hackathon July 2023

### DIFF
--- a/pysteps/blending/steps.py
+++ b/pysteps/blending/steps.py
@@ -970,7 +970,6 @@ def forecast(
                         precip_cascade[j][i] = autoregression.iterate_ar_model(
                             precip_cascade[j][i], PHI[i, :]
                         )
-
                     else:
                         # use the deterministic AR(p) model computed above if
                         # perturbations are disabled
@@ -2223,8 +2222,8 @@ def _compute_initial_nwp_skill(
     """Calculate the initial skill of the (NWP) model forecasts at t=0."""
     rho_nwp_models = [
         blending.skill_scores.spatial_correlation(
-            obs=R_c[0, :, -1, :, :],
-            mod=precip_models[n_model, :, :, :],
+            obs=R_c[0, :, -1, :, :].copy(),
+            mod=precip_models[n_model, :, :, :].copy(),
             domain_mask=domain_mask,
         )
         for n_model in range(precip_models.shape[0])

--- a/pysteps/blending/steps.py
+++ b/pysteps/blending/steps.py
@@ -970,6 +970,7 @@ def forecast(
                         precip_cascade[j][i] = autoregression.iterate_ar_model(
                             precip_cascade[j][i], PHI[i, :]
                         )
+                        precip_cascade[j][i][1] /= np.std(precip_cascade[j][i][1])
                     else:
                         # use the deterministic AR(p) model computed above if
                         # perturbations are disabled

--- a/pysteps/blending/steps.py
+++ b/pysteps/blending/steps.py
@@ -578,7 +578,7 @@ def forecast(
 
     # 2.3.1 If precip is below the norain threshold and precip_models_pm is zero,
     # we consider it as no rain in the domain.
-    # The forecast will directly return an array filled with the miminmum
+    # The forecast will directly return an array filled with the minimum
     # value present in precip (which equals zero rainfall in the used
     # transformation)
     if zero_precip_radar and zero_model_fields:
@@ -600,20 +600,22 @@ def forecast(
         # Save per time step to ensure the array does not become too large if
         # no return_output is requested and callback is not None.
         for t, subtimestep_idx in enumerate(timesteps):
-            # Create an empty np array with shape [n_ens_members, rows, cols]
-            # and fill it with the minimum value from precip (corresponding to
-            # zero precipitation)
-            R_f_ = np.full(
-                (n_ens_members, precip_shape[0], precip_shape[1]), np.nanmin(precip)
-            )
-            if callback is not None:
-                if R_f_.shape[1] > 0:
-                    callback(R_f_.squeeze())
-            if return_output:
-                for j in range(n_ens_members):
-                    R_f[j].append(R_f_[j])
+            # If the timestep is not the first one, we need to provide the zero forecast
+            if t > 0:
+                # Create an empty np array with shape [n_ens_members, rows, cols]
+                # and fill it with the minimum value from precip (corresponding to
+                # zero precipitation)
+                R_f_ = np.full(
+                    (n_ens_members, precip_shape[0], precip_shape[1]), np.nanmin(precip)
+                )
+                if callback is not None:
+                    if R_f_.shape[1] > 0:
+                        callback(R_f_.squeeze())
+                if return_output:
+                    for j in range(n_ens_members):
+                        R_f[j].append(R_f_[j])
 
-            R_f_ = None
+                R_f_ = None
 
         if measure_time:
             zero_precip_time = time.time() - starttime_init
@@ -628,7 +630,18 @@ def forecast(
             return None
 
     else:
-        # 2.3.3 Check if the NWP fields contain nans or infinite numbers. If so,
+        # 2.3.3 If zero_precip_radar, make sure that precip_cascade does not contain
+        # only nans or infs. If so, fill it with the zero value.
+        if zero_precip_radar:
+            precip_cascade = np.nan_to_num(
+                precip_cascade,
+                copy=True,
+                nan=np.nanmin(precip_models_cascade),
+                posinf=np.nanmin(precip_models_cascade),
+                neginf=np.nanmin(precip_models_cascade),
+            )
+
+        # 2.3.4 Check if the NWP fields contain nans or infinite numbers. If so,
         # fill these with the minimum value present in precip (corresponding to
         # zero rainfall in the radar observations)
         (
@@ -645,7 +658,7 @@ def forecast(
             sigma_models,
         )
 
-        # 2.3.4 If zero_precip_radar is True, only use the velocity field of the NWP
+        # 2.3.5 If zero_precip_radar is True, only use the velocity field of the NWP
         # forecast. I.e., velocity (radar) equals velocity_model at the first time
         # step.
         if zero_precip_radar:
@@ -662,7 +675,7 @@ def forecast(
         # rainfall data
         if zero_precip_radar:
             precip_noise_input = _determine_max_nr_rainy_cells_nwp(
-                precip_models_pm, precip_thr, n_ens_members, timesteps
+                precip_models_pm, precip_thr, precip_models_pm.shape[0], timesteps
             )
             # Make sure precip_noise_input is three dimensional
             precip_noise_input = precip_noise_input[np.newaxis, :, :]
@@ -1082,12 +1095,21 @@ def forecast(
                         # First recompose the cascade, advect it and decompose it again
                         # This is needed to remove the interpolation artifacts.
                         # In addition, the number of extrapolations is greatly reduced
-                        # A. Rain
+                        # A. Radar Rain
                         R_f_ip_recomp = blending.utils.recompose_cascade(
                             combined_cascade=R_f_ip,
                             combined_mean=mu_extrapolation,
                             combined_sigma=sigma_extrapolation,
                         )
+                        # Make sure we have values outside the mask
+                        if zero_precip_radar:
+                            R_f_ip_recomp = np.nan_to_num(
+                                R_f_ip_recomp,
+                                copy=True,
+                                nan=zerovalue,
+                                posinf=zerovalue,
+                                neginf=zerovalue,
+                            )
                         # Put back the mask
                         R_f_ip_recomp[domain_mask] = np.NaN
                         extrap_kwargs["displacement_prev"] = D[j]
@@ -1112,10 +1134,18 @@ def forecast(
                             compute_stats=True,
                             compact_output=True,
                         )["cascade_levels"]
+                        # Make sure we have values outside the mask
+                        if zero_precip_radar:
+                            R_f_ep = np.nan_to_num(
+                                R_f_ep,
+                                copy=True,
+                                nan=np.nanmin(R_f_ip),
+                                posinf=np.nanmin(R_f_ip),
+                                neginf=np.nanmin(R_f_ip),
+                            )
                         for i in range(n_cascade_levels):
                             R_f_ep[i][temp_mask] = np.NaN
-
-                        #B. Noise
+                        # B. Noise
                         Yn_ip_recomp = blending.utils.recompose_cascade(
                             combined_cascade=Yn_ip,
                             combined_mean=mu_noise[j],
@@ -1235,7 +1265,7 @@ def forecast(
                         [t_diff_prev],
                         allow_nonfinite_values=True,
                         **extrap_kwargs_noise,
-                        )
+                    )
 
                     # Also extrapolate the radar observation, used for the probability
                     # matching and post-processing steps
@@ -1471,11 +1501,12 @@ def forecast(
                             R_f_new[~MASK_prec_] = R_cmin
 
                         if probmatching_method == "cdf":
-                            # adjust the CDF of the forecast to match the most recent
-                            # benchmark rainfall field (R_pm_blended)
-                            R_f_new = probmatching.nonparam_match_empirical_cdf(
-                                R_f_new, R_pm_blended
-                            )
+                            # Adjust the CDF of the forecast to match the most recent
+                            # benchmark rainfall field (R_pm_blended). If the forecast
+                            if np.any(np.isfinite(R_f_new)):
+                                R_f_new = probmatching.nonparam_match_empirical_cdf(
+                                    R_f_new, R_pm_blended
+                                )
                         elif probmatching_method == "mean":
                             # Use R_pm_blended as benchmark field and
                             mu_0 = np.mean(R_pm_blended[R_pm_blended >= precip_thr])
@@ -2389,15 +2420,16 @@ def _fill_nans_infs_nwp_cascade(
 
 
 def _determine_max_nr_rainy_cells_nwp(
-    precip_models_pm, precip_thr, n_ens_members, timesteps
+    precip_models_pm, precip_thr, n_models, timesteps
 ):
     """Initialize noise based on the NWP field time step where the fraction of rainy cells is highest"""
     if precip_thr is None:
         precip_thr = np.nanmin(precip_models_pm)
+
     max_rain_pixels = -1
     max_rain_pixels_j = -1
     max_rain_pixels_t = -1
-    for j in range(n_ens_members):
+    for j in range(n_models):
         for t in range(timesteps):
             rain_pixels = precip_models_pm[j][t][
                 precip_models_pm[j][t] > precip_thr

--- a/pysteps/blending/steps.py
+++ b/pysteps/blending/steps.py
@@ -578,6 +578,10 @@ def forecast(
 
     # Also initialize the cascade of temporally correlated noise, which has the
     # same shape as precip_cascade, but starts with value zero.
+    #FIXME: Initialize noise with random values with correct spatial correlation
+    #       and standard deviations.
+    #FIXME: Should be done after _init_random_generators. Do we do it below with seperate 
+    #       _init_noise_cascade function or do we incorporate it in the worker loop?
     noise_cascade = np.zeros(precip_cascade.shape)
 
     # 6. Initialize all the random generators and prepare for the forecast loop
@@ -807,6 +811,7 @@ def forecast(
                     normalize=True,
                     compact_output=True,
                 )
+            #FIXME: Could also introduce the noise here with if t==0 clausule
             else:
                 EPS = None
 
@@ -819,6 +824,8 @@ def forecast(
                     precip_cascade[j][i] = autoregression.iterate_ar_model(
                         precip_cascade[j][i], PHI[i, :]
                     )
+                # FIXME: precipitation cascade should be renormalized here!
+                #        but how? Check slack exchange!
 
                 else:
                     # use the deterministic AR(p) model computed above if

--- a/pysteps/blending/steps.py
+++ b/pysteps/blending/steps.py
@@ -1086,9 +1086,9 @@ def forecast(
                             combined_sigma=sigma_extrapolation,
                         )
                         # Put back the mask
-                        R_f_ip_recomp[domain_mask]=np.NaN
-                        extrap_kwargs['displacement_prev'] = D[j]
-                        R_f_ep_recomp_, D[j]  = extrapolator(
+                        R_f_ip_recomp[domain_mask] = np.NaN
+                        extrap_kwargs["displacement_prev"] = D[j]
+                        R_f_ep_recomp_, D[j] = extrapolator(
                             R_f_ip_recomp,
                             velocity_blended,
                             [t_diff_prev],
@@ -1108,10 +1108,9 @@ def forecast(
                             normalize=True,
                             compute_stats=True,
                             compact_output=True,
-                        )['cascade_levels']
+                        )["cascade_levels"]
                         for i in range(n_cascade_levels):
                             R_f_ep[i][temp_mask] = np.NaN
-                        
 
                         #B. Noise
                         Yn_ip_recomp = blending.utils.recompose_cascade(
@@ -1119,9 +1118,9 @@ def forecast(
                             combined_mean=mu_noise[j],
                             combined_sigma=sigma_noise[j],
                         )
-                        extrap_kwargs_noise['displacement_prev'] = D_Yn[j]
+                        extrap_kwargs_noise["displacement_prev"] = D_Yn[j]
                         extrap_kwargs_noise["map_coordinates_mode"] = "wrap"
-                        Yn_ep_recomp_, D_Yn[j]  = extrapolator(
+                        Yn_ep_recomp_, D_Yn[j] = extrapolator(
                             Yn_ip_recomp,
                             velocity_blended,
                             [t_diff_prev],
@@ -1138,7 +1137,7 @@ def forecast(
                             normalize=True,
                             compute_stats=True,
                             compact_output=True,
-                        )['cascade_levels']
+                        )["cascade_levels"]
                         for i in range(n_cascade_levels):
                             Yn_ep[i] *= noise_std_coeffs[i]
 
@@ -1147,12 +1146,11 @@ def forecast(
                         R_f_ep_out.append(R_f_ep.copy())
                         Yn_ep_out.append(Yn_ep.copy())
                         R_f_ip_recomp = None
-                        R_f_ep_recomp_=None
-                        R_f_ep_recomp=None
-                        Yn_ip_recomp=None
-                        Yn_ep_recomp_=None
-                        Yn_ep_recomp=None
-                        
+                        R_f_ep_recomp_ = None
+                        R_f_ep_recomp = None
+                        Yn_ip_recomp = None
+                        Yn_ep_recomp_ = None
+                        Yn_ep_recomp = None
 
                         # Finally, also extrapolate the initial radar rainfall
                         # field. This will be blended with the rainfall field(s)
@@ -2308,12 +2306,12 @@ def _init_noise_cascade(
     ar_order,
 ):
     """Initialize the noise cascade with identical noise for all AR(n) steps
-       We also need to return the mean and standard deviations of the noise
-       for the recombination of the noise before advecting it.
+    We also need to return the mean and standard deviations of the noise
+    for the recombination of the noise before advecting it.
     """
     noise_cascade = np.zeros(shape)
-    mu_noise = np.zeros((n_ens_members,n_cascade_levels))
-    sigma_noise = np.zeros((n_ens_members,n_cascade_levels))
+    mu_noise = np.zeros((n_ens_members, n_cascade_levels))
+    sigma_noise = np.zeros((n_ens_members, n_cascade_levels))
     if noise_method:
         for j in range(n_ens_members):
             EPS = generate_noise(
@@ -2339,6 +2337,7 @@ def _init_noise_cascade(
             EPS = None
             EPS_ = None
     return noise_cascade, mu_noise, sigma_noise
+
 
 
 def _fill_nans_infs_nwp_cascade(
@@ -2390,6 +2389,8 @@ def _determine_max_nr_rainy_cells_nwp(
     precip_models_pm, precip_thr, n_ens_members, timesteps
 ):
     """Initialize noise based on the NWP field time step where the fraction of rainy cells is highest"""
+    if precip_thr is None:
+        precip_thr = np.nanmin(precip_models_pm)
     max_rain_pixels = -1
     max_rain_pixels_j = -1
     max_rain_pixels_t = -1

--- a/pysteps/blending/steps.py
+++ b/pysteps/blending/steps.py
@@ -1176,7 +1176,6 @@ def forecast(
                         for i in range(n_cascade_levels):
                             Yn_ep[i] *= noise_std_coeffs[i]
 
-
                         # Append the results to the output lists
                         R_f_ep_out.append(R_f_ep.copy())
                         Yn_ep_out.append(Yn_ep.copy())
@@ -2376,7 +2375,6 @@ def _init_noise_cascade(
             EPS = None
             EPS_ = None
     return noise_cascade, mu_noise, sigma_noise
-
 
 
 def _fill_nans_infs_nwp_cascade(

--- a/pysteps/blending/steps.py
+++ b/pysteps/blending/steps.py
@@ -523,26 +523,8 @@ def forecast(
         precip, velocity, ar_order, xy_coords, extrapolator, extrap_kwargs, num_workers
     )
 
-    # 2. Initialize the noise method
-    np.random.seed(seed)
-    pp, generate_noise, noise_std_coeffs = _init_noise(
-        precip,
-        precip_thr,
-        n_cascade_levels,
-        bp_filter,
-        decompositor,
-        fft,
-        noise_method,
-        noise_kwargs,
-        noise_stddev_adj,
-        measure_time,
-        num_workers,
-        seed,
-    )
-
-    # 3. Perform the cascade decomposition for the input precip fields and
+    # 2. Perform the cascade decomposition for the input precip fields and
     # and, if necessary, for the (NWP) model fields
-
     # 2.1 Compute the cascade decompositions of the input precipitation fields
     (
         precip_cascade,
@@ -574,7 +556,9 @@ def forecast(
     zero_precip_radar = blending.utils.check_norain(precip, precip_thr, norain_thr)
     # The norain fraction threshold used for nwp is the default value of 0.0,
     # since nwp does not suffer from clutter.
-    zero_model_fields = blending.utils.check_norain(precip_models_pm, precip_thr)
+    zero_model_fields = blending.utils.check_norain(
+        precip_models_pm, precip_thr, norain_thr
+    )
 
     # 2.3.1 If precip is below the norain threshold and precip_models_pm is zero,
     # we consider it as no rain in the domain.

--- a/pysteps/blending/steps.py
+++ b/pysteps/blending/steps.py
@@ -694,6 +694,7 @@ def forecast(
             noise_stddev_adj,
             measure_time,
             num_workers,
+            seed,
         )
         precip_noise_input = None
 

--- a/pysteps/blending/utils.py
+++ b/pysteps/blending/utils.py
@@ -15,6 +15,7 @@ Module with common utilities used by the blending methods.
     decompose_NWP
     compute_store_nwp_motion
     load_NWP
+    check_norain
 """
 
 import datetime
@@ -519,6 +520,7 @@ def load_NWP(input_nc_path_decomp, input_path_velocities, start_time, n_timestep
 
     return R_d, uv
 
+
 def check_norain(precip_arr, precip_thr, norain_thr=0.0):
     """
 
@@ -541,6 +543,6 @@ def check_norain(precip_arr, precip_thr, norain_thr=0.0):
 
     if precip_thr is None:
         precip_thr = np.nanmin(precip_arr)
-    rain_pixels = precip_arr [precip_arr>precip_thr]
-    norain = rain_pixels.size/precip_arr.size <= norain_thr
+    rain_pixels = precip_arr[precip_arr > precip_thr]
+    norain = rain_pixels.size / precip_arr.size <= norain_thr
     return norain

--- a/pysteps/blending/utils.py
+++ b/pysteps/blending/utils.py
@@ -518,3 +518,29 @@ def load_NWP(input_nc_path_decomp, input_path_velocities, start_time, n_timestep
         R_d.append(decomp_dict_)
 
     return R_d, uv
+
+def check_norain(precip_arr, precip_thr, norain_thr=0.0):
+    """
+
+    Parameters
+    ----------
+    precip_arr:  array-like
+      Array containing the input precipitation field
+    precip_thr: float, optional
+      Specifies the threshold value for minimum observable precipitation intensity. If None, the
+      minimum value over the domain is taken.
+    norain_thr: float, optional
+      Specifies the threshold value for the fraction of rainy pixels in precip_arr below which we consider there to be
+      no rain. Standard set to 0.0
+    Returns
+    -------
+    norain: bool
+      Returns whether the fraction of rainy pixels is below the norain_thr threshold.
+
+    """
+
+    if precip_thr is None:
+        precip_thr = np.nanmin(precip_arr)
+    rain_pixels = precip_arr [precip_arr>precip_thr]
+    norain = rain_pixels.size/precip_arr.size <= norain_thr
+    return norain

--- a/pysteps/blending/utils.py
+++ b/pysteps/blending/utils.py
@@ -491,6 +491,13 @@ def load_NWP(input_nc_path_decomp, input_path_velocities, start_time, n_timestep
     assert analysis_time + start_i * timestep == start_time
     end_i = start_i + n_timesteps + 1
 
+    # Check if the requested end time (the forecast horizon) is in the stored data.
+    # If not, raise an error
+    if end_i > ncf_decomp.variables["pr_decomposed"].shape[0]:
+        raise IndexError(
+            "The requested forecast horizon is outside the stored NWP forecast horizon. Either request a shorter forecast horizon or store a longer NWP forecast horizon"
+        )
+
     # Add the valid times to the output
     decomp_dict["valid_times"] = valid_times[start_i:end_i]
 
@@ -521,7 +528,7 @@ def load_NWP(input_nc_path_decomp, input_path_velocities, start_time, n_timestep
     return R_d, uv
 
 
-def check_norain(precip_arr, precip_thr, norain_thr=0.0):
+def check_norain(precip_arr, precip_thr=None, norain_thr=0.0):
     """
 
     Parameters

--- a/pysteps/blending/utils.py
+++ b/pysteps/blending/utils.py
@@ -502,21 +502,17 @@ def load_NWP(input_nc_path_decomp, input_path_velocities, start_time, n_timestep
     for i in range(start_i, end_i):
         decomp_dict_ = decomp_dict.copy()
 
+        # Obtain the decomposed cascades for time step i
         cascade_levels = ncf_decomp.variables["pr_decomposed"][i, :, :, :]
-
-        # In the netcdf file this is saved as a masked array, so we're checking if there is no mask
-        assert not cascade_levels.mask
-
+        # Obtain the mean values
         means = ncf_decomp.variables["means"][i, :]
-        assert not means.mask
-
+        # Obtain de standard deviations
         stds = ncf_decomp.variables["stds"][i, :]
-        assert not stds.mask
 
         # Save the values in the dictionary as normal arrays with the filled method
-        decomp_dict_["cascade_levels"] = np.ma.filled(cascade_levels)
-        decomp_dict_["means"] = np.ma.filled(means)
-        decomp_dict_["stds"] = np.ma.filled(stds)
+        decomp_dict_["cascade_levels"] = np.ma.filled(cascade_levels, fill_value=np.nan)
+        decomp_dict_["means"] = np.ma.filled(means, fill_value=np.nan)
+        decomp_dict_["stds"] = np.ma.filled(stds, fill_value=np.nan)
 
         # Append the output list
         R_d.append(decomp_dict_)

--- a/pysteps/blending/utils.py
+++ b/pysteps/blending/utils.py
@@ -525,6 +525,7 @@ def load_NWP(input_nc_path_decomp, input_path_velocities, start_time, n_timestep
         # Append the output list
         R_d.append(decomp_dict_)
 
+    ncf_decomp.close()
     return R_d, uv
 
 
@@ -552,4 +553,6 @@ def check_norain(precip_arr, precip_thr=None, norain_thr=0.0):
         precip_thr = np.nanmin(precip_arr)
     rain_pixels = precip_arr[precip_arr > precip_thr]
     norain = rain_pixels.size / precip_arr.size <= norain_thr
+    print("Field is below no rain fraction :", norain)
+    print("rain fraction is :", rain_pixels.size / precip_arr.size)
     return norain

--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -1374,7 +1374,7 @@ def import_odim_hdf5(filename, qty="RATE", **kwargs):
         raise IOError("requested quantity %s not found" % qty)
 
     where = f["where"]
-    if isinstance(where.attrs["projdef"],str):
+    if isinstance(where.attrs["projdef"], str):
         proj4str = where.attrs["projdef"]
     else:
         proj4str = where.attrs["projdef"].decode()

--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -1374,7 +1374,10 @@ def import_odim_hdf5(filename, qty="RATE", **kwargs):
         raise IOError("requested quantity %s not found" % qty)
 
     where = f["where"]
-    proj4str = where.attrs["projdef"].decode()
+    if isinstance(where.attrs["projdef"],str):
+        proj4str = where.attrs["projdef"]
+    else:
+        proj4str = where.attrs["projdef"].decode()
     pr = pyproj.Proj(proj4str)
 
     ll_lat = where.attrs["LL_lat"]


### PR DESCRIPTION
This pull request brings all developments made during the July 2023 pySTEPS-hackathon at the RMIB.  
Many thanks to all contributors: @ladc, @RubenImhoff, Simon De Kock and Ricardo  Reinoso-Rondinel.

The work was focussed on the STEPS blending routine.

**NEW FEATURES**
1. Scientificaly correct handling of following cases when using STEPS blending (linked with #309)
- No rain in radar fields | No rain in NWP fields
- No rain in rader fiels | Rain in NWP fields

**REFACTORING** (all linked with #332)
1. Initialisation of the noise cascade with random noise (with correct spatial correlation) to have correct power 
2. Renormalize radar extrapolation cascade after AR(2)-evolution to not lose power
3. STEPS Blending extrapolation component:
- Precipiation and noise cascade are recomposed before advection
- Both fields are advected
- They are decomposed again for blending with NWP cascade
This removes the loss of power in the smallest scales due to the interpolation needed for the semilagrangian advection.  
In addition computational cost is reduced because the number of extrapolation is greatly reduced.

**BUGFIXES**
- Decoding issue for loading older (RMI) ODIM HDF5-files
- Avoid accidentally masking precip arrays by passing a copy to spatial_correlation