### PR TITLE
Use the seed in all rng in blending code

### DIFF
--- a/pysteps/blending/steps.py
+++ b/pysteps/blending/steps.py
@@ -1096,20 +1096,16 @@ class StepsBlendingNowcaster:
     def __initialize_random_generators(self):
         # 6. Initialize all the random generators and prepare for the forecast loop
         """Initialize all the random generators."""
+        seed = self.__config.seed
         if self.__config.noise_method is not None:
             self.__state.randgen_precip = []
-            seed = self.__config.seed
             for j in range(self.__config.n_ens_members):
                 rs = np.random.RandomState(seed)
                 self.__state.randgen_precip.append(rs)
                 seed = rs.randint(0, high=1e9)
-                rs = np.random.RandomState(seed)
-                self.__state.randgen_motion.append(rs)
-                seed = rs.randint(0, high=1e9)
 
         if self.__config.probmatching_method is not None:
             self.__state.randgen_probmatching = []
-            seed = self.__config.seed
             for j in range(self.__config.n_ens_members):
                 rs = np.random.RandomState(seed)
                 self.__state.randgen_probmatching.append(rs)

--- a/pysteps/noise/utils.py
+++ b/pysteps/noise/utils.py
@@ -101,8 +101,9 @@ def compute_noise_stddev_adjs(
     randstates = []
 
     for k in range(num_iter):
-        randstates.append(np.random.RandomState(seed=seed))
-        seed = np.random.randint(0, high=1e9)
+        rs = np.random.RandomState(seed=seed)
+        randstates.append(rs)
+        seed = rs.randint(0, high=1e9)
 
     def worker(k):
         # generate Gaussian white noise field, filter it using the chosen

--- a/pysteps/postprocessing/probmatching.py
+++ b/pysteps/postprocessing/probmatching.py
@@ -274,7 +274,7 @@ def shift_scale(R, f, rain_fraction_trg, second_moment_trg, **kwargs):
     return shift, scale, R.reshape(shape)
 
 
-def resample_distributions(first_array, second_array, probability_first_array):
+def resample_distributions(first_array, second_array, probability_first_array, randgen):
     """
     Merges two distributions (e.g., from the extrapolation nowcast and NWP in the blending module)
     to effectively combine two distributions for probability matching without losing extremes.
@@ -324,7 +324,7 @@ def resample_distributions(first_array, second_array, probability_first_array):
     n = asort.shape[0]
 
     # Resample the distributions
-    idxsamples = np.random.binomial(1, probability_first_array, n).astype(bool)
+    idxsamples = randgen.binomial(1, probability_first_array, n).astype(bool)
     csort = np.where(idxsamples, asort, bsort)
     csort = np.sort(csort)[::-1]
 

--- a/pysteps/tests/test_blending_steps.py
+++ b/pysteps/tests/test_blending_steps.py
@@ -27,6 +27,7 @@ steps_arg_values = [
     (1, 10, 1, 8, "incremental", "cdf", False, "spn", True, 1, False, False, 0, False, None),
     (2, 3, 2, 8, "incremental", "cdf", True, "spn", True, 2, False, False, 0, False, None),
     (1, 3, 6, 8, None, None, False, "spn", True, 6, False, False, 0, False, None),
+    (1, 3, 6, 8, None, None, False, "spn", True, 6, False, False, 0, False, "bps"),
     #    Test the case where the radar image contains no rain.
     (1, 3, 6, 8, None, None, False, "spn", True, 6, True, False, 0, False, None),
     (5, 3, 5, 6, "incremental", "cdf", False, "spn", False, 5, True, False, 0, False, None),
@@ -47,7 +48,6 @@ steps_arg_values = [
     (5, 3, 5, 6, "obs", "mean", False, "spn", False, 5, True, True, 80, False, None),
     (5, [1, 2, 3], 5, 6, "obs", "mean", False, "spn", False, 5, True, True, 80, False, None),
     (5, [1, 3], 5, 6, "obs", "mean", False, "spn", False, 5, True, True, 80, False, None),
-    (5, [1, 3], 5, 6, "obs", "mean", False, "spn", False, 5, True, True, 80, False, "bps"),
 ]
 # fmt:on
 

--- a/pysteps/tests/test_blending_steps.py
+++ b/pysteps/tests/test_blending_steps.py
@@ -8,48 +8,48 @@ import pytest
 import pysteps
 from pysteps import blending, cascade
 
+# fmt:off
 steps_arg_values = [
-    # Test the case where both the radar image and the NWP fields contain no rain.
-    (1, 3, 4, 8, None, None, False, "spn", True, 4, False, False, 0, False),
-    (1, 3, 4, 8, "obs", None, False, "spn", True, 4, False, False, 0, False),
-    (1, 3, 4, 8, "incremental", None, False, "spn", True, 4, False, False, 0, False),
-    (1, 3, 4, 8, None, "mean", False, "spn", True, 4, False, False, 0, False),
-    (1, 3, 4, 8, None, "mean", False, "spn", True, 4, False, False, 0, True),
-    (1, 3, 4, 8, None, "cdf", False, "spn", True, 4, False, False, 0, False),
-    (1, [1, 2, 3], 4, 8, None, "cdf", False, "spn", True, 4, False, False, 0, False),
-    (1, 3, 4, 8, "incremental", "cdf", False, "spn", True, 4, False, False, 0, False),
-    (1, 3, 4, 6, "incremental", "cdf", False, "bps", True, 4, False, False, 0, False),
-    (1, 3, 4, 6, "incremental", "cdf", False, "bps", False, 4, False, False, 0, False),
-    (1, 3, 4, 6, "incremental", "cdf", False, "bps", False, 4, False, False, 0, True),
-    (1, 3, 4, 9, "incremental", "cdf", False, "spn", True, 4, False, False, 0, False),
-    (2, 3, 10, 8, "incremental", "cdf", False, "spn", True, 10, False, False, 0, False),
-    (5, 3, 5, 8, "incremental", "cdf", False, "spn", True, 5, False, False, 0, False),
-    (1, 10, 1, 8, "incremental", "cdf", False, "spn", True, 1, False, False, 0, False),
-    (2, 3, 2, 8, "incremental", "cdf", True, "spn", True, 2, False, False, 0, False),
-    # TODO: make next test work! This is currently not working on the main branch
-    # (2, 3, 4, 8, "incremental", "cdf", True, "spn", True, 2, False, False, 0, False),
-    # (2, 3, 4, 8, "incremental", "cdf", False, "spn", True, 2, False, False, 0, False),
-    (1, 3, 6, 8, None, None, False, "spn", True, 6, False, False, 0, False),
+    (1, 3, 4, 8, None, None, False, "spn", True, 4, False, False, 0, False, None),
+    (1, 3, 4, 8, "obs", None, False, "spn", True, 4, False, False, 0, False, None),
+    (1, 3, 4, 8, "incremental", None, False, "spn", True, 4, False, False, 0, False, None),
+    (1, 3, 4, 8, None, "mean", False, "spn", True, 4, False, False, 0, False, None),
+    (1, 3, 4, 8, None, "mean", False, "spn", True, 4, False, False, 0, True, None),
+    (1, 3, 4, 8, None, "cdf", False, "spn", True, 4, False, False, 0, False, None),
+    (1, [1, 2, 3], 4, 8, None, "cdf", False, "spn", True, 4, False, False, 0, False, None),
+    (1, 3, 4, 8, "incremental", "cdf", False, "spn", True, 4, False, False, 0, False, None),
+    (1, 3, 4, 6, "incremental", "cdf", False, "bps", True, 4, False, False, 0, False, None),
+    (1, 3, 4, 6, "incremental", "cdf", False, "bps", False, 4, False, False, 0, False, None),
+    (1, 3, 4, 6, "incremental", "cdf", False, "bps", False, 4, False, False, 0, True, None),
+    (1, 3, 4, 9, "incremental", "cdf", False, "spn", True, 4, False, False, 0, False, None),
+    (2, 3, 10, 8, "incremental", "cdf", False, "spn", True, 10, False, False, 0, False, None),
+    (5, 3, 5, 8, "incremental", "cdf", False, "spn", True, 5, False, False, 0, False, None),
+    (1, 10, 1, 8, "incremental", "cdf", False, "spn", True, 1, False, False, 0, False, None),
+    (2, 3, 2, 8, "incremental", "cdf", True, "spn", True, 2, False, False, 0, False, None),
+    (1, 3, 6, 8, None, None, False, "spn", True, 6, False, False, 0, False, None),
     #    Test the case where the radar image contains no rain.
-    (1, 3, 6, 8, None, None, False, "spn", True, 6, True, False, 0, False),
-    (5, 3, 5, 6, "incremental", "cdf", False, "spn", False, 5, True, False, 0, False),
-    (5, 3, 5, 6, "incremental", "cdf", False, "spn", False, 5, True, False, 0, True),
+    (1, 3, 6, 8, None, None, False, "spn", True, 6, True, False, 0, False, None),
+    (5, 3, 5, 6, "incremental", "cdf", False, "spn", False, 5, True, False, 0, False, None),
+    (5, 3, 5, 6, "incremental", "cdf", False, "spn", False, 5, True, False, 0, True, None),
     #   Test the case where the NWP fields contain no rain.
-    (1, 3, 6, 8, None, None, False, "spn", True, 6, False, True, 0, False),
-    (5, 3, 5, 6, "incremental", "cdf", False, "spn", False, 5, False, True, 0, True),
-    (1, 3, 6, 8, None, None, False, "spn", True, 6, True, True, 0, False),
-    (5, 3, 5, 6, "incremental", "cdf", False, "spn", False, 5, True, True, 0, False),
-    (5, 3, 5, 6, "obs", "mean", True, "spn", True, 5, True, True, 0, False),
+    (1, 3, 6, 8, None, None, False, "spn", True, 6, False, True, 0, False, None),
+    (5, 3, 5, 6, "incremental", "cdf", False, "spn", False, 5, False, True, 0, True, None),
+    # Test the case where both the radar image and the NWP fields contain no rain.
+    (1, 3, 6, 8, None, None, False, "spn", True, 6, True, True, 0, False, None),
+    (5, 3, 5, 6, "incremental", "cdf", False, "spn", False, 5, True, True, 0, False, None),
+    (5, 3, 5, 6, "obs", "mean", True, "spn", True, 5, True, True, 0, False, None),
     # Test for smooth radar mask
-    (1, 3, 6, 8, None, None, False, "spn", True, 6, False, False, 80, False),
-    (5, 3, 5, 6, "incremental", "cdf", False, "spn", False, 5, False, False, 80, False),
-    (5, 3, 5, 6, "obs", "mean", False, "spn", False, 5, False, False, 80, False),
-    (1, 3, 6, 8, None, None, False, "spn", True, 6, False, True, 80, False),
-    (5, 3, 5, 6, "incremental", "cdf", False, "spn", False, 5, True, False, 80, True),
-    (5, 3, 5, 6, "obs", "mean", False, "spn", False, 5, True, True, 80, False),
-    (5, [1, 2, 3], 5, 6, "obs", "mean", False, "spn", False, 5, True, True, 80, False),
-    (5, [1, 3], 5, 6, "obs", "mean", False, "spn", False, 5, True, True, 80, False),
+    (1, 3, 6, 8, None, None, False, "spn", True, 6, False, False, 80, False, None),
+    (5, 3, 5, 6, "incremental", "cdf", False, "spn", False, 5, False, False, 80, False, None),
+    (5, 3, 5, 6, "obs", "mean", False, "spn", False, 5, False, False, 80, False, None),
+    (1, 3, 6, 8, None, None, False, "spn", True, 6, False, True, 80, False, None),
+    (5, 3, 5, 6, "incremental", "cdf", False, "spn", False, 5, True, False, 80, True, None),
+    (5, 3, 5, 6, "obs", "mean", False, "spn", False, 5, True, True, 80, False, None),
+    (5, [1, 2, 3], 5, 6, "obs", "mean", False, "spn", False, 5, True, True, 80, False, None),
+    (5, [1, 3], 5, 6, "obs", "mean", False, "spn", False, 5, True, True, 80, False, None),
+    (5, [1, 3], 5, 6, "obs", "mean", False, "spn", False, 5, True, True, 80, False, "bps"),
 ]
+# fmt:on
 
 steps_arg_names = (
     "n_models",
@@ -66,6 +66,7 @@ steps_arg_names = (
     "zero_nwp",
     "smooth_radar_mask_range",
     "resample_distribution",
+    "vel_pert_method",
 )
 
 
@@ -85,6 +86,7 @@ def test_steps_blending(
     zero_nwp,
     smooth_radar_mask_range,
     resample_distribution,
+    vel_pert_method,
 ):
     pytest.importorskip("cv2")
 
@@ -278,7 +280,7 @@ def test_steps_blending(
         noise_method="nonparametric",
         noise_stddev_adj="auto",
         ar_order=2,
-        vel_pert_method=None,
+        vel_pert_method=vel_pert_method,
         weights_method=weights_method,
         conditional=False,
         probmatching_method=probmatching_method,

--- a/pysteps/tests/test_postprocessing_probmatching.py
+++ b/pysteps/tests/test_postprocessing_probmatching.py
@@ -1,7 +1,10 @@
 import numpy as np
 import pytest
-from pysteps.postprocessing.probmatching import resample_distributions
-from pysteps.postprocessing.probmatching import nonparam_match_empirical_cdf
+
+from pysteps.postprocessing.probmatching import (
+    nonparam_match_empirical_cdf,
+    resample_distributions,
+)
 
 
 class TestResampleDistributions:
@@ -16,7 +19,7 @@ class TestResampleDistributions:
         second_array = np.array([2, 4, 6, 8, 10])
         probability_first_array = 0.6
         result = resample_distributions(
-            first_array, second_array, probability_first_array
+            first_array, second_array, probability_first_array, np.random
         )
         expected_result = np.array([9, 8, 6, 3, 1])  # Expected result based on the seed
         assert result.shape == first_array.shape
@@ -27,7 +30,7 @@ class TestResampleDistributions:
         second_array = np.array([2, 4, 6, 8, 10])
         probability_first_array = 0.0
         result = resample_distributions(
-            first_array, second_array, probability_first_array
+            first_array, second_array, probability_first_array, np.random
         )
         assert np.array_equal(result, np.sort(second_array)[::-1])
 
@@ -36,7 +39,7 @@ class TestResampleDistributions:
         second_array = np.array([2, 4, 6, 8, 10])
         probability_first_array = 1.0
         result = resample_distributions(
-            first_array, second_array, probability_first_array
+            first_array, second_array, probability_first_array, np.random
         )
         assert np.array_equal(result, np.sort(first_array)[::-1])
 
@@ -45,7 +48,7 @@ class TestResampleDistributions:
         array_without_nan = np.array([2.0, 4, 6, 8, 10])
         probability_first_array = 1.0
         result = resample_distributions(
-            array_with_nan, array_without_nan, probability_first_array
+            array_with_nan, array_without_nan, probability_first_array, np.random
         )
         expected_result = np.array([np.nan, 9, 7, 3, 1], dtype=float)
         assert np.allclose(result, expected_result, equal_nan=True)
@@ -55,7 +58,7 @@ class TestResampleDistributions:
         array_without_nan = np.array([2, 4, 6, 8, 10])
         probability_first_array = 0.0
         result = resample_distributions(
-            array_with_nan, array_without_nan, probability_first_array
+            array_with_nan, array_without_nan, probability_first_array, np.random
         )
         expected_result = np.array([np.nan, 10, 8, 4, 2], dtype=float)
         assert np.allclose(result, expected_result, equal_nan=True)
@@ -65,7 +68,7 @@ class TestResampleDistributions:
         array_with_nan = np.array([2.0, 4, 6, np.nan, 10])
         probability_first_array = 1.0
         result = resample_distributions(
-            array_without_nan, array_with_nan, probability_first_array
+            array_without_nan, array_with_nan, probability_first_array, np.random
         )
         expected_result = np.array([np.nan, 9, 5, 3, 1], dtype=float)
         assert np.allclose(result, expected_result, equal_nan=True)
@@ -75,7 +78,7 @@ class TestResampleDistributions:
         array_with_nan = np.array([2, 4, 6, np.nan, 10])
         probability_first_array = 0.0
         result = resample_distributions(
-            array_without_nan, array_with_nan, probability_first_array
+            array_without_nan, array_with_nan, probability_first_array, np.random
         )
         expected_result = np.array([np.nan, 10, 6, 4, 2], dtype=float)
         assert np.allclose(result, expected_result, equal_nan=True)
@@ -85,7 +88,7 @@ class TestResampleDistributions:
         array2_with_nan = np.array([2.0, 4, np.nan, np.nan, 10])
         probability_first_array = 1.0
         result = resample_distributions(
-            array1_with_nan, array2_with_nan, probability_first_array
+            array1_with_nan, array2_with_nan, probability_first_array, np.random
         )
         expected_result = np.array([np.nan, np.nan, np.nan, 9, 1], dtype=float)
         assert np.allclose(result, expected_result, equal_nan=True)
@@ -95,7 +98,7 @@ class TestResampleDistributions:
         array2_with_nan = np.array([2.0, 4, np.nan, np.nan, 10])
         probability_first_array = 0.0
         result = resample_distributions(
-            array1_with_nan, array2_with_nan, probability_first_array
+            array1_with_nan, array2_with_nan, probability_first_array, np.random
         )
         expected_result = np.array([np.nan, np.nan, np.nan, 10, 2], dtype=float)
         assert np.allclose(result, expected_result, equal_nan=True)


### PR DESCRIPTION
In some places in the blending code the rng was done without using the provided seed. This meant that a run with a specified seed did not have a completely deterministic outcome and this makes testing harder. This PR fixes this.

NOTE: This PR is based on the refactor branch from @sidekock, so that branch needs to be merged first before this can be merged.
The only changes I added are in this commit: https://github.com/pySTEPS/pysteps/commit/07fbeb08ec297dc7da25f2d74a71645fe0a12fa6.