### PR TITLE
fix: make sure netcdf exporters can handle list of timesteps

### DIFF
--- a/pysteps/io/exporters.py
+++ b/pysteps/io/exporters.py
@@ -592,7 +592,7 @@ def initialize_forecast_exporter_netcdf(
     var_time = ncf.createVariable("time", int, dimensions=("time",))
     if isinstance(n_timesteps, list):
         if incremental != "timestep":
-            var_time[:] = n_timesteps * timestep * 60
+            var_time[:] = np.array(n_timesteps) * timestep * 60
     else:
         if incremental != "timestep":
             var_time[:] = [i * timestep * 60 for i in range(1, n_timesteps + 1)]

--- a/pysteps/io/exporters.py
+++ b/pysteps/io/exporters.py
@@ -461,7 +461,8 @@ def initialize_forecast_exporter_netcdf(
             + "'timestep' or 'member'"
         )
 
-    if isinstance(n_timesteps, list):
+    n_timesteps_is_list = isinstance(n_timesteps, list)
+    if n_timesteps_is_list:
         num_timesteps = len(n_timesteps)
     else:
         num_timesteps = n_timesteps
@@ -590,11 +591,10 @@ def initialize_forecast_exporter_netcdf(
         var_ens_num.units = ""
 
     var_time = ncf.createVariable("time", int, dimensions=("time",))
-    if isinstance(n_timesteps, list):
-        if incremental != "timestep":
+    if incremental != "timestep":
+        if n_timesteps_is_list:
             var_time[:] = np.array(n_timesteps) * timestep * 60
-    else:
-        if incremental != "timestep":
+        else:
             var_time[:] = [i * timestep * 60 for i in range(1, n_timesteps + 1)]
     var_time.long_name = "forecast time"
     startdate_str = datetime.strftime(startdate, "%Y-%m-%d %H:%M:%S")

--- a/pysteps/tests/test_exporters.py
+++ b/pysteps/tests/test_exporters.py
@@ -23,14 +23,17 @@ exporter_arg_names = (
     "fill_value",
     "scale_factor",
     "offset",
+    "n_timesteps",
 )
 
 exporter_arg_values = [
-    (1, None, np.float32, None, None, None),
-    (1, "timestep", np.float32, 65535, None, None),
-    (2, None, np.float32, 65535, None, None),
-    (2, "timestep", np.float32, None, None, None),
-    (2, "member", np.float64, None, 0.01, 1.0),
+    (1, None, np.float32, None, None, None, 3),
+    (1, "timestep", np.float32, 65535, None, None, 3),
+    (2, None, np.float32, 65535, None, None, 3),
+    (2, None, np.float32, 65535, None, None, [1, 2, 4]),
+    (2, "timestep", np.float32, None, None, None, 3),
+    (2, "timestep", np.float32, None, None, None, [1, 2, 4]),
+    (2, "member", np.float64, None, 0.01, 1.0, 3),
 ]
 
 
@@ -54,7 +57,7 @@ def test_get_geotiff_filename():
 
 @pytest.mark.parametrize(exporter_arg_names, exporter_arg_values)
 def test_io_export_netcdf_one_member_one_time_step(
-    n_ens_members, incremental, datatype, fill_value, scale_factor, offset
+    n_ens_members, incremental, datatype, fill_value, scale_factor, offset, n_timesteps
 ):
     """
     Test the export netcdf.
@@ -75,7 +78,6 @@ def test_io_export_netcdf_one_member_one_time_step(
         file_path = os.path.join(outpath, outfnprefix + ".nc")
         startdate = metadata["timestamps"][0]
         timestep = metadata["accutime"]
-        n_timesteps = 3
         shape = precip.shape[1:]
 
         exporter = initialize_forecast_exporter_netcdf(
@@ -100,7 +102,11 @@ def test_io_export_netcdf_one_member_one_time_step(
         if incremental == None:
             export_forecast_dataset(precip, exporter)
         if incremental == "timestep":
-            for t in range(n_timesteps):
+            if isinstance(n_timesteps, list):
+                timesteps = len(n_timesteps)
+            else:
+                timesteps = n_timesteps
+            for t in range(timesteps):
                 if n_ens_members > 1:
                     export_forecast_dataset(precip[:, t, :, :], exporter)
                 else:


### PR DESCRIPTION
This PR ensures that the netcdf exporters can handle a list of timesteps next to just an integers number of timesteps. One of pysteps' functionalities is that you can give it specific output timesteps for which the nowcasts should be stored, but it was not yet possible to store these output timesteps as such in a netCDF. This PR tries to fix that.