### PR TITLE
Fixes to linear and saliency based blending

### DIFF
--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.2
 Name: pysteps
-Version: 1.16.0
+Version: 1.17.0
 Summary: Python framework for short-term ensemble prediction systems
 Home-page: http://pypi.python.org/pypi/pysteps/
 License: LICENSE

--- a/pysteps/blending/linear_blending.py
+++ b/pysteps/blending/linear_blending.py
@@ -177,6 +177,17 @@ def forecast(
             precip_nwp.shape, precip_nowcast.shape
         )
 
+        # Ensure we are not working with nans in the bleding.
+        # Check if the NWP data contains any nans. If so, fill them with 0.0.
+        precip_nwp = np.nan_to_num(precip_nwp, nan=0.0)
+
+        # Fill nans in precip_nowcast
+        nan_indices = np.isnan(precip_nowcast)
+        if fill_nwp:
+            precip_nowcast[nan_indices] = precip_nwp[nan_indices]
+        else:
+            precip_nowcast[nan_indices] = 0.0
+
         # Initialise output
         precip_blended = np.zeros_like(precip_nowcast)
 
@@ -228,10 +239,6 @@ def forecast(
                         + weight_nowcast * precip_nowcast[slc_id]
                     )
 
-            # Find where the NaN values are and replace them with NWP data
-            if fill_nwp:
-                nan_indices = np.isnan(precip_blended)
-                precip_blended[nan_indices] = precip_nwp[nan_indices]
     else:
         # If no NWP data is given, the blended field is simply equal to the nowcast field
         precip_blended = precip_nowcast

