### PR TITLE
Modify probability matching code to allow ignoring a part of the domain

### DIFF
--- a/pysteps/blending/steps.py
+++ b/pysteps/blending/steps.py
@@ -1540,11 +1540,10 @@ def forecast(
                         # both the extrapolation cascade and the model (NWP) cascade and use
                         # that for the probability matching
                         if probmatching_method is not None and resample_distribution:
-                            # deal with missing values
                             arr1 = R_pm_ep[t_index]
                             arr2 = precip_models_pm_temp[j]
-                            arr2 = np.where(np.isnan(arr2), np.nanmin(arr2), arr2)
-                            arr1 = np.where(np.isnan(arr1), arr2, arr1)
+                            # arr2 = np.where(np.isnan(arr2), np.nanmin(arr2), arr2)
+                            # arr1 = np.where(np.isnan(arr1), arr2, arr1)
                             # resample weights based on cascade level 2
                             R_pm_resampled = probmatching.resample_distributions(
                                 first_array=arr1,
@@ -1555,11 +1554,14 @@ def forecast(
                             R_pm_resampled = R_pm_blended.copy()
 
                         if probmatching_method == "cdf":
+                            # nan indices in the extrapolation nowcast
+                            nan_indices = np.isnan(R_pm_ep[t_index])
                             # Adjust the CDF of the forecast to match the most recent
-                            # benchmark rainfall field (R_pm_blended). If the forecast
+                            # benchmark rainfall field (R_pm_blended).
+                            # Rainfall outside the pure extrapolation domain is not taken into account.
                             if np.any(np.isfinite(R_f_new)):
                                 R_f_new = probmatching.nonparam_match_empirical_cdf(
-                                    R_f_new, R_pm_resampled
+                                    R_f_new, R_pm_resampled, nan_indices
                                 )
                                 R_pm_resampled = None
                         elif probmatching_method == "mean":

--- a/pysteps/blending/steps.py
+++ b/pysteps/blending/steps.py
@@ -1538,13 +1538,12 @@ def forecast(
 
                         # If probmatching_method is not None, resample the distribution from
                         # both the extrapolation cascade and the model (NWP) cascade and use
-                        # that for the probability matching
+                        # that for the probability matching.
                         if probmatching_method is not None and resample_distribution:
                             arr1 = R_pm_ep[t_index]
                             arr2 = precip_models_pm_temp[j]
-                            # arr2 = np.where(np.isnan(arr2), np.nanmin(arr2), arr2)
-                            # arr1 = np.where(np.isnan(arr1), arr2, arr1)
-                            # resample weights based on cascade level 2
+                            # resample weights based on cascade level 2.
+                            # Areas where one of the fields is nan are not included.
                             R_pm_resampled = probmatching.resample_distributions(
                                 first_array=arr1,
                                 second_array=arr2,
@@ -1556,8 +1555,8 @@ def forecast(
                         if probmatching_method == "cdf":
                             # nan indices in the extrapolation nowcast
                             nan_indices = np.isnan(R_pm_ep[t_index])
-                            # Adjust the CDF of the forecast to match the most recent
-                            # benchmark rainfall field (R_pm_blended).
+                            # Adjust the CDF of the forecast to match the resampled distribution combined from
+                            # extrapolation and model fields.
                             # Rainfall outside the pure extrapolation domain is not taken into account.
                             if np.any(np.isfinite(R_f_new)):
                                 R_f_new = probmatching.nonparam_match_empirical_cdf(

--- a/pysteps/postprocessing/probmatching.py
+++ b/pysteps/postprocessing/probmatching.py
@@ -111,10 +111,9 @@ def nonparam_match_empirical_cdf(initial_array, target_array, ignore_indices=Non
         p = np.percentile(target_array, 100 * (1 - war))
         target_array[target_array < p] = zvalue_trg
 
-    # flatten the arrays
-    arrayshape = initial_array_copy.shape
-    target_array = target_array.flatten()
-    initial_array_copy = initial_array_copy.flatten()
+    # flatten the arrays without copying them
+    target_array.reshape(-1)
+    initial_array_copy.reshape(-1)
 
     # rank target values
     order = target_array.argsort()

--- a/pysteps/postprocessing/probmatching.py
+++ b/pysteps/postprocessing/probmatching.py
@@ -113,8 +113,8 @@ def nonparam_match_empirical_cdf(initial_array, target_array, ignore_indices=Non
 
     # flatten the arrays without copying them
     arrayshape = initial_array_copy.shape
-    target_array.reshape(-1)
-    initial_array_copy.reshape(-1)
+    target_array = target_array.reshape(-1)
+    initial_array_copy = initial_array_copy.reshape(-1)
 
     # rank target values
     order = target_array.argsort()

--- a/pysteps/postprocessing/probmatching.py
+++ b/pysteps/postprocessing/probmatching.py
@@ -112,6 +112,7 @@ def nonparam_match_empirical_cdf(initial_array, target_array, ignore_indices=Non
         target_array[target_array < p] = zvalue_trg
 
     # flatten the arrays without copying them
+    arrayshape = initial_array_copy.shape
     target_array.reshape(-1)
     initial_array_copy.reshape(-1)
 

--- a/pysteps/postprocessing/probmatching.py
+++ b/pysteps/postprocessing/probmatching.py
@@ -66,7 +66,10 @@ def nonparam_match_empirical_cdf(initial_array, target_array, ignore_indices=Non
     target_array: array_like
         The target array
     ignore_indices: array_like, optional
-        Indices of pixels in the initial_array which are to be ignored (not rescaled)
+        Indices of pixels in the initial_array which are to be ignored (not
+        rescaled) or an array of booleans with True at the pixel locations to
+        be ignored in initial_array and False elsewhere.
+
 
     Returns
     -------

--- a/pysteps/tests/test_postprocessing_probmatching.py
+++ b/pysteps/tests/test_postprocessing_probmatching.py
@@ -191,3 +191,10 @@ class TestNonparamMatchEmpiricalCDF:
         )
         expected_result = np.array([0, 0, 10, 8, 0, 0, 0, 0, 0, 0])
         assert np.allclose(result, expected_result, equal_nan=True)
+
+    def test_2dim_array(self):
+        initial_array = np.array([[1, 3, 5], [11, 9, 7]])
+        target_array = np.array([[2, 4, 6], [8, 10, 12]])
+        result = nonparam_match_empirical_cdf(initial_array, target_array)
+        expected_result = np.array([[2, 4, 6], [12, 10, 8]])
+        assert np.allclose(result, expected_result, equal_nan=True)

--- a/pysteps/tests/test_postprocessing_probmatching.py
+++ b/pysteps/tests/test_postprocessing_probmatching.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 from pysteps.postprocessing.probmatching import resample_distributions
+from pysteps.postprocessing.probmatching import nonparam_match_empirical_cdf
 
 
 class TestResampleDistributions:
@@ -97,4 +98,96 @@ class TestResampleDistributions:
             array1_with_nan, array2_with_nan, probability_first_array
         )
         expected_result = np.array([np.nan, np.nan, np.nan, 10, 2], dtype=float)
+        assert np.allclose(result, expected_result, equal_nan=True)
+
+
+class TestNonparamMatchEmpiricalCDF:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        # Set the seed for reproducibility
+        np.random.seed(42)
+
+    def test_ignore_indices_with_nans_both(self):
+        initial_array = np.array([np.nan, np.nan, 6, 2, 0, 0, 0, 0, 0, 0])
+        target_array = np.array([np.nan, np.nan, 9, 5, 4, 0, 0, 0, 0, 0])
+        result = nonparam_match_empirical_cdf(
+            initial_array, target_array, ignore_indices=np.isnan(initial_array)
+        )
+        expected_result = np.array([np.nan, np.nan, 9, 5, 0, 0, 0, 0, 0, 0])
+        assert np.allclose(result, expected_result, equal_nan=True)
+
+    def test_zeroes_initial(self):
+        initial_array = np.zeros(10)
+        target_array = np.array([0, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        result = nonparam_match_empirical_cdf(initial_array, target_array)
+        expected_result = np.zeros(10)
+        assert np.allclose(result, expected_result)
+
+    def test_nans_initial(self):
+        initial_array = np.array(
+            [0, 1, 2, 3, 4, np.nan, np.nan, np.nan, np.nan, np.nan]
+        )
+        target_array = np.array([0, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        with pytest.raises(
+            ValueError,
+            match="Initial array contains non-finite values outside ignore_indices mask.",
+        ):
+            nonparam_match_empirical_cdf(initial_array, target_array)
+
+    def test_all_nans_initial(self):
+        initial_array = np.full(10, np.nan)
+        target_array = np.array([0, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        with pytest.raises(ValueError, match="Initial array contains only nans."):
+            nonparam_match_empirical_cdf(initial_array, target_array)
+
+    def test_ignore_indices_nans_initial(self):
+        initial_array = np.array(
+            [0, 1, 2, 3, 4, np.nan, np.nan, np.nan, np.nan, np.nan]
+        )
+        target_array = np.array([0, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        result = nonparam_match_empirical_cdf(
+            initial_array, target_array, ignore_indices=np.isnan(initial_array)
+        )
+        expected_result = np.array(
+            [0, 7, 8, 9, 10, np.nan, np.nan, np.nan, np.nan, np.nan]
+        )
+        assert np.allclose(result, expected_result, equal_nan=True)
+
+    def test_ignore_indices_nans_target(self):
+        # We expect the initial_array values for which ignore_indices is true to be conserved as-is.
+        initial_array = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        target_array = np.array(
+            [0, 2, 3, 4, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan]
+        )
+        result = nonparam_match_empirical_cdf(
+            initial_array, target_array, ignore_indices=np.isnan(target_array)
+        )
+        expected_result = np.array([0, 2, 3, 4, 4, 5, 6, 7, 8, 9])
+        assert np.allclose(result, expected_result, equal_nan=True)
+
+    def test_more_zeroes_in_initial(self):
+        initial_array = np.array([1, 4, 0, 0, 0, 0, 0, 0, 0, 0])
+        target_array = np.array([10, 8, 6, 4, 2, 0, 0, 0, 0, 0])
+        result = nonparam_match_empirical_cdf(
+            initial_array, target_array, ignore_indices=np.isnan(initial_array)
+        )
+        expected_result = np.array([8, 10, 0, 0, 0, 0, 0, 0, 0, 0])
+        assert np.allclose(result, expected_result, equal_nan=True)
+
+    def test_more_zeroes_in_initial_unsrt(self):
+        initial_array = np.array([1, 4, 0, 0, 0, 0, 0, 0, 0, 0])
+        target_array = np.array([6, 4, 2, 0, 0, 0, 0, 0, 10, 8])
+        result = nonparam_match_empirical_cdf(
+            initial_array, target_array, ignore_indices=np.isnan(initial_array)
+        )
+        expected_result = np.array([8, 10, 0, 0, 0, 0, 0, 0, 0, 0])
+        assert np.allclose(result, expected_result, equal_nan=True)
+
+    def test_more_zeroes_in_target(self):
+        initial_array = np.array([1, 3, 7, 5, 0, 0, 0, 0, 0, 0])
+        target_array = np.array([10, 8, 0, 0, 0, 0, 0, 0, 0, 0])
+        result = nonparam_match_empirical_cdf(
+            initial_array, target_array, ignore_indices=np.isnan(initial_array)
+        )
+        expected_result = np.array([0, 0, 10, 8, 0, 0, 0, 0, 0, 0])
         assert np.allclose(result, expected_result, equal_nan=True)

--- a/pysteps/tests/test_postprocessing_probmatching.py
+++ b/pysteps/tests/test_postprocessing_probmatching.py
@@ -39,19 +39,62 @@ class TestResampleDistributions:
         )
         assert np.array_equal(result, np.sort(first_array)[::-1])
 
-    def test_nan_in_inputs(self):
+    def test_nan_in_arr1_prob_1(self):
+        array_with_nan = np.array([1, 3, np.nan, 7, 9])
+        array_without_nan = np.array([2.0, 4, 6, 8, 10])
+        probability_first_array = 1.0
+        result = resample_distributions(
+            array_with_nan, array_without_nan, probability_first_array
+        )
+        expected_result = np.array([np.nan, 9, 7, 3, 1], dtype=float)
+        assert np.allclose(result, expected_result, equal_nan=True)
+
+    def test_nan_in_arr1_prob_0(self):
         array_with_nan = np.array([1, 3, np.nan, 7, 9])
         array_without_nan = np.array([2, 4, 6, 8, 10])
-        probability_first_array = 0.6
-        with pytest.raises(ValueError, match="Input arrays must not contain NaNs"):
-            resample_distributions(
-                array_with_nan, array_without_nan, probability_first_array
-            )
-        with pytest.raises(ValueError, match="Input arrays must not contain NaNs"):
-            resample_distributions(
-                array_without_nan, array_with_nan, probability_first_array
-            )
-        with pytest.raises(ValueError, match="Input arrays must not contain NaNs"):
-            resample_distributions(
-                array_with_nan, array_with_nan, probability_first_array
-            )
+        probability_first_array = 0.0
+        result = resample_distributions(
+            array_with_nan, array_without_nan, probability_first_array
+        )
+        expected_result = np.array([np.nan, 10, 8, 4, 2], dtype=float)
+        assert np.allclose(result, expected_result, equal_nan=True)
+
+    def test_nan_in_arr2_prob_1(self):
+        array_without_nan = np.array([1, 3, 5, 7, 9])
+        array_with_nan = np.array([2.0, 4, 6, np.nan, 10])
+        probability_first_array = 1.0
+        result = resample_distributions(
+            array_without_nan, array_with_nan, probability_first_array
+        )
+        expected_result = np.array([np.nan, 9, 5, 3, 1], dtype=float)
+        assert np.allclose(result, expected_result, equal_nan=True)
+
+    def test_nan_in_arr2_prob_0(self):
+        array_without_nan = np.array([1, 3, 5, 7, 9])
+        array_with_nan = np.array([2, 4, 6, np.nan, 10])
+        probability_first_array = 0.0
+        result = resample_distributions(
+            array_without_nan, array_with_nan, probability_first_array
+        )
+        expected_result = np.array([np.nan, 10, 6, 4, 2], dtype=float)
+        assert np.allclose(result, expected_result, equal_nan=True)
+
+    def test_nan_in_both_prob_1(self):
+        array1_with_nan = np.array([1, np.nan, np.nan, 7, 9])
+        array2_with_nan = np.array([2.0, 4, np.nan, np.nan, 10])
+        probability_first_array = 1.0
+        result = resample_distributions(
+            array1_with_nan, array2_with_nan, probability_first_array
+        )
+        expected_result = np.array([np.nan, np.nan, np.nan, 9, 1], dtype=float)
+        assert np.allclose(result, expected_result, equal_nan=True)
+
+    def test_nan_in_both_prob_0(self):
+        array1_with_nan = np.array([1, np.nan, np.nan, 7, 9])
+        array2_with_nan = np.array([2.0, 4, np.nan, np.nan, 10])
+        probability_first_array = 0.0
+        result = resample_distributions(
+            array1_with_nan, array2_with_nan, probability_first_array
+        )
+        expected_result = np.array([np.nan, np.nan, np.nan, 10, 2], dtype=float)
+        assert np.allclose(result, expected_result, equal_nan=True)


### PR DESCRIPTION
The resampling now allows the presence of nans. For pixel locations with a nan, both arrays are ignored.
The probability matching has an extra argument ignore_indices which are left untouched. 

This functionality is added so that the values outside the radar mask, where there is only NWP data, don't affect the distribution of rainfall inside the mask.
In the case of high intensity in NWP but not in the radar for example, you'd otherwise get a huge jump in intensity due to the extremes affecting the radar nowcast area. 

Result is in the top right and bottom left:
![control_ens_mean_obs](https://github.com/user-attachments/assets/3041dfaf-c797-4806-a41e-19ec6fecc011)
