### PR TITLE
Replace use of distutils by shutils.copytree in datasets.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 25.1.0
     hooks:
     - id: black
       language_version: python3

--- a/pysteps/datasets.py
+++ b/pysteps/datasets.py
@@ -328,7 +328,9 @@ def download_pysteps_data(dir_path, force=True):
 
         zip_obj.extractall(tmp_dir.name)
 
-        shutil.copytree(os.path.join(tmp_dir.name, common_path), dir_path, dirs_exist_ok=True)
+        shutil.copytree(
+            os.path.join(tmp_dir.name, common_path), dir_path, dirs_exist_ok=True
+        )
 
 
 def create_default_pystepsrc(

--- a/pysteps/datasets.py
+++ b/pysteps/datasets.py
@@ -21,7 +21,6 @@ import shutil
 import sys
 import time
 from datetime import datetime, timedelta
-from distutils.dir_util import copy_tree
 from logging.handlers import RotatingFileHandler
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from urllib import request
@@ -329,7 +328,7 @@ def download_pysteps_data(dir_path, force=True):
 
         zip_obj.extractall(tmp_dir.name)
 
-        copy_tree(os.path.join(tmp_dir.name, common_path), dir_path)
+        shutil.copytree(os.path.join(tmp_dir.name, common_path), dir_path, dirs_exist_ok=True)
 
 
 def create_default_pystepsrc(


### PR DESCRIPTION
As mentioned in issue #457, the module `distutils` is deprecated since python v3.12. I believe it is only used in `datasets.py` and can be replaced with `shutils.copytree`.

This PR attempts to fix the issue by replacing `distutils.dir_util.copy_tree` by `shutils.copytree`.