### PR TITLE
Add option to smooth radar mask

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 24.3.0
+    rev: 24.4.2
     hooks:
     - id: black
       language_version: python3

--- a/pysteps/blending/steps.py
+++ b/pysteps/blending/steps.py
@@ -211,11 +211,13 @@ def forecast(
       'obs' = apply precip_thr to the most recently observed precipitation intensity
       field, 'incremental' = iteratively buffer the mask with a certain rate
       (currently it is 1 km/min), None=no masking.
-    smooth_radar_mask_range: int, Default  is 0.
-      If 0 this generates a normal forecast. To create a smooth mask, this range
+    smooth_radar_mask_range: int, Default is 0.
+      Method to smooth the transition between the radar-NWP-noise blend and the NWP-noise
+      blend near the edge of the radar domain (radar mask), where the radar data is either
+      not present anymore or is not reliable. If set to 0 (grid cells), this generates a normal forecast without smoothing. To create a smooth mask, this range
       should be a positive value, representing a buffer band of a number of pixels
       by which the mask is cropped and smoothed. The smooth radar mask removes
-      the hard edges between NWP and radar in the final blended product.
+      the hard edges between NWP and radar in the final blended product. Typically, a value between 50 and 100 km can be used. 80 km generally gives good results.
     probmatching_method: {'cdf','mean',None}, optional
       Method for matching the statistics of the forecast field with those of
       the most recently observed one. 'cdf'=map the forecast CDF to the observed
@@ -1464,9 +1466,6 @@ def forecast(
                             new_mask = blending.utils.compute_smooth_dilated_mask(
                                 nan_indices,
                                 max_padding_size_in_px=smooth_radar_mask_range,
-                                gaussian_kernel_size=9,
-                                inverted=False,
-                                non_linear_growth_kernel_sizes=False,
                             )
 
                             # Ensure mask values are between 0 and 1

--- a/pysteps/blending/steps.py
+++ b/pysteps/blending/steps.py
@@ -90,6 +90,7 @@ def forecast(
     conditional=False,
     probmatching_method="cdf",
     mask_method="incremental",
+    create_smooth_radar_mask=False,
     callback=None,
     return_output=True,
     seed=None,
@@ -210,6 +211,9 @@ def forecast(
       'obs' = apply precip_thr to the most recently observed precipitation intensity
       field, 'incremental' = iteratively buffer the mask with a certain rate
       (currently it is 1 km/min), None=no masking.
+    create_smooth_radar_mask: bool
+      If set to True, this generates a smooth mask for the radar that removes
+      hard edges between NWP and radar in the final blended product.
     probmatching_method: {'cdf','mean',None}, optional
       Method for matching the statistics of the forecast field with those of
       the most recently observed one. 'cdf'=map the forecast CDF to the observed
@@ -1451,16 +1455,35 @@ def forecast(
                         # forecast outside the radar domain. Therefore, fill these
                         # areas with the "..._mod_only" blended forecasts, consisting
                         # of the NWP and noise components.
-                        nan_indices = np.isnan(R_f_new)
-                        R_f_new[nan_indices] = R_f_new_mod_only[nan_indices]
-                        nan_indices = np.isnan(R_pm_blended)
-                        R_pm_blended[nan_indices] = R_pm_blended_mod_only[nan_indices]
-                        # Finally, fill the remaining nan values, if present, with
-                        # the minimum value in the forecast
-                        nan_indices = np.isnan(R_f_new)
-                        R_f_new[nan_indices] = np.nanmin(R_f_new)
-                        nan_indices = np.isnan(R_pm_blended)
-                        R_pm_blended[nan_indices] = np.nanmin(R_pm_blended)
+                        if create_smooth_radar_mask is True:
+                            # Compute the smooth dilated mask
+                            nan_indices = np.isnan(R_f_new)
+                            new_mask = blending.utils.compute_smooth_dilated_mask(nan_indices, 100, gaussian_kernel_size=9, inverted=False, non_linear_growth_kernel_sizes=False)
+
+                            # Ensure mask values are between 0 and 1
+                            mask_model = new_mask
+                            mask_radar = 1 - new_mask
+
+                            # Handle NaNs in R_f_new and R_f_new_mod_only by setting NaNs to 0 in the blending step
+                            R_f_new_mod_only_no_nan = np.nan_to_num(R_f_new_mod_only, nan=0)
+                            R_f_new_no_nan = np.nan_to_num(R_f_new, nan=0)
+
+                            # Perform the blending of radar and model inside the radar domain using a weighted combination
+                            R_f_new = np.nansum([mask_model * R_f_new_mod_only_no_nan,  mask_radar * R_f_new_no_nan], axis=0)
+                            # Finally, fill the remaining nan values, if present, with
+                            # the minimum value in the forecast
+                            R_f_new[np.isnan(R_f_new)] = np.nanmin(R_f_new)
+                        else:
+                            nan_indices = np.isnan(R_f_new)
+                            R_f_new[nan_indices] = R_f_new_mod_only[nan_indices]
+                            nan_indices = np.isnan(R_pm_blended)
+                            R_pm_blended[nan_indices] = R_pm_blended_mod_only[nan_indices]
+                            # Finally, fill the remaining nan values, if present, with
+                            # the minimum value in the forecast
+                            nan_indices = np.isnan(R_f_new)
+                            R_f_new[nan_indices] = np.nanmin(R_f_new)
+                            nan_indices = np.isnan(R_pm_blended)
+                            R_pm_blended[nan_indices] = np.nanmin(R_pm_blended)
 
                         # 8.7.2. Apply the masking and prob. matching
                         if mask_method is not None:

--- a/pysteps/blending/steps.py
+++ b/pysteps/blending/steps.py
@@ -213,7 +213,8 @@ def forecast(
       (currently it is 1 km/min), None=no masking.
     smooth_radar_mask_range: int, Default  is 0.
       If 0 this generates a normal forecast. To create a smooth mask, this range
-      should be a positive value. The smooth radar mask for the radar removes
+      should be a positive value, representing a buffer band of a number of pixels
+      by which the mask is cropped and smoothed. The smooth radar mask removes
       the hard edges between NWP and radar in the final blended product.
     probmatching_method: {'cdf','mean',None}, optional
       Method for matching the statistics of the forecast field with those of
@@ -1469,8 +1470,8 @@ def forecast(
                             )
 
                             # Ensure mask values are between 0 and 1
-                            mask_model = new_mask
-                            mask_radar = 1 - new_mask
+                            mask_model = np.clip(new_mask, 0, 1)
+                            mask_radar = np.clip(1 - new_mask, 0, 1)
 
                             # Handle NaNs in R_f_new and R_f_new_mod_only by setting NaNs to 0 in the blending step
                             R_f_new_mod_only_no_nan = np.nan_to_num(

--- a/pysteps/blending/steps.py
+++ b/pysteps/blending/steps.py
@@ -1458,18 +1458,32 @@ def forecast(
                         if create_smooth_radar_mask is True:
                             # Compute the smooth dilated mask
                             nan_indices = np.isnan(R_f_new)
-                            new_mask = blending.utils.compute_smooth_dilated_mask(nan_indices, 100, gaussian_kernel_size=9, inverted=False, non_linear_growth_kernel_sizes=False)
+                            new_mask = blending.utils.compute_smooth_dilated_mask(
+                                nan_indices,
+                                100,
+                                gaussian_kernel_size=9,
+                                inverted=False,
+                                non_linear_growth_kernel_sizes=False,
+                            )
 
                             # Ensure mask values are between 0 and 1
                             mask_model = new_mask
                             mask_radar = 1 - new_mask
 
                             # Handle NaNs in R_f_new and R_f_new_mod_only by setting NaNs to 0 in the blending step
-                            R_f_new_mod_only_no_nan = np.nan_to_num(R_f_new_mod_only, nan=0)
+                            R_f_new_mod_only_no_nan = np.nan_to_num(
+                                R_f_new_mod_only, nan=0
+                            )
                             R_f_new_no_nan = np.nan_to_num(R_f_new, nan=0)
 
                             # Perform the blending of radar and model inside the radar domain using a weighted combination
-                            R_f_new = np.nansum([mask_model * R_f_new_mod_only_no_nan,  mask_radar * R_f_new_no_nan], axis=0)
+                            R_f_new = np.nansum(
+                                [
+                                    mask_model * R_f_new_mod_only_no_nan,
+                                    mask_radar * R_f_new_no_nan,
+                                ],
+                                axis=0,
+                            )
                             # Finally, fill the remaining nan values, if present, with
                             # the minimum value in the forecast
                             R_f_new[np.isnan(R_f_new)] = np.nanmin(R_f_new)
@@ -1477,7 +1491,9 @@ def forecast(
                             nan_indices = np.isnan(R_f_new)
                             R_f_new[nan_indices] = R_f_new_mod_only[nan_indices]
                             nan_indices = np.isnan(R_pm_blended)
-                            R_pm_blended[nan_indices] = R_pm_blended_mod_only[nan_indices]
+                            R_pm_blended[nan_indices] = R_pm_blended_mod_only[
+                                nan_indices
+                            ]
                             # Finally, fill the remaining nan values, if present, with
                             # the minimum value in the forecast
                             nan_indices = np.isnan(R_f_new)

--- a/pysteps/blending/utils.py
+++ b/pysteps/blending/utils.py
@@ -584,17 +584,15 @@ def compute_smooth_dilated_mask(
     max_padding_size_in_px : int
         The maximum size of the padding in pixels. Default is 100.
     gaussian_kernel_size : int, optional
-        Size of the Gaussian kernel to use for blurring. Default is 9.
+        Size of the Gaussian kernel to use for blurring. This ensures that the nan-fields are large enough to start the smoothing. Without it, the method will also be applied to local nan-values in the radar domain. Default is 9, which is generally a recommended number to work with.
     inverted : bool, optional
-        If True, invert the original mask before processing. Default is False.
+        Typically, the smoothed mask works from the outside of the radar domain inward, using the max_padding_size_in_px. If set to True, it works from the edge of the radar domain outward (generally not recommended). Default is False.
     non_linear_growth_kernel_sizes : bool, optional
         If True, use non-linear growth for kernel sizes. Default is False.
 
     Returns
     -------
-    initial_mask : array_like
-        The initial binary mask after Gaussian blur and thresholding.
-    new_mask : array_like
+    final_mask : array_like
         The smooth dilated mask normalized to the range [0,1].
     """
     if not CV2_IMPORTED:

--- a/pysteps/blending/utils.py
+++ b/pysteps/blending/utils.py
@@ -569,7 +569,7 @@ def check_norain(precip_arr, precip_thr=None, norain_thr=0.0):
 
 def compute_smooth_dilated_mask(
     original_mask,
-    max_padding_size_in_px,
+    max_padding_size_in_px=0,
     gaussian_kernel_size=9,
     inverted=False,
     non_linear_growth_kernel_sizes=False,
@@ -582,7 +582,7 @@ def compute_smooth_dilated_mask(
     original_mask : array_like
         Two-dimensional boolean array containing the input mask.
     max_padding_size_in_px : int
-        The maximum size of the padding in pixels.
+        The maximum size of the padding in pixels. Default is 100.
     gaussian_kernel_size : int, optional
         Size of the Gaussian kernel to use for blurring. Default is 9.
     inverted : bool, optional
@@ -602,6 +602,9 @@ def compute_smooth_dilated_mask(
             "CV2 package is required to transform the mask into a smoot mask."
             " Please install it using `pip install opencv-python`."
         )
+
+    if max_padding_size_in_px < 0:
+        raise ValueError("max_padding_size_in_px must be greater than or equal to 0.")
 
     # Convert the original mask to uint8 numpy array and invert if needed
     array_2d = np.array(original_mask, dtype=np.uint8)

--- a/pysteps/blending/utils.py
+++ b/pysteps/blending/utils.py
@@ -38,9 +38,11 @@ except ImportError:
 
 try:
     import cv2
+
     CV2_IMPORTED = True
 except ImportError:
     CV2_IMPORTED = False
+
 
 def stack_cascades(R_d, donorm=True):
     """Stack the given cascades into a larger array.
@@ -564,8 +566,14 @@ def check_norain(precip_arr, precip_thr=None, norain_thr=0.0):
     )
     return norain
 
-def compute_smooth_dilated_mask(original_mask, max_padding_size_in_px, gaussian_kernel_size=9,
-                                inverted=False, non_linear_growth_kernel_sizes=False):
+
+def compute_smooth_dilated_mask(
+    original_mask,
+    max_padding_size_in_px,
+    gaussian_kernel_size=9,
+    inverted=False,
+    non_linear_growth_kernel_sizes=False,
+):
     """
     Compute a smooth dilated mask using Gaussian blur and dilation with varying kernel sizes.
 

--- a/pysteps/blending/utils.py
+++ b/pysteps/blending/utils.py
@@ -584,9 +584,14 @@ def compute_smooth_dilated_mask(
     max_padding_size_in_px : int
         The maximum size of the padding in pixels. Default is 100.
     gaussian_kernel_size : int, optional
-        Size of the Gaussian kernel to use for blurring. This ensures that the nan-fields are large enough to start the smoothing. Without it, the method will also be applied to local nan-values in the radar domain. Default is 9, which is generally a recommended number to work with.
+        Size of the Gaussian kernel to use for blurring, this should be an uneven number. This option ensures
+        that the nan-fields are large enough to start the smoothing. Without it, the method will also be applied
+        to local nan-values in the radar domain. Default is 9, which is generally a recommended number to work
+        with.
     inverted : bool, optional
-        Typically, the smoothed mask works from the outside of the radar domain inward, using the max_padding_size_in_px. If set to True, it works from the edge of the radar domain outward (generally not recommended). Default is False.
+        Typically, the smoothed mask works from the outside of the radar domain inward, using the
+        max_padding_size_in_px. If set to True, it works from the edge of the radar domain outward
+        (generally not recommended). Default is False.
     non_linear_growth_kernel_sizes : bool, optional
         If True, use non-linear growth for kernel sizes. Default is False.
 
@@ -603,6 +608,9 @@ def compute_smooth_dilated_mask(
 
     if max_padding_size_in_px < 0:
         raise ValueError("max_padding_size_in_px must be greater than or equal to 0.")
+
+    # Check if gaussian_kernel_size is an uneven number
+    assert gaussian_kernel_size % 2
 
     # Convert the original mask to uint8 numpy array and invert if needed
     array_2d = np.array(original_mask, dtype=np.uint8)

--- a/pysteps/nowcasts/utils.py
+++ b/pysteps/nowcasts/utils.py
@@ -24,10 +24,10 @@ from pysteps import extrapolation
 
 try:
     import dask
+
     DASK_IMPORTED = True
 except ImportError:
     DASK_IMPORTED = False
-
 
 
 def binned_timesteps(timesteps):
@@ -96,6 +96,7 @@ def compute_dilated_mask(input_mask, kr, r):
 
     # normalize between 0 and 1
     return mask / mask.max()
+
 
 def compute_percentile_mask(precip, pct):
     """Compute a precipitation mask, where True/False values are assigned for

--- a/pysteps/nowcasts/utils.py
+++ b/pysteps/nowcasts/utils.py
@@ -21,14 +21,14 @@ import numpy as np
 from scipy.ndimage import binary_dilation, generate_binary_structure
 
 from pysteps import extrapolation
-
+from pysteps.pysteps.exceptions import MissingOptionalDependency
 
 try:
     import dask
-
     DASK_IMPORTED = True
 except ImportError:
     DASK_IMPORTED = False
+
 
 
 def binned_timesteps(timesteps):
@@ -97,7 +97,6 @@ def compute_dilated_mask(input_mask, kr, r):
 
     # normalize between 0 and 1
     return mask / mask.max()
-
 
 def compute_percentile_mask(precip, pct):
     """Compute a precipitation mask, where True/False values are assigned for

--- a/pysteps/nowcasts/utils.py
+++ b/pysteps/nowcasts/utils.py
@@ -21,7 +21,6 @@ import numpy as np
 from scipy.ndimage import binary_dilation, generate_binary_structure
 
 from pysteps import extrapolation
-from pysteps.pysteps.exceptions import MissingOptionalDependency
 
 try:
     import dask

--- a/pysteps/tests/test_blending_steps.py
+++ b/pysteps/tests/test_blending_steps.py
@@ -72,6 +72,7 @@ def test_steps_blending(
     expected_n_ens_members,
     zero_radar,
     zero_nwp,
+    smooth_radar_mask_range,
 ):
     pytest.importorskip("cv2")
 

--- a/pysteps/tests/test_blending_steps.py
+++ b/pysteps/tests/test_blending_steps.py
@@ -264,6 +264,7 @@ def test_steps_blending(
         conditional=False,
         probmatching_method=probmatching_method,
         mask_method=mask_method,
+        smooth_radar_mask_range=smooth_radar_mask_range,
         callback=None,
         return_output=True,
         seed=None,

--- a/pysteps/tests/test_blending_steps.py
+++ b/pysteps/tests/test_blending_steps.py
@@ -8,31 +8,39 @@ from pysteps import cascade, blending
 
 
 steps_arg_values = [
-    (1, 3, 4, 8, None, None, False, "spn", True, 4, False, False),
-    (1, 3, 4, 8, "obs", None, False, "spn", True, 4, False, False),
-    (1, 3, 4, 8, "incremental", None, False, "spn", True, 4, False, False),
-    (1, 3, 4, 8, None, "mean", False, "spn", True, 4, False, False),
-    (1, 3, 4, 8, None, "cdf", False, "spn", True, 4, False, False),
-    (1, 3, 4, 8, "incremental", "cdf", False, "spn", True, 4, False, False),
-    (1, 3, 4, 6, "incremental", "cdf", False, "bps", True, 4, False, False),
-    (1, 3, 4, 6, "incremental", "cdf", False, "bps", False, 4, False, False),
-    (1, 3, 4, 9, "incremental", "cdf", False, "spn", True, 4, False, False),
-    (2, 3, 10, 8, "incremental", "cdf", False, "spn", True, 10, False, False),
-    (5, 3, 5, 8, "incremental", "cdf", False, "spn", True, 5, False, False),
-    (1, 10, 1, 8, "incremental", "cdf", False, "spn", True, 1, False, False),
-    (2, 3, 2, 8, "incremental", "cdf", True, "spn", True, 2, False, False),
-    (1, 3, 6, 8, None, None, False, "spn", True, 6, False, False),
+    (1, 3, 4, 8, None, None, False, "spn", True, 4, False, False, 0),
+    (1, 3, 4, 8, "obs", None, False, "spn", True, 4, False, False, 0),
+    (1, 3, 4, 8, "incremental", None, False, "spn", True, 4, False, False, 0),
+    (1, 3, 4, 8, None, "mean", False, "spn", True, 4, False, False, 0),
+    (1, 3, 4, 8, None, "cdf", False, "spn", True, 4, False, False, 0),
+    (1, 3, 4, 8, "incremental", "cdf", False, "spn", True, 4, False, False, 0),
+    (1, 3, 4, 6, "incremental", "cdf", False, "bps", True, 4, False, False, 0),
+    (1, 3, 4, 6, "incremental", "cdf", False, "bps", False, 4, False, False, 0),
+    (1, 3, 4, 9, "incremental", "cdf", False, "spn", True, 4, False, False, 0),
+    (2, 3, 10, 8, "incremental", "cdf", False, "spn", True, 10, False, False, 0),
+    (5, 3, 5, 8, "incremental", "cdf", False, "spn", True, 5, False, False, 0),
+    (1, 10, 1, 8, "incremental", "cdf", False, "spn", True, 1, False, False, 0),
+    (2, 3, 2, 8, "incremental", "cdf", True, "spn", True, 2, False, False, 0),
+    (1, 3, 6, 8, None, None, False, "spn", True, 6, False, False, 0),
     #    Test the case where the radar image contains no rain.
-    (1, 3, 6, 8, None, None, False, "spn", True, 6, True, False),
-    (5, 3, 5, 6, "incremental", "cdf", False, "spn", False, 5, True, False),
+    (1, 3, 6, 8, None, None, False, "spn", True, 6, True, False, 0),
+    (5, 3, 5, 6, "incremental", "cdf", False, "spn", False, 5, True, False, 0),
     #   Test the case where the NWP fields contain no rain.
-    (1, 3, 6, 8, None, None, False, "spn", True, 6, False, True),
-    (5, 3, 5, 6, "incremental", "cdf", False, "spn", False, 5, False, True),
+    (1, 3, 6, 8, None, None, False, "spn", True, 6, False, True, 0),
+    (5, 3, 5, 6, "incremental", "cdf", False, "spn", False, 5, False, True, 0),
     # Test the case where both the radar image and the NWP fields contain no rain.
-    (1, 3, 6, 8, None, None, False, "spn", True, 6, True, True),
-    (5, 3, 5, 6, "incremental", "cdf", False, "spn", False, 5, True, True),
-    (5, 3, 5, 6, "obs", "mean", True, "spn", True, 5, True, True),
+    (1, 3, 6, 8, None, None, False, "spn", True, 6, True, True, 0),
+    (5, 3, 5, 6, "incremental", "cdf", False, "spn", False, 5, True, True, 0),
+    (5, 3, 5, 6, "obs", "mean", True, "spn", True, 5, True, True, 0),
+    # Test for smooth radar mask
+    (1, 3, 6, 8, None, None, False, "spn", True, 6, False, False, 80),
+    (5, 3, 5, 6, "incremental", "cdf", False, "spn", False, 5, False, False, 80),
+    (5, 3, 5, 6, "obs", "mean", False, "spn", False, 5, False, False, 80),
+    (1, 3, 6, 8, None, None, False, "spn", True, 6, False, True, 80),
+    (5, 3, 5, 6, "incremental", "cdf", False, "spn", False, 5, True, False, 80),
+    (5, 3, 5, 6, "obs", "mean", False, "spn", False, 5, True, True, 80),
 ]
+
 steps_arg_names = (
     "n_models",
     "n_timesteps",
@@ -46,6 +54,7 @@ steps_arg_names = (
     "expected_n_ens_members",
     "zero_radar",
     "zero_nwp",
+    "smooth_radar_mask_range",
 )
 
 


### PR DESCRIPTION
Solution for #377 

Addition done by adding a cv2 based method in blending.utils.py called compute_smooth_dilated_mask(...).

This function can be used in the blending.steps.forecast by changing the create_smooth_radar_mask parameter to True, standard this is put to False to not create conflicts with existing code.