### PR TITLE
Fix: make sure that precip_models variable has the correct length

### DIFF
--- a/pysteps/blending/steps.py
+++ b/pysteps/blending/steps.py
@@ -1808,7 +1808,7 @@ def _check_inputs(
     if isinstance(timesteps, list) and not sorted(timesteps) == timesteps:
         raise ValueError("timesteps is not in ascending order")
     if isinstance(timesteps, list):
-        if precip_models.shape[1] != len(timesteps) + 1:
+        if precip_models.shape[1] != timesteps[-1] + 1:
             raise ValueError(
                 "precip_models does not contain sufficient lead times for this forecast"
             )

--- a/pysteps/blending/steps.py
+++ b/pysteps/blending/steps.py
@@ -43,6 +43,7 @@ consists of the following main steps:
     blend_means_sigmas
 """
 
+import math
 import time
 
 import numpy as np
@@ -1808,7 +1809,7 @@ def _check_inputs(
     if isinstance(timesteps, list) and not sorted(timesteps) == timesteps:
         raise ValueError("timesteps is not in ascending order")
     if isinstance(timesteps, list):
-        if precip_models.shape[1] != timesteps[-1] + 1:
+        if precip_models.shape[1] != math.ceil(timesteps[-1]) + 1:
             raise ValueError(
                 "precip_models does not contain sufficient lead times for this forecast"
             )


### PR DESCRIPTION
Fix to ensure that the `_check_inputs` function in `/blending/steps.py` looks for the correct `precip_models` length when a list of timesteps instead of an integer is provided.