--- a/pysteps/blending/linear_blending.py
+++ b/pysteps/blending/linear_blending.py
@@ -182,11 +182,11 @@ def forecast(
         precip_nwp = np.nan_to_num(precip_nwp, nan=0.0)
 
         # Fill nans in precip_nowcast
-        nan_indices = np.isnan(precip_nowcast)
+        nan_mask = np.isnan(precip_nowcast)
         if fill_nwp:
-            precip_nowcast[nan_indices] = precip_nwp[nan_indices]
+            precip_nowcast[nan_mask] = precip_nwp[nan_mask]
         else:
-            precip_nowcast[nan_indices] = 0.0
+            precip_nowcast[nan_mask] = 0.0
 
         # Initialise output
         precip_blended = np.zeros_like(precip_nowcast)

--- a/pysteps/blending/linear_blending.py
+++ b/pysteps/blending/linear_blending.py
@@ -105,6 +105,10 @@ def forecast(
     if nowcast_kwargs is None:
         nowcast_kwargs = dict()
 
+    # Ensure that only the most recent precip timestep is used
+    if len(precip.shape) == 3:
+        precip = precip[-1, :, :]
+
     # Calculate the nowcasts
     nowcast_method_func = nowcasts.get_method(nowcast_method)
     precip_nowcast = nowcast_method_func(

--- a/pysteps/tests/test_blending_linear_blending.py
+++ b/pysteps/tests/test_blending_linear_blending.py
@@ -8,33 +8,155 @@ from pysteps.utils import transformation
 
 # Test function arguments
 linear_arg_values = [
-    (5, 30, 60, 20, 45, "eulerian", None, 1, False, True),
-    (5, 30, 60, 20, 45, "eulerian", None, 2, False, False),
-    (5, 30, 60, 20, 45, "eulerian", None, 0, False, False),
-    (4, 23, 33, 9, 28, "eulerian", None, 1, False, False),
-    (3, 18, 36, 13, 27, "eulerian", None, 1, False, False),
-    (7, 30, 68, 11, 49, "eulerian", None, 1, False, False),
-    (10, 100, 160, 25, 130, "eulerian", None, 1, False, False),
-    (6, 60, 180, 22, 120, "eulerian", None, 1, False, False),
-    (5, 100, 200, 40, 150, "eulerian", None, 1, False, False),
-    (5, 30, 60, 20, 45, "extrapolation", np.zeros((2, 200, 200)), 1, False, False),
-    (4, 23, 33, 9, 28, "extrapolation", np.zeros((2, 200, 200)), 1, False, False),
-    (3, 18, 36, 13, 27, "extrapolation", np.zeros((2, 200, 200)), 1, False, False),
-    (7, 30, 68, 11, 49, "extrapolation", np.zeros((2, 200, 200)), 1, False, False),
-    (10, 100, 160, 25, 130, "extrapolation", np.zeros((2, 200, 200)), 1, False, False),
-    (6, 60, 180, 22, 120, "extrapolation", np.zeros((2, 200, 200)), 1, False, False),
-    (5, 100, 200, 40, 150, "extrapolation", np.zeros((2, 200, 200)), 1, False, False),
-    (5, 30, 60, 20, 45, "eulerian", None, 1, True, True),
-    (5, 30, 60, 20, 45, "eulerian", None, 2, True, False),
-    (5, 30, 60, 20, 45, "eulerian", None, 0, True, False),
-    (5, 30, 60, 20, 45, "extrapolation", np.zeros((2, 200, 200)), 1, True, False),
-    (4, 23, 33, 9, 28, "extrapolation", np.zeros((2, 200, 200)), 1, True, False),
-    (3, 18, 36, 13, 27, "extrapolation", np.zeros((2, 200, 200)), 1, True, False),
+    (5, 30, 60, 20, 45, "eulerian", None, 1, False, True, False),
+    (5, 30, 60, 20, 45, "eulerian", None, 2, False, False, False),
+    (5, 30, 60, 20, 45, "eulerian", None, 0, False, False, False),
+    (4, 23, 33, 9, 28, "eulerian", None, 1, False, False, False),
+    (3, 18, 36, 13, 27, "eulerian", None, 1, False, False, False),
+    (7, 30, 68, 11, 49, "eulerian", None, 1, False, False, False),
+    (7, 30, 68, 11, 49, "eulerian", None, 1, False, False, True),
+    (10, 100, 160, 25, 130, "eulerian", None, 1, False, False, False),
+    (6, 60, 180, 22, 120, "eulerian", None, 1, False, False, False),
+    (5, 100, 200, 40, 150, "eulerian", None, 1, False, False, False),
+    (
+        5,
+        30,
+        60,
+        20,
+        45,
+        "extrapolation",
+        np.zeros((2, 200, 200)),
+        1,
+        False,
+        False,
+        False,
+    ),
+    (
+        4,
+        23,
+        33,
+        9,
+        28,
+        "extrapolation",
+        np.zeros((2, 200, 200)),
+        1,
+        False,
+        False,
+        False,
+    ),
+    (
+        3,
+        18,
+        36,
+        13,
+        27,
+        "extrapolation",
+        np.zeros((2, 200, 200)),
+        1,
+        False,
+        False,
+        False,
+    ),
+    (
+        7,
+        30,
+        68,
+        11,
+        49,
+        "extrapolation",
+        np.zeros((2, 200, 200)),
+        1,
+        False,
+        False,
+        False,
+    ),
+    (
+        10,
+        100,
+        160,
+        25,
+        130,
+        "extrapolation",
+        np.zeros((2, 200, 200)),
+        1,
+        False,
+        False,
+        False,
+    ),
+    (
+        6,
+        60,
+        180,
+        22,
+        120,
+        "extrapolation",
+        np.zeros((2, 200, 200)),
+        1,
+        False,
+        False,
+        False,
+    ),
+    (
+        5,
+        100,
+        200,
+        40,
+        150,
+        "extrapolation",
+        np.zeros((2, 200, 200)),
+        1,
+        False,
+        False,
+        False,
+    ),
+    (
+        5,
+        100,
+        200,
+        40,
+        150,
+        "extrapolation",
+        np.zeros((2, 200, 200)),
+        1,
+        False,
+        False,
+        True,
+    ),
+    (5, 30, 60, 20, 45, "eulerian", None, 1, True, True, False),
+    (5, 30, 60, 20, 45, "eulerian", None, 2, True, False, False),
+    (5, 30, 60, 20, 45, "eulerian", None, 0, True, False, False),
+    (
+        5,
+        30,
+        60,
+        20,
+        45,
+        "extrapolation",
+        np.zeros((2, 200, 200)),
+        1,
+        True,
+        False,
+        False,
+    ),
+    (4, 23, 33, 9, 28, "extrapolation", np.zeros((2, 200, 200)), 1, True, False, False),
+    (
+        3,
+        18,
+        36,
+        13,
+        27,
+        "extrapolation",
+        np.zeros((2, 200, 200)),
+        1,
+        True,
+        False,
+        False,
+    ),
 ]
 
 
 @pytest.mark.parametrize(
-    "timestep, start_blending, end_blending, n_timesteps, controltime, nowcast_method, V, n_models, salient_blending, squeeze_nwp_array",
+    "timestep, start_blending, end_blending, n_timesteps, controltime, nowcast_method, V, n_models, salient_blending, squeeze_nwp_array, fill_nwp",
     linear_arg_values,
 )
 def test_linear_blending(
@@ -48,6 +170,7 @@ def test_linear_blending(
     n_models,
     salient_blending,
     squeeze_nwp_array,
+    fill_nwp,
 ):
     """Tests if the linear blending function is correct. For the nowcast data a precipitation field
     which is constant over time is taken. One half of the field has no rain and the other half
@@ -89,11 +212,15 @@ def test_linear_blending(
         if squeeze_nwp_array:
             r_nwp = np.squeeze(r_nwp)
 
-    # Define nowcast input data
-    r_input = np.zeros((200, 200))
-
-    for i in range(100, 200):
-        r_input[i, :] = 11.0
+    # Define nowcast input data (alternate between 2D and 3D arrays for testing)
+    if timestep % 2 == 0:
+        r_input = np.zeros((4, 200, 200))
+        for i in range(100, 200):
+            r_input[:, i, :] = 11.0
+    else:
+        r_input = np.zeros((200, 200))
+        for i in range(100, 200):
+            r_input[i, :] = 11.0
 
     # Transform from mm/h to dB
     r_input, _ = transformation.dB_transform(
@@ -112,6 +239,7 @@ def test_linear_blending(
         dict({"unit": "mm/h", "transform": None}),
         start_blending=start_blending,
         end_blending=end_blending,
+        fill_nwp=fill_nwp,
         saliency=salient_blending,
     )
 

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ requirements = [
 
 setup(
     name="pysteps",
-    version="1.16.0",
+    version="1.17.0",
     author="PySteps developers",
     packages=find_packages(),
     license="LICENSE",


### PR DESCRIPTION
Fixes #467 

PR to ensure that linear blending method can also handle multiple timesteps in the `precip` input variable, and to ensure that saliency-based blending works well when there are nans in the forecast.

- [x] Ensure linear blending can also handle multiple input timesteps.
- [x] Ensure that saliency-based blending works well when there are nans in the forecast. See the figure below from our Gallery, where it becomes clear that the saliency-based blending at +80 min becomes directly the same as NWP, while that is not warranted, as this is the time where the saliency-based blending should have just started. This seems to be caused by nans following from the `_get_ranked_salience` function.
- [x] Add tests (if needed).


![image](https://github.com/user-attachments/assets/847fd1bf-064b-4a18-9bc6-f082caa2c54c)
