### PR TITLE
Fix docs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -85,7 +85,7 @@ release = version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/examples/optical_flow_methods_convergence.py
+++ b/examples/optical_flow_methods_convergence.py
@@ -22,7 +22,7 @@ import time
 
 import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib.cm import get_cmap
+from matplotlib.pyplot import get_cmap
 from scipy.ndimage import uniform_filter
 
 import pysteps as stp

--- a/pysteps/nowcasts/utils.py
+++ b/pysteps/nowcasts/utils.py
@@ -103,6 +103,9 @@ def compute_percentile_mask(precip, pct):
     """Compute a precipitation mask, where True/False values are assigned for
     pixels above/below the given percentile.
 
+    .. _ndarray:\
+    https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.html
+
     Parameters
     ----------
     precip: array_like

--- a/pysteps/visualization/precipfields.py
+++ b/pysteps/visualization/precipfields.py
@@ -16,7 +16,7 @@ import warnings
 
 import matplotlib.pylab as plt
 import numpy as np
-from matplotlib import cm, colors
+from matplotlib import pyplot, colors
 
 from pysteps.visualization.utils import get_geogrid, get_basemap_axis
 
@@ -294,7 +294,7 @@ def get_colormap(ptype, units="mm/h", colorscale="pysteps"):
         clevs_str = [f"{clev:.1f}" for clev in clevs]
         return cmap, norm, clevs, clevs_str
 
-    return cm.get_cmap("jet"), colors.Normalize(), None, None
+    return pyplot.get_cmap("jet"), colors.Normalize(), None, None
 
 
 def _get_colorlist(units="mm/h", colorscale="pysteps"):


### PR DESCRIPTION
Various fixes to the docs. In particular, use `pyplot.get_cmap()` instead of `cm.get_cmap()` with matplotlib 3.9