### PR TITLE
fix noise tapering and error handling

### DIFF
--- a/pysteps/blending/steps.py
+++ b/pysteps/blending/steps.py
@@ -78,7 +78,7 @@ class StepsBlendingConfig:
     precip_threshold: float, optional
       Specifies the threshold value for minimum observable precipitation
       intensity. Required if mask_method is not None or conditional is True.
-    norain_threshold: float, optional
+    norain_threshold: float
       Specifies the threshold value for the fraction of rainy (see above) pixels
       in the radar rainfall field below which we consider there to be no rain.
       Depends on the amount of clutter typically present.
@@ -436,7 +436,6 @@ class StepsBlendingNowcaster:
 
         # Additional variables for time measurement
         self.__start_time_init = None
-        self.__zero_precip_time = None
         self.__init_time = None
         self.__mainloop_time = None
 
@@ -1144,7 +1143,7 @@ class StepsBlendingNowcaster:
                 precip_forecast_workers = None
 
         if self.__config.measure_time:
-            self.__zero_precip_time = time.time() - self.__start_time_init
+            zero_precip_time = time.time() - self.__start_time_init
 
         if self.__config.return_output:
             precip_forecast_all_members_all_times = np.stack(
@@ -1157,8 +1156,8 @@ class StepsBlendingNowcaster:
             if self.__config.measure_time:
                 return (
                     precip_forecast_all_members_all_times,
-                    self.__zero_precip_time,
-                    self.__zero_precip_time,
+                    zero_precip_time,
+                    zero_precip_time,
                 )
             else:
                 return precip_forecast_all_members_all_times
@@ -2929,7 +2928,7 @@ def forecast(
     precip_thr: float, optional
       Specifies the threshold value for minimum observable precipitation
       intensity. Required if mask_method is not None or conditional is True.
-    norain_thr: float, optional
+    norain_thr: float
       Specifies the threshold value for the fraction of rainy (see above) pixels
       in the radar rainfall field below which we consider there to be no rain.
       Depends on the amount of clutter typically present.

--- a/pysteps/blending/utils.py
+++ b/pysteps/blending/utils.py
@@ -553,7 +553,7 @@ def check_norain(precip_arr, precip_thr=None, norain_thr=0.0):
 
     """
     warnings.warn(
-        "pysteps.blending.utils.check_norain has been deprecated, use pysteps.utils.check_norain.check_norain in stead"
+        "pysteps.blending.utils.check_norain has been deprecated, use pysteps.utils.check_norain.check_norain instead"
     )
     return new_check_norain(precip_arr, precip_thr, norain_thr, None)
 

--- a/pysteps/blending/utils.py
+++ b/pysteps/blending/utils.py
@@ -15,11 +15,11 @@ Module with common utilities used by the blending methods.
     decompose_NWP
     compute_store_nwp_motion
     load_NWP
-    check_norain
     compute_smooth_dilated_mask
 """
 
 import datetime
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -28,6 +28,7 @@ from pysteps.cascade import get_method as cascade_get_method
 from pysteps.cascade.bandpass_filters import filter_gaussian
 from pysteps.exceptions import MissingOptionalDependency
 from pysteps.utils import get_method as utils_get_method
+from pysteps.utils.check_norain import check_norain as new_check_norain
 
 try:
     import netCDF4
@@ -534,7 +535,7 @@ def load_NWP(input_nc_path_decomp, input_path_velocities, start_time, n_timestep
 
 def check_norain(precip_arr, precip_thr=None, norain_thr=0.0):
     """
-
+    DEPRECATED use :py:mod:`pysteps.utils.check_norain.check_norain` in stead
     Parameters
     ----------
     precip_arr:  array-like
@@ -551,15 +552,10 @@ def check_norain(precip_arr, precip_thr=None, norain_thr=0.0):
       Returns whether the fraction of rainy pixels is below the norain_thr threshold.
 
     """
-
-    if precip_thr is None:
-        precip_thr = np.nanmin(precip_arr)
-    rain_pixels = precip_arr[precip_arr > precip_thr]
-    norain = rain_pixels.size / precip_arr.size <= norain_thr
-    print(
-        f"Rain fraction is: {str(rain_pixels.size / precip_arr.size)}, while minimum fraction is {str(norain_thr)}"
+    warnings.warn(
+        "pysteps.blending.utils.check_norain has been deprecated, use pysteps.utils.check_norain.check_norain in stead"
     )
-    return norain
+    return new_check_norain(precip_arr, precip_thr, norain_thr, None)
 
 
 def compute_smooth_dilated_mask(

--- a/pysteps/noise/fftgenerators.py
+++ b/pysteps/noise/fftgenerators.py
@@ -104,6 +104,7 @@ def initialize_param_2d_fft_filter(field, **kwargs):
             "field contains non-finite values, this typically happens when the input\n"
             + "precipitation field provided to pysteps contains (mostly)zero values.\n"
             + "To prevent this error please call pysteps.utils.check_norain first,\n"
+            + "using the same win_fun as used in this method (tukey by default)\n"
             + "and then only call this method if that check fails."
         )
 
@@ -264,6 +265,7 @@ def initialize_nonparam_2d_fft_filter(field, **kwargs):
             "field contains non-finite values, this typically happens when the input\n"
             + "precipitation field provided to pysteps contains (mostly)zero values.\n"
             + "To prevent this error please call pysteps.utils.check_norain first,\n"
+            + "using the same win_fun as used in this method (tukey by default)\n"
             + "and then only call this method if that check fails."
         )
 
@@ -376,6 +378,7 @@ def generate_noise_2d_fft_filter(
             "field contains non-finite values, this typically happens when the input\n"
             + "precipitation field provided to pysteps contains (mostly)zero values.\n"
             + "To prevent this error please call pysteps.utils.check_norain first,\n"
+            + "using the same win_fun as used in this method (tukey by default)\n"
             + "and then only call this method if that check fails."
         )
 
@@ -775,6 +778,7 @@ def generate_noise_2d_ssft_filter(F, randstate=None, seed=None, **kwargs):
             "field contains non-finite values, this typically happens when the input\n"
             + "precipitation field provided to pysteps contains (mostly) zero value.s\n"
             + "To prevent this error please call pysteps.utils.check_norain first,\n"
+            + "using the same win_fun as used in this method (tukey by default)\n"
             + "and then only call this method if that check fails."
         )
 

--- a/pysteps/noise/fftgenerators.py
+++ b/pysteps/noise/fftgenerators.py
@@ -46,6 +46,7 @@ field of correlated noise cN of shape (m, n).
 
 import numpy as np
 from scipy import optimize
+
 from .. import utils
 
 
@@ -99,7 +100,12 @@ def initialize_param_2d_fft_filter(field, **kwargs):
     if len(field.shape) < 2 or len(field.shape) > 3:
         raise ValueError("the input is not two- or three-dimensional array")
     if np.any(~np.isfinite(field)):
-        raise ValueError("field contains non-finite values")
+        raise ValueError(
+            "field contains non-finite values, this typically happens when the input\n"
+            + "precipitation field provided to pysteps contains (mostly)zero values.\n"
+            + "To prevent this error please call pysteps.utils.check_norain first,\n"
+            + "and then only call this method if that check fails."
+        )
 
     # defaults
     win_fun = kwargs.get("win_fun", None)
@@ -254,7 +260,12 @@ def initialize_nonparam_2d_fft_filter(field, **kwargs):
     if len(field.shape) < 2 or len(field.shape) > 3:
         raise ValueError("the input is not two- or three-dimensional array")
     if np.any(~np.isfinite(field)):
-        raise ValueError("field contains non-finite values")
+        raise ValueError(
+            "field contains non-finite values, this typically happens when the input\n"
+            + "precipitation field provided to pysteps contains (mostly)zero values.\n"
+            + "To prevent this error please call pysteps.utils.check_norain first,\n"
+            + "and then only call this method if that check fails."
+        )
 
     # defaults
     win_fun = kwargs.get("win_fun", "tukey")
@@ -361,7 +372,12 @@ def generate_noise_2d_fft_filter(
     if len(F.shape) != 2:
         raise ValueError("field is not two-dimensional array")
     if np.any(~np.isfinite(F)):
-        raise ValueError("field contains non-finite values")
+        raise ValueError(
+            "field contains non-finite values, this typically happens when the input\n"
+            + "precipitation field provided to pysteps contains (mostly)zero values.\n"
+            + "To prevent this error please call pysteps.utils.check_norain first,\n"
+            + "and then only call this method if that check fails."
+        )
 
     if randstate is None:
         randstate = np.random
@@ -755,7 +771,12 @@ def generate_noise_2d_ssft_filter(F, randstate=None, seed=None, **kwargs):
     if len(F.shape) != 4:
         raise ValueError("the input is not four-dimensional array")
     if np.any(~np.isfinite(F)):
-        raise ValueError("field contains non-finite values")
+        raise ValueError(
+            "field contains non-finite values, this typically happens when the input\n"
+            + "precipitation field provided to pysteps contains (mostly) zero value.s\n"
+            + "To prevent this error please call pysteps.utils.check_norain first,\n"
+            + "and then only call this method if that check fails."
+        )
 
     if "domain" in kwargs.keys() and kwargs["domain"] == "spectral":
         raise NotImplementedError(

--- a/pysteps/nowcasts/sseps.py
+++ b/pysteps/nowcasts/sseps.py
@@ -18,17 +18,16 @@ size.
     forecast
 """
 
-import numpy as np
 import time
+
+import numpy as np
 from scipy.ndimage import generate_binary_structure, iterate_structure
 
-
-from pysteps import cascade
-from pysteps import extrapolation
-from pysteps import noise
+from pysteps import cascade, extrapolation, noise
 from pysteps.nowcasts import utils as nowcast_utils
 from pysteps.postprocessing import probmatching
 from pysteps.timeseries import autoregression, correlation
+from pysteps.utils.check_norain import check_norain
 
 try:
     import dask
@@ -188,13 +187,7 @@ def forecast(
 
     See also
     --------
-    pysteps.extrapolation.interface, pysteps.cascade.interface,
-    pysteps.noise.interface, pysteps.noise.utils.compute_noise_stddev_adjs
-
-    Notes
-    -----
-    Please be aware that this represents a (very) experimental implementation.
-
+    pysteps.extrapolation.interface, pystepsemilagrangian
     References
     ----------
     :cite:`Seed2003`, :cite:`BPS2006`, :cite:`SPN2013`, :cite:`NBSG2017`
@@ -211,7 +204,7 @@ def forecast(
         filter_kwargs = dict()
 
     if noise_kwargs is None:
-        noise_kwargs = dict()
+        noise_kwargs = {"win_fun": "tukey"}
 
     if vel_pert_kwargs is None:
         vel_pert_kwargs = dict()
@@ -297,6 +290,8 @@ def forecast(
 
     if measure_time:
         starttime_init = time.time()
+    else:
+        starttime_init = None
 
     # get methods
     extrapolator_method = extrapolation.get_method(extrap_method)
@@ -311,6 +306,22 @@ def forecast(
     filter_method = cascade.get_method(bandpass_filter_method)
     if noise_method is not None:
         init_noise, generate_noise = noise.get_method(noise_method)
+
+    if check_norain(
+        precip,
+        precip_thr,
+        war_thr,
+        noise_kwargs["win_fun"],
+    ):
+        return nowcast_utils.zero_precipitation_forecast(
+            n_ens_members,
+            timesteps,
+            precip,
+            callback,
+            return_output,
+            measure_time,
+            starttime_init,
+        )
 
     # advect the previous precipitation fields to the same position with the
     # most recent one (i.e. transform them into the Lagrangian coordinates)

--- a/pysteps/nowcasts/sseps.py
+++ b/pysteps/nowcasts/sseps.py
@@ -187,7 +187,13 @@ def forecast(
 
     See also
     --------
-    pysteps.extrapolation.interface, pystepsemilagrangian
+    pysteps.extrapolation.interface, pysteps.cascade.interface,
+    pysteps.noise.interface, pysteps.noise.utils.compute_noise_stddev_adjs
+
+    Notes
+    -----
+    Please be aware that this represents a (very) experimental implementation.
+
     References
     ----------
     :cite:`Seed2003`, :cite:`BPS2006`, :cite:`SPN2013`, :cite:`NBSG2017`

--- a/pysteps/nowcasts/steps.py
+++ b/pysteps/nowcasts/steps.py
@@ -11,22 +11,24 @@ Implementation of the STEPS stochastic nowcasting method as described in
     forecast
 """
 
-import numpy as np
-from scipy.ndimage import generate_binary_structure, iterate_structure
 import time
 from copy import deepcopy
-
-from pysteps import cascade
-from pysteps import extrapolation
-from pysteps import noise
-from pysteps import utils
-from pysteps.nowcasts import utils as nowcast_utils
-from pysteps.postprocessing import probmatching
-from pysteps.timeseries import autoregression, correlation
-from pysteps.nowcasts.utils import compute_percentile_mask, nowcast_main_loop
-
 from dataclasses import dataclass, field
 from typing import Any, Callable
+
+import numpy as np
+from scipy.ndimage import generate_binary_structure, iterate_structure
+
+from pysteps import cascade, extrapolation, noise, utils
+from pysteps.nowcasts import utils as nowcast_utils
+from pysteps.nowcasts.utils import (
+    compute_percentile_mask,
+    nowcast_main_loop,
+    zero_precipitation_forecast,
+)
+from pysteps.postprocessing import probmatching
+from pysteps.timeseries import autoregression, correlation
+from pysteps.utils.check_norain import check_norain
 
 try:
     import dask
@@ -50,6 +52,11 @@ class StepsNowcasterConfig:
     precip_threshold: float, optional
         Specifies the threshold value for minimum observable precipitation
         intensity. Required if mask_method is not None or conditional is True.
+    norain_threshold: float
+      Specifies the threshold value for the fraction of rainy (see above) pixels
+      in the radar rainfall field below which we consider there to be no rain.
+      Depends on the amount of clutter typically present.
+      Standard set to 0.0
     kmperpixel: float, optional
         Spatial resolution of the input data (kilometers/pixel). Required if
         vel_pert_method is not None or mask_method is 'incremental'.
@@ -201,6 +208,7 @@ class StepsNowcasterConfig:
     n_ens_members: int = 24
     n_cascade_levels: int = 6
     precip_threshold: float | None = None
+    norain_threshold: float = 0.0
     kmperpixel: float | None = None
     timestep: float | None = None
     extrapolation_method: str = "semilagrangian"
@@ -349,6 +357,21 @@ class StepsNowcaster:
         # Slice the precipitation field to only use the last ar_order + 1 fields
         self.__precip = self.__precip[-(self.__config.ar_order + 1) :, :, :].copy()
         self.__initialize_nowcast_components()
+        if check_norain(
+            self.__precip,
+            self.__config.precip_threshold,
+            self.__config.norain_threshold,
+            self.__params.noise_kwargs["win_fun"],
+        ):
+            return zero_precipitation_forecast(
+                self.__config.n_ens_members,
+                self.__time_steps,
+                self.__precip,
+                self.__config.callback,
+                self.__config.return_output,
+                self.__config.measure_time,
+                self.__start_time_init,
+            )
 
         self.__perform_extrapolation()
         self.__apply_noise_and_ar_model()
@@ -501,7 +524,7 @@ class StepsNowcaster:
             self.__params.filter_kwargs = deepcopy(self.__config.filter_kwargs)
 
         if self.__config.noise_kwargs is None:
-            self.__params.noise_kwargs = dict()
+            self.__params.noise_kwargs = {"win_fun": "tukey"}
         else:
             self.__params.noise_kwargs = deepcopy(self.__config.noise_kwargs)
 
@@ -1246,6 +1269,7 @@ def forecast(
     n_ens_members=24,
     n_cascade_levels=6,
     precip_thr=None,
+    norain_thr=0.0,
     kmperpixel=None,
     timestep=None,
     extrap_method="semilagrangian",
@@ -1297,6 +1321,11 @@ def forecast(
     precip_thr: float, optional
         Specifies the threshold value for minimum observable precipitation
         intensity. Required if mask_method is not None or conditional is True.
+    norain_thr: float
+      Specifies the threshold value for the fraction of rainy (see above) pixels
+      in the radar rainfall field below which we consider there to be no rain.
+      Depends on the amount of clutter typically present.
+      Standard set to 0.0
     kmperpixel: float, optional
         Spatial resolution of the input data (kilometers/pixel). Required if
         vel_pert_method is not None or mask_method is 'incremental'.
@@ -1470,6 +1499,7 @@ def forecast(
         n_ens_members=n_ens_members,
         n_cascade_levels=n_cascade_levels,
         precip_threshold=precip_thr,
+        norain_threshold=norain_thr,
         kmperpixel=kmperpixel,
         timestep=timestep,
         extrapolation_method=extrap_method,

--- a/pysteps/nowcasts/utils.py
+++ b/pysteps/nowcasts/utils.py
@@ -151,6 +151,45 @@ def zero_precipitation_forecast(
     Generate a zero-precipitation forecast (filled with the minimum precip value)
     when no precipitation above the threshold is detected. The forecast is
     optionally returned or passed to a callback.
+
+    Parameters
+    ----------
+    n_ens_members: int, optional
+        The number of ensemble members to generate.
+    timesteps: int or list of floats
+        Number of time steps to forecast or a list of time steps for which the
+        forecasts are computed (relative to the input time step). The elements
+        of the list are required to be in ascending order.
+    precip: array-like
+        Array of shape (ar_order+1,m,n) containing the input precipitation fields
+        ordered by timestamp from oldest to newest. The time steps between the
+        inputs are assumed to be regular.
+    callback: function, optional
+        Optional function that is called after computation of each time step of
+        the nowcast. The function takes one argument: a three-dimensional array
+        of shape (n_ens_members,h,w), where h and w are the height and width
+        of the input precipitation fields, respectively. This can be used, for
+        instance, writing the outputs into files.
+    return_output: bool, optional
+        Set to False to disable returning the outputs as numpy arrays. This can
+        save memory if the intermediate results are written to output files using
+        the callback function.
+    measure_time: bool
+        If set to True, measure, print and return the computation time.
+    start_time_init: float
+        The value of the start time counter used to compute total run time.
+
+    Returns
+    -------
+    out: ndarray
+        If return_output is True, a four-dimensional array of shape
+        (n_ens_members,num_timesteps,m,n) containing a time series of forecast
+        precipitation fields for each ensemble member. Otherwise, a None value
+        is returned. The time series starts from t0+timestep, where timestep is
+        taken from the input precipitation fields. If measure_time is True, the
+        return value is a three-element tuple containing the nowcast array, the
+        initialization time of the nowcast generator and the time used in the
+        main loop (seconds).
     """
     print("No precipitation above the threshold found in the radar field")
     print("The resulting forecast will contain only zeros")

--- a/pysteps/tests/test_blending_utils.py
+++ b/pysteps/tests/test_blending_utils.py
@@ -3,21 +3,21 @@
 import os
 
 import numpy as np
-from numpy.testing import assert_array_almost_equal
 import pytest
+from numpy.testing import assert_array_almost_equal
 
 import pysteps
 from pysteps.blending.utils import (
-    stack_cascades,
     blend_cascades,
-    recompose_cascade,
     blend_optical_flows,
-    decompose_NWP,
-    compute_store_nwp_motion,
-    load_NWP,
-    check_norain,
     compute_smooth_dilated_mask,
+    compute_store_nwp_motion,
+    decompose_NWP,
+    load_NWP,
+    recompose_cascade,
+    stack_cascades,
 )
+from pysteps.utils.check_norain import check_norain
 
 pytest.importorskip("netCDF4")
 
@@ -398,28 +398,30 @@ def test_blending_utils(
 
     precip_arr = precip_nwp
     # rainy fraction is 0.005847
-    assert not check_norain(precip_arr)
-    assert not check_norain(precip_arr, precip_thr=nwp_metadata["threshold"])
+    assert not check_norain(precip_arr, win_fun=None)
     assert not check_norain(
-        precip_arr, precip_thr=nwp_metadata["threshold"], norain_thr=0.005
+        precip_arr, precip_thr=nwp_metadata["threshold"], win_fun=None
     )
-    assert not check_norain(precip_arr, norain_thr=0.005)
+    assert not check_norain(
+        precip_arr, precip_thr=nwp_metadata["threshold"], norain_thr=0.005, win_fun=None
+    )
+    assert not check_norain(precip_arr, norain_thr=0.005, win_fun=None)
     # so with norain_thr beyond this number it should report that there's no rain
-    assert check_norain(precip_arr, norain_thr=0.006)
+    assert check_norain(precip_arr, norain_thr=0.006, win_fun=None)
     assert check_norain(
-        precip_arr, precip_thr=nwp_metadata["threshold"], norain_thr=0.006
+        precip_arr, precip_thr=nwp_metadata["threshold"], norain_thr=0.006, win_fun=None
     )
 
     # also if we set the precipitation threshold sufficiently high, it should report there's no rain
     # rainy fraction > 4mm/h is 0.004385
-    assert not check_norain(precip_arr, precip_thr=4.0, norain_thr=0.004)
-    assert check_norain(precip_arr, precip_thr=4.0, norain_thr=0.005)
+    assert not check_norain(precip_arr, precip_thr=4.0, norain_thr=0.004, win_fun=None)
+    assert check_norain(precip_arr, precip_thr=4.0, norain_thr=0.005, win_fun=None)
 
     # no rain above 100mm/h so it should give norain
-    assert check_norain(precip_arr, precip_thr=100)
+    assert check_norain(precip_arr, precip_thr=100, win_fun=None)
 
     # should always give norain if the threshold is set to 100%
-    assert check_norain(precip_arr, norain_thr=1.0)
+    assert check_norain(precip_arr, norain_thr=1.0, win_fun=None)
 
 
 # Finally, also test the compute_smooth_dilated mask functionality

--- a/pysteps/tests/test_nowcasts_anvil.py
+++ b/pysteps/tests/test_nowcasts_anvil.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from pysteps import motion, nowcasts, verification

--- a/pysteps/tests/test_nowcasts_anvil.py
+++ b/pysteps/tests/test_nowcasts_anvil.py
@@ -23,7 +23,7 @@ def test_default_anvil_norain():
     """Tests anvil nowcast with default params and all-zero inputs."""
 
     # Define dummy nowcast input data
-    precip_input = np.zeros((3, 100, 100))
+    precip_input = np.zeros((4, 100, 100))
 
     pytest.importorskip("cv2")
     oflow_method = motion.get_method("LK")

--- a/pysteps/tests/test_nowcasts_anvil.py
+++ b/pysteps/tests/test_nowcasts_anvil.py
@@ -19,6 +19,7 @@ anvil_arg_values = [
     (8, 1, 50, [3], 0.6, False, True),
 ]
 
+
 def test_default_anvil_norain():
     """Tests anvil nowcast with default params and all-zero inputs."""
 

--- a/pysteps/tests/test_nowcasts_anvil.py
+++ b/pysteps/tests/test_nowcasts_anvil.py
@@ -18,6 +18,27 @@ anvil_arg_values = [
     (8, 1, 50, [3], 0.6, False, True),
 ]
 
+def test_default_anvil_norain():
+    """Tests anvil nowcast with default params and all-zero inputs."""
+
+    # Define dummy nowcast input data
+    precip_input = np.zeros((3, 100, 100))
+
+    pytest.importorskip("cv2")
+    oflow_method = motion.get_method("LK")
+    retrieved_motion = oflow_method(precip_input)
+
+    nowcast_method = nowcasts.get_method("anvil")
+    precip_forecast = nowcast_method(
+        precip_input,
+        retrieved_motion,
+        timesteps=3,
+    )
+
+    assert precip_forecast.ndim == 3
+    assert precip_forecast.shape[0] == 3
+    assert precip_forecast.sum() == 0.0
+
 
 @pytest.mark.parametrize(anvil_arg_names, anvil_arg_values)
 def test_anvil_rainrate(

--- a/pysteps/tests/test_nowcasts_linda.py
+++ b/pysteps/tests/test_nowcasts_linda.py
@@ -41,6 +41,7 @@ def test_default_linda_norain():
         retrieved_motion,
         n_ens_members=3,
         timesteps=3,
+        kmperpixel=1,
     )
 
     assert precip_forecast.ndim == 4

--- a/pysteps/tests/test_nowcasts_linda.py
+++ b/pysteps/tests/test_nowcasts_linda.py
@@ -42,6 +42,7 @@ def test_default_linda_norain():
         n_ens_members=3,
         timesteps=3,
         kmperpixel=1,
+        timestep=5,
     )
 
     assert precip_forecast.ndim == 4

--- a/pysteps/tests/test_nowcasts_linda.py
+++ b/pysteps/tests/test_nowcasts_linda.py
@@ -25,6 +25,29 @@ linda_arg_values = [
     (True, "isotropic", "bps", 5, True, None, 0.3),
 ]
 
+def test_default_linda_norain():
+    """Tests linda nowcast with default params and all-zero inputs."""
+
+    # Define dummy nowcast input data
+    precip_input = np.zeros((3, 100, 100))
+
+    pytest.importorskip("cv2")
+    oflow_method = motion.get_method("LK")
+    retrieved_motion = oflow_method(precip_input)
+
+    nowcast_method = nowcasts.get_method("linda")
+    precip_forecast = nowcast_method(
+        precip_input,
+        retrieved_motion,
+        n_ens_members=3,
+        timesteps=3,
+    )
+
+    assert precip_forecast.ndim == 4
+    assert precip_forecast.shape[0] == 3
+    assert precip_forecast.shape[1] == 3
+    assert precip_forecast.sum() == 0.0
+
 
 @pytest.mark.parametrize(linda_arg_names, linda_arg_values)
 def test_linda(

--- a/pysteps/tests/test_nowcasts_linda.py
+++ b/pysteps/tests/test_nowcasts_linda.py
@@ -25,6 +25,7 @@ linda_arg_values = [
     (True, "isotropic", "bps", 5, True, None, 0.3),
 ]
 
+
 def test_default_linda_norain():
     """Tests linda nowcast with default params and all-zero inputs."""
 

--- a/pysteps/tests/test_nowcasts_sprog.py
+++ b/pysteps/tests/test_nowcasts_sprog.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import numpy as np
 import pytest
 
 from pysteps import motion, nowcasts, verification

--- a/pysteps/tests/test_nowcasts_sprog.py
+++ b/pysteps/tests/test_nowcasts_sprog.py
@@ -23,6 +23,27 @@ sprog_arg_values = [
     (6, 2, "cdf", "spectral", 3, 0.5),
 ]
 
+def test_default_sprog_norain():
+    """Tests SPROG nowcast with default params and all-zero inputs."""
+
+    # Define dummy nowcast input data
+    precip_input = np.zeros((3, 100, 100))
+
+    pytest.importorskip("cv2")
+    oflow_method = motion.get_method("LK")
+    retrieved_motion = oflow_method(precip_input)
+
+    nowcast_method = nowcasts.get_method("sprog")
+    precip_forecast = nowcast_method(
+        precip_input,
+        retrieved_motion,
+        timesteps=3,
+        precip_thr=0.1,
+    )
+
+    assert precip_forecast.ndim == 3
+    assert precip_forecast.shape[0] == 3
+    assert precip_forecast.sum() == 0.0
 
 @pytest.mark.parametrize(sprog_arg_names, sprog_arg_values)
 def test_sprog(

--- a/pysteps/tests/test_nowcasts_sprog.py
+++ b/pysteps/tests/test_nowcasts_sprog.py
@@ -24,6 +24,7 @@ sprog_arg_values = [
     (6, 2, "cdf", "spectral", 3, 0.5),
 ]
 
+
 def test_default_sprog_norain():
     """Tests SPROG nowcast with default params and all-zero inputs."""
 
@@ -45,6 +46,7 @@ def test_default_sprog_norain():
     assert precip_forecast.ndim == 3
     assert precip_forecast.shape[0] == 3
     assert precip_forecast.sum() == 0.0
+
 
 @pytest.mark.parametrize(sprog_arg_names, sprog_arg_values)
 def test_sprog(

--- a/pysteps/tests/test_nowcasts_sseps.py
+++ b/pysteps/tests/test_nowcasts_sseps.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import numpy as np
 import pytest
 
 from pysteps import motion, nowcasts, verification

--- a/pysteps/tests/test_nowcasts_sseps.py
+++ b/pysteps/tests/test_nowcasts_sseps.py
@@ -22,6 +22,7 @@ sseps_arg_values = [
     (5, 6, 2, "incremental", "cdf", 200, [3], 0.60),
 ]
 
+
 def test_default_sseps_norain():
     """Tests SSEPS nowcast with default params and all-zero inputs."""
 
@@ -31,7 +32,7 @@ def test_default_sseps_norain():
         "accutime": 5,
         "xpixelsize": 1000,
         "threshold": 0.1,
-        "zerovalue": 0, 
+        "zerovalue": 0,
     }
 
     pytest.importorskip("cv2")

--- a/pysteps/tests/test_nowcasts_sseps.py
+++ b/pysteps/tests/test_nowcasts_sseps.py
@@ -21,6 +21,36 @@ sseps_arg_values = [
     (5, 6, 2, "incremental", "cdf", 200, [3], 0.60),
 ]
 
+def test_default_sseps_norain():
+    """Tests SSEPS nowcast with default params and all-zero inputs."""
+
+    # Define dummy nowcast input data
+    precip_input = np.zeros((3, 100, 100))
+    metadata = {
+        "accutime": 5,
+        "xpixelsize": 1000,
+        "threshold": 0.1,
+        "zerovalue": 0, 
+    }
+
+    pytest.importorskip("cv2")
+    oflow_method = motion.get_method("LK")
+    retrieved_motion = oflow_method(precip_input)
+
+    nowcast_method = nowcasts.get_method("sseps")
+    precip_forecast = nowcast_method(
+        precip_input,
+        metadata,
+        retrieved_motion,
+        n_ens_members=3,
+        timesteps=3,
+    )
+
+    assert precip_forecast.ndim == 4
+    assert precip_forecast.shape[0] == 3
+    assert precip_forecast.shape[1] == 3
+    assert precip_forecast.sum() == 0.0
+
 
 @pytest.mark.parametrize(sseps_arg_names, sseps_arg_values)
 def test_sseps(

--- a/pysteps/tests/test_nowcasts_steps.py
+++ b/pysteps/tests/test_nowcasts_steps.py
@@ -48,6 +48,7 @@ def test_default_steps_norain():
         timesteps=3,
         precip_thr=0.1,
         kmperpixel=1,
+        timestep=5,
     )
 
     assert precip_forecast.ndim == 4

--- a/pysteps/tests/test_nowcasts_steps.py
+++ b/pysteps/tests/test_nowcasts_steps.py
@@ -47,6 +47,7 @@ def test_default_steps_norain():
         n_ens_members=3,
         timesteps=3,
         precip_thr=0.1,
+        kmperpixel=1,
     )
 
     assert precip_forecast.ndim == 4

--- a/pysteps/tests/test_nowcasts_steps.py
+++ b/pysteps/tests/test_nowcasts_steps.py
@@ -7,7 +7,6 @@ import pytest
 from pysteps import io, motion, nowcasts, verification
 from pysteps.tests.helpers import get_precipitation_fields
 
-
 steps_arg_names = (
     "n_ens_members",
     "n_cascade_levels",
@@ -22,7 +21,7 @@ steps_arg_names = (
 steps_arg_values = [
     (5, 6, 2, None, None, "spatial", 3, 1.30),
     (5, 6, 2, None, None, "spatial", [3], 1.30),
-    (5, 6, 2, "incremental", None, "spatial", 3, 7.31),
+    (5, 6, 2, "incremental", None, "spatial", 3, 7.32),
     (5, 6, 2, "sprog", None, "spatial", 3, 8.4),
     (5, 6, 2, "obs", None, "spatial", 3, 8.37),
     (5, 6, 2, None, "cdf", "spatial", 3, 0.60),

--- a/pysteps/tests/test_nowcasts_steps.py
+++ b/pysteps/tests/test_nowcasts_steps.py
@@ -46,6 +46,7 @@ def test_default_steps_norain():
         retrieved_motion,
         n_ens_members=3,
         timesteps=3,
+        precip_thr=0.1,
     )
 
     assert precip_forecast.ndim == 4

--- a/pysteps/tests/test_nowcasts_steps.py
+++ b/pysteps/tests/test_nowcasts_steps.py
@@ -30,6 +30,39 @@ steps_arg_values = [
 ]
 
 
+def test_default_steps_norain(
+    n_ens_members,
+    n_cascade_levels,
+    ar_order,
+    mask_method,
+    probmatching_method,
+    domain,
+    timesteps,
+    max_crps,
+):
+    """Tests STEPS nowcast with default params and all-zero inputs."""
+
+    # Define dummy nowcast input data
+    precip_input = np.zeros((3, 100, 100))
+
+    pytest.importorskip("cv2")
+    oflow_method = motion.get_method("LK")
+    retrieved_motion = oflow_method(precip_input)
+
+    nowcast_method = nowcasts.get_method("steps")
+    precip_forecast = nowcast_method(
+        precip_input,
+        retrieved_motion,
+        n_ens_members=2,
+        timesteps=3,
+    )
+
+    assert precip_forecast.ndim == 4
+    assert precip_forecast.shape[0] == 3
+    assert precip_forecast.shape[1] == 3
+    assert precip_forecast.sum() == 0.0
+
+
 @pytest.mark.parametrize(steps_arg_names, steps_arg_values)
 def test_steps_skill(
     n_ens_members,

--- a/pysteps/tests/test_nowcasts_steps.py
+++ b/pysteps/tests/test_nowcasts_steps.py
@@ -30,16 +30,7 @@ steps_arg_values = [
 ]
 
 
-def test_default_steps_norain(
-    n_ens_members,
-    n_cascade_levels,
-    ar_order,
-    mask_method,
-    probmatching_method,
-    domain,
-    timesteps,
-    max_crps,
-):
+def test_default_steps_norain():
     """Tests STEPS nowcast with default params and all-zero inputs."""
 
     # Define dummy nowcast input data
@@ -53,7 +44,7 @@ def test_default_steps_norain(
     precip_forecast = nowcast_method(
         precip_input,
         retrieved_motion,
-        n_ens_members=2,
+        n_ens_members=3,
         timesteps=3,
     )
 

--- a/pysteps/utils/check_norain.py
+++ b/pysteps/utils/check_norain.py
@@ -3,7 +3,7 @@ import numpy as np
 from pysteps import utils
 
 
-def check_norain(precip_arr, precip_thr=None, norain_thr=0.0, win_fun="tukey"):
+def check_norain(precip_arr, precip_thr=None, norain_thr=0.0, win_fun=None):
     """
 
     Parameters
@@ -19,7 +19,7 @@ def check_norain(precip_arr, precip_thr=None, norain_thr=0.0, win_fun="tukey"):
     win_fun: {'hann', 'tukey', None}
       Optional tapering function to be applied to the input field, generated with
       :py:func:`pysteps.utils.tapering.compute_window_function`
-      (default 'tukey').
+      (default None).
       This parameter needs to match the window function you use in later noise generation,
       or else this method will say that there is rain, while after the tapering function is
       applied there is no rain left, so you will run into a ValueError.

--- a/pysteps/utils/check_norain.py
+++ b/pysteps/utils/check_norain.py
@@ -1,0 +1,51 @@
+import numpy as np
+
+from pysteps import utils
+
+
+def check_norain(precip_arr, precip_thr=None, norain_thr=0.0, win_fun="tukey"):
+    """
+
+    Parameters
+    ----------
+    precip_arr:  array-like
+      An at least 2 dimensional array containing the input precipitation field
+    precip_thr: float, optional
+      Specifies the threshold value for minimum observable precipitation intensity. If None, the
+      minimum value over the domain is taken.
+    norain_thr: float, optional
+      Specifies the threshold value for the fraction of rainy pixels in precip_arr below which we consider there to be
+      no rain. Standard set to 0.0
+    win_fun: {'hann', 'tukey', None}
+      Optional tapering function to be applied to the input field, generated with
+      :py:func:`pysteps.utils.tapering.compute_window_function`
+      (default 'tukey').
+      This parameter needs to match the window function you use in later noise generation,
+      or else this method will say that there is rain, while after the tapering function is
+      applied there is no rain left, so you will run into a ValueError.
+    Returns
+    -------
+    norain: bool
+      Returns whether the fraction of rainy pixels is below the norain_thr threshold.
+
+    """
+
+    if win_fun is not None:
+        tapering = utils.tapering.compute_window_function(
+            precip_arr.shape[-2], precip_arr.shape[-1], win_fun
+        )
+    else:
+        tapering = np.ones((precip_arr.shape[-2], precip_arr.shape[-1]))
+
+    tapering_mask = tapering == 0.0
+    masked_precip = precip_arr.copy()
+    masked_precip[..., tapering_mask] = np.nanmin(precip_arr)
+
+    if precip_thr is None:
+        precip_thr = np.nanmin(masked_precip)
+    rain_pixels = masked_precip[masked_precip > precip_thr]
+    norain = rain_pixels.size / masked_precip.size <= norain_thr
+    print(
+        f"Rain fraction is: {str(rain_pixels.size / masked_precip.size)}, while minimum fraction is {str(norain_thr)}"
+    )
+    return norain

--- a/pysteps/utils/tapering.py
+++ b/pysteps/utils/tapering.py
@@ -82,7 +82,7 @@ def compute_window_function(m, n, func, **kwargs):
         Array of shape (m, n) containing the tapering weights.
     """
     X, Y = np.meshgrid(np.arange(n), np.arange(m))
-    R = np.sqrt((X - int(n / 2)) ** 2 + (Y - int(m / 2)) ** 2)
+    R = np.sqrt(((X / n) - 0.5) ** 2 + ((Y / m) - 0.5) ** 2)
 
     if func == "hann":
         return _hann(R)
@@ -108,26 +108,24 @@ def _compute_mask_distances(mask):
 
 def _hann(R):
     W = np.ones_like(R)
-    N = min(R.shape[0], R.shape[1])
-    mask = R > int(N / 2)
+    mask = R > 0.5
 
     W[mask] = 0.0
-    W[~mask] = 0.5 * (1.0 - np.cos(2.0 * np.pi * (R[~mask] + int(N / 2)) / N))
+    W[~mask] = 0.5 * (1.0 - np.cos(2.0 * np.pi * (R[~mask] + 0.5)))
 
     return W
 
 
 def _tukey(R, alpha):
     W = np.ones_like(R)
-    N = min(R.shape[0], R.shape[1])
 
-    mask1 = R < int(N / 2)
-    mask2 = R > int(N / 2) * (1.0 - alpha)
+    mask1 = R < 0.5
+    mask2 = R > 0.5 * (1.0 - alpha)
     mask = np.logical_and(mask1, mask2)
     W[mask] = 0.5 * (
-        1.0 + np.cos(np.pi * (R[mask] / (alpha * 0.5 * N) - 1.0 / alpha + 1.0))
+        1.0 + np.cos(np.pi * (R[mask] / (alpha * 0.5) - 1.0 / alpha + 1.0))
     )
-    mask = R >= int(N / 2)
+    mask = R >= 0.5
     W[mask] = 0.0
 
     return W


### PR DESCRIPTION
Fixes #451

This applies the 2 solutions proposed in the issue. For the error handling I choose a more pragmatic approach than the one I proposed in the issue.

I define the no_precip booleans based on the zero mask of the tapering method provided. This should be exactly what we want, because these booleans are intended to represent whether we can use the specified field for the noise generation right?

@RubenImhoff: can you verify that this will not have unintented side effects?