### PR TITLE
Expire argument deprecation warnings

### DIFF
--- a/examples/anvil_nowcast.py
+++ b/examples/anvil_nowcast.py
@@ -99,7 +99,7 @@ rainrate_thr, _ = transformation.dB_transform(
     np.array([0.5]), metadata, threshold=0.1, zerovalue=-15.0
 )
 forecast_sprog = sprog.forecast(
-    rainrate_field_db[-3:], velocity, 3, n_cascade_levels=6, R_thr=rainrate_thr[0]
+    rainrate_field_db[-3:], velocity, 3, n_cascade_levels=6, precip_thr=rainrate_thr[0]
 )
 forecast_sprog, _ = transformation.dB_transform(
     forecast_sprog, threshold=-10.0, inverse=True

--- a/examples/linda_nowcasts.py
+++ b/examples/linda_nowcasts.py
@@ -91,7 +91,7 @@ nowcast_sprog = sprog.forecast(
     advection,
     6,
     n_cascade_levels=6,
-    R_thr=-10.0,
+    precip_thr=-10.0,
 )
 
 # Convert reflectivity nowcast to rain rate
@@ -146,7 +146,7 @@ nowcast_steps = steps.forecast(
     6,
     40,
     n_cascade_levels=6,
-    R_thr=-10.0,
+    precip_thr=-10.0,
     mask_method="incremental",
     kmperpixel=2.0,
     timestep=datasource_params["timestep"],

--- a/examples/plot_ensemble_verification.py
+++ b/examples/plot_ensemble_verification.py
@@ -95,7 +95,7 @@ R_f = nowcast_method(
     n_leadtimes,
     n_ens_members,
     n_cascade_levels=6,
-    R_thr=-10.0,
+    precip_thr=-10.0,
     kmperpixel=2.0,
     timestep=timestep,
     decomp_method="fft",

--- a/examples/plot_steps_nowcast.py
+++ b/examples/plot_steps_nowcast.py
@@ -93,7 +93,7 @@ R_f = nowcast_method(
     V,
     n_leadtimes,
     n_cascade_levels=6,
-    R_thr=-10.0,
+    precip_thr=-10.0,
 )
 
 # Back-transform to rain rate
@@ -132,7 +132,7 @@ R_f = nowcast_method(
     n_leadtimes,
     n_ens_members,
     n_cascade_levels=6,
-    R_thr=-10.0,
+    precip_thr=-10.0,
     kmperpixel=2.0,
     timestep=timestep,
     noise_method="nonparametric",

--- a/pysteps/nowcasts/linda.py
+++ b/pysteps/nowcasts/linda.py
@@ -54,18 +54,9 @@ from scipy.signal import convolve
 from scipy import stats
 
 from pysteps import extrapolation, feature, noise
-from pysteps.decorators import deprecate_args
 from pysteps.nowcasts.utils import nowcast_main_loop
 
 
-@deprecate_args(
-    {
-        "precip_fields": "precip",
-        "advection_field": "velocity",
-        "num_ens_members": "n_ens_members",
-    },
-    "1.8.0",
-)
 def forecast(
     precip,
     velocity,

--- a/pysteps/nowcasts/sprog.py
+++ b/pysteps/nowcasts/sprog.py
@@ -16,7 +16,6 @@ import time
 from pysteps import cascade
 from pysteps import extrapolation
 from pysteps import utils
-from pysteps.decorators import deprecate_args
 from pysteps.nowcasts import utils as nowcast_utils
 from pysteps.postprocessing import probmatching
 from pysteps.timeseries import autoregression, correlation
@@ -30,7 +29,6 @@ except ImportError:
     DASK_IMPORTED = False
 
 
-@deprecate_args({"R": "precip", "V": "velocity", "R_thr": "precip_thr"}, "1.8.0")
 def forecast(
     precip,
     velocity,

--- a/pysteps/nowcasts/sseps.py
+++ b/pysteps/nowcasts/sseps.py
@@ -26,7 +26,6 @@ from scipy.ndimage import generate_binary_structure, iterate_structure
 from pysteps import cascade
 from pysteps import extrapolation
 from pysteps import noise
-from pysteps.decorators import deprecate_args
 from pysteps.nowcasts import utils as nowcast_utils
 from pysteps.postprocessing import probmatching
 from pysteps.timeseries import autoregression, correlation
@@ -39,7 +38,6 @@ except ImportError:
     dask_imported = False
 
 
-@deprecate_args({"R": "precip", "V": "velocity"}, "1.8.0")
 def forecast(
     precip,
     metadata,


### PR DESCRIPTION
This PR enforces the deprecation warnings that have been present in previous versions. The following arguments in the forecast functions across different modules have been officially deprecated and replaced:

### pysteps.nowcasts.linda
- `precip_fields` becomes `precip`
- `advection_field` becomes `velocity`
- `num_ens_members` becomes `n_ens_members`

### pysteps.nowcasts.sprog
- `R` becomes `precip`
- `V` becomes `velocity`
- `R_thr` becomes `precip_thr`

### pysteps.nowcasts.sseps
- `R` becomes `precip`
- `V` becomes `velocity`
