### PR TITLE
Optimisation in excprob function

### DIFF
--- a/pysteps/postprocessing/ensemblestats.py
+++ b/pysteps/postprocessing/ensemblestats.py
@@ -99,10 +99,9 @@ def excprob(X, X_thr, ignore_nan=False):
         scalar_thr = False
 
     for x in X_thr:
-        X_ = X.copy()
+        X_ = np.zeros(X.shape)
 
         X_[X >= x] = 1.0
-        X_[X < x] = 0.0
         X_[~np.isfinite(X)] = np.nan
 
         if ignore_nan:


### PR DESCRIPTION
Currently `pysteps.postprocesing.ensemblestats.excprob` copies the input array only to replace all values afterwards by either a `0`or a `1`. It is much more efficient to just initialize an array of the same shape using `np.zeros()`. By doing this, the code can also be simplified by removing the part of the code setting values to `0`.

Below, is example code showing the difference in performance between the two methods. This is for a `700x700` grid with 12 timesteps and 24 ensemble members. This shows a significant difference. The specific part of the code is sped up by four orders of magnitude, going from taking `153 ms` to `20.5 µs`.

```
import numpy as np
s = (24, 12, 700, 700)
test_arr = np.random.randint(1., 5., size=s)

%timeit test_arr.copy()
>>> 153 ms ± 4.87 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

%timeit np.zeros(s)
>>> 20.5 µs ± 656 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```