### PR TITLE
fix: change extrapolation values for resampling outside radar domain to zero

### DIFF
--- a/pysteps/blending/steps.py
+++ b/pysteps/blending/steps.py
@@ -1545,7 +1545,7 @@ def forecast(
                             arr1 = R_pm_ep[t_index]
                             arr2 = precip_models_pm_temp[j]
                             arr2 = np.where(np.isnan(arr2), np.nanmin(arr2), arr2)
-                            arr1 = np.where(np.isnan(arr1), arr2, arr1)
+                            arr1 = np.where(np.isnan(arr1), np.nanmin(arr1), arr1)
                             # resample weights based on cascade level 2
                             R_pm_resampled = probmatching.resample_distributions(
                                 first_array=arr1,


### PR DESCRIPTION
Fix for issue #416.

The small fix introduced here, which sets all extrapolation component values to zero outside the radar domain (instead of to the NWP value as in the code now), gives the following results for the case indicated in #390:

Radar observations (up to 60 minutes ahead):
![radar_observations](https://github.com/user-attachments/assets/16363d3e-d197-4889-92b0-f5cfa0a899c4)

Blended forecast for ensemble member 0, without the smoothing mask as introduced in #379:
![forecast_withoutsmoothing](https://github.com/user-attachments/assets/08b1aa6f-5649-4896-b091-cdd4c1ad45c7)

Blended forecast for ensemble member 0, with the smoothing mask:
![forecast_with_smoothing](https://github.com/user-attachments/assets/070237a5-2db8-4ff6-bf9d-a437015be0fc)

See also #390 for the previous results. The first lead time is still not perfect, but we got a lot closer already. What do you think?
