### PR TITLE
Print missing filename

### DIFF
--- a/pysteps/io/archive.py
+++ b/pysteps/io/archive.py
@@ -110,15 +110,15 @@ def _find_matching_filename(
         fn = os.path.join(path, fn)
 
         if os.path.exists(fn):
-            fn = fn
+            return fn
         else:
             if not silent:
-                print("file not found: %s" % fn)
+                print(f"file not found: {fn}")
             return None
-    elif not silent:
-        print("path", path, "not found.")
-
-    return None
+    else:
+        if not silent:
+            print(f"path not found: {path}")
+        return None
 
 
 def _generate_path(date, root_path, path_format):

--- a/pysteps/io/archive.py
+++ b/pysteps/io/archive.py
@@ -94,7 +94,6 @@ def _find_matching_filename(
     date, root_path, path_fmt, fn_pattern, fn_ext, silent=False
 ):
     path = _generate_path(date, root_path, path_fmt)
-    fn = None
 
     if os.path.exists(path):
         fn = datetime.strftime(date, fn_pattern) + "." + fn_ext
@@ -113,13 +112,13 @@ def _find_matching_filename(
         if os.path.exists(fn):
             fn = fn
         else:
-            fn = None
             if not silent:
                 print("file not found: %s" % fn)
+            return None
     elif not silent:
         print("path", path, "not found.")
 
-    return fn
+    return None
 
 
 def _generate_path(date, root_path, path_format):


### PR DESCRIPTION
when looking into #426, I noticed that the the `pysteps.io.archive.find_by_date` function wrongly logs `None` instead of the wrong filename. This PR fixes it.