### PR TITLE
Add importer for DWD radar data products and reprojection onto a regular grid as part of #464

### DIFF
--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -1656,6 +1656,13 @@ def import_dwd_hdf5(filename, qty="RATE", **kwargs):
             "but it is not installed"
         )
 
+    if not PYPROJ_IMPORTED:
+        raise MissingOptionalDependency(
+            "pyproj package is required to import "
+            "DWD's radar reflectivity composite "
+            "but it is not installed"
+        )
+
     if qty not in ["ACRR", "DBZH", "RATE"]:
         raise ValueError(
             "unknown quantity %s: the available options are 'ACRR', 'DBZH' and 'RATE'"
@@ -1740,11 +1747,13 @@ def import_dwd_hdf5(filename, qty="RATE", **kwargs):
         transform = None
 
     startdate = datetime.datetime.strptime(
-        f"{file_content['dataset1']['what']['startdate']}{file_content['dataset1']['what']['starttime']}",
+        file_content["dataset1"]["what"]["startdate"]
+        + file_content["dataset1"]["what"]["starttime"],
         "%Y%m%d%H%M%S",
     )
     enddate = datetime.datetime.strptime(
-        f"{file_content['dataset1']['what']['enddate']}{file_content['dataset1']['what']['endtime']}",
+        file_content["dataset1"]["what"]["enddate"]
+        + file_content["dataset1"]["what"]["endtime"],
         "%Y%m%d%H%M%S",
     )
     accutime = (enddate - startdate).total_seconds() / 60.0
@@ -1762,7 +1771,7 @@ def import_dwd_hdf5(filename, qty="RATE", **kwargs):
         "xpixelsize": xpixelsize,
         "ypixelsize": ypixelsize,
         "cartesian_unit": "m",
-        "yorigin": "lower",
+        "yorigin": "upper",
         "institution": file_content["what"]["source"],
         "accutime": accutime,
         "unit": unit,
@@ -1962,7 +1971,7 @@ def _import_dwd_geodata(product, dims):
     geodata["xpixelsize"] = 1000.0
     geodata["ypixelsize"] = 1000.0
     geodata["cartesian_unit"] = "m"
-    geodata["yorigin"] = "lower"
+    geodata["yorigin"] = "upper"
 
     prod_cat1 = ["RX", "RY", "RW"]  # 900x900
     prod_cat2 = ["WN"]  # 1200x1100

--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -195,7 +195,10 @@ def _get_grib_projection(grib_msg):
     _grib_shapes_of_earth[4] = {"ellps": "GRS80"}
     _grib_shapes_of_earth[5] = {"ellps": "WGS84"}
     _grib_shapes_of_earth[6] = {"R": 6371229}
-    _grib_shapes_of_earth[8] = {"datum": "WGS84", "R": 6371200}
+    _grib_shapes_of_earth[8] = {
+        "datum": "WGS84",
+        "R": 6371200,
+    }
     _grib_shapes_of_earth[9] = {"datum": "OSGB36"}
 
     # pygrib defines the ellipsoids using "a" and "b" only.
@@ -358,7 +361,10 @@ def import_mrms_grib(filename, extent=None, window_size=4, **kwargs):
         lons = block_reduce(lons, window_size[1])
 
         # Update the limits
-        ul_lat, lr_lat = lats[0], lats[-1]  # Lat from North to south!
+        ul_lat, lr_lat = (
+            lats[0],
+            lats[-1],
+        )  # Lat from North to south!
         ul_lon, lr_lon = lons[0], lons[-1]
 
         precip[no_data_mask] = 0  # block_reduce does not handle nan values
@@ -367,7 +373,9 @@ def import_mrms_grib(filename, extent=None, window_size=4, **kwargs):
         # Consider that if a single invalid observation is located in the block,
         # then mark that value as invalid.
         no_data_mask = block_reduce(
-            no_data_mask.astype("int"), window_size, axis=(0, 1)
+            no_data_mask.astype("int"),
+            window_size,
+            axis=(0, 1),
         ).astype(bool)
 
     lons, lats = np.meshgrid(lons, lats)
@@ -376,11 +384,15 @@ def import_mrms_grib(filename, extent=None, window_size=4, **kwargs):
     if extent is not None:
         # clip domain
         ul_lon, lr_lon = _check_coords_range(
-            (extent[0], extent[1]), "longitude", (ul_lon, lr_lon)
+            (extent[0], extent[1]),
+            "longitude",
+            (ul_lon, lr_lon),
         )
 
         lr_lat, ul_lat = _check_coords_range(
-            (extent[2], extent[3]), "latitude", (ul_lat, lr_lat)
+            (extent[2], extent[3]),
+            "latitude",
+            (ul_lat, lr_lat),
         )
 
         mask_lat = (lats >= lr_lat) & (lats <= ul_lat)
@@ -747,7 +759,13 @@ def _import_fmi_pgm_metadata(filename, gzipped=False):
 
 
 @postprocess_import()
-def import_knmi_hdf5(filename, qty="ACRR", accutime=5.0, pixelsize=1000.0, **kwargs):
+def import_knmi_hdf5(
+    filename,
+    qty="ACRR",
+    accutime=5.0,
+    pixelsize=1000.0,
+    **kwargs,
+):
     """
     Import a precipitation or reflectivity field (and optionally the quality
     field) from a HDF5 file conforming to the KNMI Data Centre specification.
@@ -814,7 +832,9 @@ def import_knmi_hdf5(filename, qty="ACRR", accutime=5.0, pixelsize=1000.0, **kwa
     # the no data value. The precision of the data is two decimals (0.01 mm).
     if qty == "ACRR":
         precip = np.where(
-            precip_intermediate == 65535, np.nan, precip_intermediate / 100.0
+            precip_intermediate == 65535,
+            np.nan,
+            precip_intermediate / 100.0,
         )
 
     # In case reflectivities are imported, the no data value is 255. Values are
@@ -822,7 +842,9 @@ def import_knmi_hdf5(filename, qty="ACRR", accutime=5.0, pixelsize=1000.0, **kwa
     # as: dBZ = 0.5 * pixel_value - 32.0 (this used to be 31.5).
     if qty == "DBZH":
         precip = np.where(
-            precip_intermediate == 255, np.nan, precip_intermediate * 0.5 - 32.0
+            precip_intermediate == 255,
+            np.nan,
+            precip_intermediate * 0.5 - 32.0,
         )
 
     if precip is None:
@@ -952,14 +974,21 @@ def import_mch_gif(filename, product, unit, accutime, **kwargs):
         # load lookup table
         if product.lower() == "azc":
             lut_filename = os.path.join(
-                os.path.dirname(__file__), "mch_lut_8bit_Metranet_AZC_V104.txt"
+                os.path.dirname(__file__),
+                "mch_lut_8bit_Metranet_AZC_V104.txt",
             )
         else:
             lut_filename = os.path.join(
-                os.path.dirname(__file__), "mch_lut_8bit_Metranet_v103.txt"
+                os.path.dirname(__file__),
+                "mch_lut_8bit_Metranet_v103.txt",
             )
         lut = np.genfromtxt(lut_filename, skip_header=1)
-        lut = dict(zip(zip(lut[:, 1], lut[:, 2], lut[:, 3]), lut[:, -1]))
+        lut = dict(
+            zip(
+                zip(lut[:, 1], lut[:, 2], lut[:, 3]),
+                lut[:, -1],
+            )
+        )
 
         # apply lookup table conversion
         precip = np.zeros(len(img_rgb.getdata()))
@@ -975,7 +1004,12 @@ def import_mch_gif(filename, product, unit, accutime, **kwargs):
         precip[precip < 0] = 0
         precip[precip > 9999] = np.nan
 
-    elif product.lower() in ["aqc", "cpc", "acquire ", "combiprecip"]:
+    elif product.lower() in [
+        "aqc",
+        "cpc",
+        "acquire ",
+        "combiprecip",
+    ]:
         # convert digital numbers to physical values
         img = np.array(img).astype(int)
 
@@ -1309,9 +1343,13 @@ def import_odim_hdf5(filename, qty="RATE", **kwargs):
             if "what" in list(dsg[1].keys()):
                 if "quantity" in dsg[1]["what"].attrs.keys():
                     try:
-                        qty_, gain, offset, nodata, undetect = (
-                            _read_opera_hdf5_what_group(dsg[1]["what"])
-                        )
+                        (
+                            qty_,
+                            gain,
+                            offset,
+                            nodata,
+                            undetect,
+                        ) = _read_opera_hdf5_what_group(dsg[1]["what"])
                         what_grp_found = True
                     except KeyError:
                         pass
@@ -1535,11 +1573,19 @@ def import_saf_crri(filename, extent=None, **kwargs):
 
     if extent:
         xcoord = (
-            np.arange(metadata["x1"], metadata["x2"], metadata["xpixelsize"])
+            np.arange(
+                metadata["x1"],
+                metadata["x2"],
+                metadata["xpixelsize"],
+            )
             + metadata["xpixelsize"] / 2
         )
         ycoord = (
-            np.arange(metadata["y1"], metadata["y2"], metadata["ypixelsize"])
+            np.arange(
+                metadata["y1"],
+                metadata["y2"],
+                metadata["ypixelsize"],
+            )
             + metadata["ypixelsize"] / 2
         )
         ycoord = ycoord[::-1]  # yorigin = "upper"
@@ -1643,11 +1689,27 @@ def import_dwd_hdf5(filename, qty="RATE", **kwargs):
 
     Returns
     -------
-    out: tuple
-        A three-element tuple containing the DWD preciptiaton product with the
-        requested quantity and the associated quality field and metadata. The
-        quality field is read from the file if it contains a dataset whose
-        quantity identifier is 'QIND'.
+    tuple
+        A tuple containing:
+        - data : np.ndarray
+            The requested precipitation product imported from a HDF5 file
+        - quality : None
+        - metadata : dict
+            Dictionary containing geospatial metadata such as:
+            - 'projection': PROJ.4 string defining the stereographic projection.
+            - 'll_lon', 'll_lat': Coordinates of the lower-left corner.
+            - 'ur_lon', 'ur_lat': Coordinates of the upper-right corner.
+            - 'x1', 'y1': Carthesian coordinates of the lower-left corner.
+            - 'x2', 'y2': Carthesian coordinates of the upper-right corner.
+            - 'xpixelsize', 'ypixelsize': Pixel size in meters.
+            - 'cartesian_unit': Unit of the coordinate system (meters).
+            - 'yorigin': Origin of the y-axis ('lower').
+            - 'institution': Originating institution ('DWD' or 'DWD Radolan')
+            - 'accutime': Accumulation period of the requested precipitation product
+            - 'unit': Unit.
+            - 'transform': Logarithmic transformation.
+            - 'zerovalue': No echo value.
+            - 'threshold': Precipitation threshold.
     """
     if not H5PY_IMPORTED:
         raise MissingOptionalDependency(
@@ -1668,32 +1730,39 @@ def import_dwd_hdf5(filename, qty="RATE", **kwargs):
             "unknown quantity %s: the available options are 'ACRR', 'DBZH' and 'RATE'"
         )
 
-    # Read the data
+    # Open file
     f = h5py.File(filename, "r")
     precip = None
     quality = None
 
+    # Read data recursively
     file_content = {}
     _read_hdf5_cont(f, file_content)
     f.close()
 
+    # Read attributes
     data_prop = {}
     _get_whatgrp(file_content, data_prop)
 
+    # Get data as well as no data and no echo masks
     arr = file_content["dataset1"]["data1"]["data"]
     mask_n = arr == data_prop["nodata"]
     mask_u = arr == data_prop["undetect"]
     mask = np.logical_and(~mask_u, ~mask_n)
 
-    # Read the precipitation variable and quantity from the data
+    # If the requested quantity in the file
+    # Transform precipitation data by gain and offset
     if data_prop["quantity"] == qty:
         precip = np.empty(arr.shape)
         precip[mask] = arr[mask] * data_prop["gain"] + data_prop["offset"]
         if qty != "DBZH":
             precip[mask_u] = data_prop["offset"]
         else:
+            # Set the no echo value manually to -32.5
+            # if the file contains horizontal reflectivity
             precip[mask_u] = -32.5
         precip[mask_n] = np.nan
+    # Get possible information about data quality
     elif data_prop["quantity"] == "QIND":
         quality = np.empty(arr.shape, dtype=float)
         quality[mask] = arr[mask]
@@ -1704,15 +1773,24 @@ def import_dwd_hdf5(filename, qty="RATE", **kwargs):
 
     # Get the projection and grid information from the HDF5 file
     pr = pyproj.Proj(file_content["where"]["projdef"])
-    ll_x, ll_y = pr(file_content["where"]["LL_lon"], file_content["where"]["LL_lat"])
-    ur_x, ur_y = pr(file_content["where"]["UR_lon"], file_content["where"]["UR_lat"])
+    ll_x, ll_y = pr(
+        file_content["where"]["LL_lon"],
+        file_content["where"]["LL_lat"],
+    )
+    ur_x, ur_y = pr(
+        file_content["where"]["UR_lon"],
+        file_content["where"]["UR_lat"],
+    )
 
+    # Determine domain corners in geographic and carthesian coordinates
     if len([k for k in file_content["where"].keys() if "_lat" in k]) == 4:
         lr_x, lr_y = pr(
-            file_content["where"]["LR_lon"], file_content["where"]["LR_lat"]
+            file_content["where"]["LR_lon"],
+            file_content["where"]["LR_lat"],
         )
         ul_x, ul_y = pr(
-            file_content["where"]["UL_lon"], file_content["where"]["UL_lat"]
+            file_content["where"]["UL_lon"],
+            file_content["where"]["UL_lat"],
         )
         x1 = min(ll_x, ul_x)
         y1 = min(ll_y, lr_y)
@@ -1808,7 +1886,7 @@ def _read_hdf5_cont(f, d):
     --------
     None.
     """
-    # set simple types of hdf content
+    # Set simple types of hdf content
     group_type = h5py._hl.group.Group
 
     for key, value in f.items():
@@ -1821,24 +1899,39 @@ def _read_hdf5_cont(f, d):
                 # Handle empty group with attributes
                 d[key] = {attr: value.attrs[attr] for attr in value.attrs}
                 d[key] = {
-                    k: v.decode() if type(v) == np.bytes_ else v
+                    k: (v.decode() if type(v) == np.bytes_ else v)
                     for k, v in d[key].items()
                 }
 
         else:
-            try:
-                d[key] = np.array(value)
-            except TypeError:
-                d[key] = np.array(value.astype(float))
+
+            # Save h5py.Dataset by group name
+            d[key] = np.array(value)
 
     return
 
 
 def _get_whatgrp(d, g):
     """
-    Recursively get the what group containing the data field properties.
+    Recursively get attributes of the what group containing
+    the scaling properties.
+
+    Parameters:
+    -----------
+    d : dict
+        Dictionary including content of an ODIM compliant
+        HDF5 file.
+    g : dict
+        Dictionary containing attributes of what group.
+
+
+    Returns:
+    --------
+    None.
     """
     if "what" in d.keys():
+        # Searching for the corresponding what group
+        # that contains the scaling properties
         if "gain" in d["what"].keys():
             g.update(d["what"])
         else:
@@ -1872,33 +1965,42 @@ def import_dwd_radolan(filename, product_name):
 
     Returns
     -------
-    out: tuple
-        A three-element tuple containing the precipitation field in mm/h imported
-        from a MeteoSwiss gif file and the associated quality field and metadata.
-        The quality field is currently set to None.
+    tuple
+        A tuple containing:
+        - data : np.ndarray
+            The desired precipitation product in mm/h imported from a RADOLAN file
+        - quality : None
+        - metadata : dict
+            Dictionary containing geospatial metadata such as:
+            - 'projection': PROJ.4 string defining the stereographic projection.
+            - 'xpixelsize', 'ypixelsize': Pixel size in meters.
+            - 'cartesian_unit': Unit of the coordinate system (meters).
+            - 'yorigin': Origin of the y-axis ('upper').
+            - 'x1', 'y1': Coordinates of the lower-left corner.
+            - 'x2', 'y2': Coordinates of the upper-right corner.
     """
     # Determine file size and header size
     size_file = os.path.getsize(filename)
     size_data = np.round(size_file, -3)
     size_header = size_file - size_data
 
-    # open file and read header
+    # Open file and read header
     f = open(filename, "rb")
     header = f.read(size_header).decode("utf-8")
 
-    # get product name from header
+    # Get product name from header
     product = header[:2]
 
-    # check if its the correct product
+    # Check if its the desired product
     assert product == product_name, "Product not in File!"
 
-    # distinguish between products saved with 8 or 16bit
+    # Distinguish between products saved with 8 or 16bit
     product_cat1 = np.array(["WX", "RX"])
     product_cat2 = np.array(["RY", "RW", "YW"])
 
     # Determine byte size and data type
-    nbyte = 1 if prod in prod_cat1 else 2
-    signed = "B" if prod in prod_cat1 else "H"
+    nbyte = 1 if product in product_cat1 else 2
+    signed = "B" if product in product_cat1 else "H"
 
     # Extract the scaling factor and grid dimensions
     fac = int(header.split("E-")[1].split("INT")[0])
@@ -1914,7 +2016,7 @@ def import_dwd_radolan(filename, product_name):
     data = np.array(np.reshape(data, dims, order="F"), dtype=float).T
 
     # Define no-echo values based on product type
-    if prod == "SF":
+    if product == "SF":
         no_echo_value = 0.0
     elif product in product_cat2:
         no_echo_value = -0.01
@@ -1939,7 +2041,6 @@ def import_dwd_radolan(filename, product_name):
     data[no_data_mask] = np.nan
 
     # Load geospatial metadata
-    # get geo data
     geodata = _import_dwd_geodata(product_name, dims)
     metadata = geodata
 
@@ -1951,10 +2052,10 @@ def _identify_info_bits(data):
     Identifies and processes information bits embedded in RADOLAN data values.
 
     This function decodes metadata flags embedded in the RADOLAN data array, such as:
-    - Clutter (bit 15)
-    - Negative values (bit 14)
-    - No data (bit 13)
-    - Secondary data (bit 12)
+    - Clutter (bit 16)
+    - Negative values (bit 15)
+    - No data (bit 14)
+    - Secondary data (bit 13)
 
     Parameters
     ----------
@@ -1970,21 +2071,21 @@ def _identify_info_bits(data):
         - no_data_mask : np.ndarray
             A boolean mask indicating positions of no-data values.
     """
-    # Identify and remove clutter (bit 15)
+    # Identify and remove clutter (bit 16)
     clutter_mask = data - 2**15 >= 0.0
     data[clutter_mask] = 0
 
-    # Identify and convert negative values (bit 14)
+    # Identify and convert negative values (bit 15)
     mask = data - 2**14 >= 0.0
     data[mask] -= 2**14
 
-    # Identify no-data values (bit 13)
+    # Identify no-data values (bit 14)
     no_data_mask = data - 2**13 == 2500.0
     if np.sum(no_data_mask) == 0.0:
         no_data_mask = data - 2**13 == 0.0
     data[no_data_mask] = 0.0
 
-    # Identify and remove secondary data flag (bit 12)
+    # Identify and remove secondary data flag (bit 13)
     data[data - 2**12 > 0.0] -= 2**12
 
     # Apply negative sign to previously marked negative values
@@ -2033,17 +2134,17 @@ def _import_dwd_geodata(product_name, dims):
     geodata["cartesian_unit"] = "m"
     geodata["yorigin"] = "upper"
 
-    # Define product categories and their reference points
-    prod_cat1 = ["RX", "RY", "RW"]
-    prod_cat2 = ["WN"]
-    prod_cat3 = ["WX", "YW"]
+    # Define product categories
+    product_cat1 = ["RX", "RY", "RW"]
+    product_cat2 = ["WN"]
+    product_cat3 = ["WX", "YW"]
 
     # Assign reference coordinates based on product type
-    if product in prod_cat1:
+    if product_name in product_cat1:
         lon, lat = 3.604382995, 46.95361536
-    elif product in prod_cat2:
+    elif product_name in product_cat2:
         lon, lat = 3.566994635, 45.69642538
-    elif product in prod_cat3:
+    elif product_name in product_cat3:
         lon, lat = 9.0, 51.0
 
     # Project reference coordinates to Cartesian system

--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -161,7 +161,9 @@ def _check_coords_range(selected_range, coordinate, full_range):
 
     if not isinstance(selected_range, (list, tuple)):
         if len(selected_range) != 2:
-            raise ValueError(f"The {coordinate} range must be None or a two-element tuple or list")
+            raise ValueError(
+                f"The {coordinate} range must be None or a two-element tuple or list"
+            )
 
         selected_range = list(selected_range)  # Make mutable
 
@@ -807,11 +809,15 @@ def import_knmi_hdf5(
 
     if not H5PY_IMPORTED:
         raise MissingOptionalDependency(
-            "h5py package is required to import " "KNMI's radar datasets " "but it is not installed"
+            "h5py package is required to import "
+            "KNMI's radar datasets "
+            "but it is not installed"
         )
 
     if qty not in ["ACRR", "DBZH"]:
-        raise ValueError("unknown quantity %s: the available options are 'ACRR' and 'DBZH' ")
+        raise ValueError(
+            "unknown quantity %s: the available options are 'ACRR' and 'DBZH' "
+        )
 
     ####
     # Precipitation fields
@@ -1072,7 +1078,9 @@ def import_mch_hdf5(filename, qty="RATE", **kwargs):
         )
 
     if qty not in ["ACRR", "DBZH", "RATE"]:
-        raise ValueError("unknown quantity %s: the available options are 'ACRR', 'DBZH' and 'RATE'")
+        raise ValueError(
+            "unknown quantity %s: the available options are 'ACRR', 'DBZH' and 'RATE'"
+        )
 
     f = h5py.File(filename, "r")
 
@@ -1084,7 +1092,9 @@ def import_mch_hdf5(filename, qty="RATE", **kwargs):
             what_grp_found = False
             # check if the "what" group is in the "dataset" group
             if "what" in list(dsg[1].keys()):
-                qty_, gain, offset, nodata, undetect = _read_mch_hdf5_what_group(dsg[1]["what"])
+                qty_, gain, offset, nodata, undetect = _read_mch_hdf5_what_group(
+                    dsg[1]["what"]
+                )
                 what_grp_found = True
 
             for dg in dsg[1].items():
@@ -1317,7 +1327,9 @@ def import_odim_hdf5(filename, qty="RATE", **kwargs):
         )
 
     if qty not in ["ACRR", "DBZH", "RATE"]:
-        raise ValueError("unknown quantity %s: the available options are 'ACRR', 'DBZH' and 'RATE'")
+        raise ValueError(
+            "unknown quantity %s: the available options are 'ACRR', 'DBZH' and 'RATE'"
+        )
 
     f = h5py.File(filename, "r")
 
@@ -1379,7 +1391,9 @@ def import_odim_hdf5(filename, qty="RATE", **kwargs):
                             quality[mask] = arr[mask]
                             quality[~mask] = np.nan
                     if quality is None:
-                        for dgg in dg[1].items():  # da qui  ----------------------------
+                        for dgg in dg[
+                            1
+                        ].items():  # da qui  ----------------------------
                             if dgg[0][0:7] == "quality":
                                 quality_keys = list(dgg[1].keys())
                                 if "what" in quality_keys:
@@ -1397,7 +1411,9 @@ def import_odim_hdf5(filename, qty="RATE", **kwargs):
                                     mask = np.logical_and(~mask_u, ~mask_n)
                                     quality = np.empty(arr.shape)  # , dtype=float)
                                     quality[mask] = arr[mask] * gain + offset
-                                    quality[~mask] = np.nan  # a qui -----------------------------
+                                    quality[~mask] = (
+                                        np.nan
+                                    )  # a qui -----------------------------
 
     if precip is None:
         raise IOError("requested quantity %s not found" % qty)
@@ -1448,7 +1464,10 @@ def import_odim_hdf5(filename, qty="RATE", **kwargs):
     if "xscale" in where.attrs.keys() and "yscale" in where.attrs.keys():
         xpixelsize = where.attrs["xscale"]
         ypixelsize = where.attrs["yscale"]
-    elif "xscale" in dataset1["where"].attrs.keys() and "yscale" in dataset1["where"].attrs.keys():
+    elif (
+        "xscale" in dataset1["where"].attrs.keys()
+        and "yscale" in dataset1["where"].attrs.keys()
+    ):
         where = dataset1["where"]
         xpixelsize = where.attrs["xscale"]
         ypixelsize = where.attrs["yscale"]
@@ -1545,7 +1564,8 @@ def import_saf_crri(filename, extent=None, **kwargs):
     """
     if not NETCDF4_IMPORTED:
         raise MissingOptionalDependency(
-            "netCDF4 package is required to import CRRI SAF products " "but it is not installed"
+            "netCDF4 package is required to import CRRI SAF products "
+            "but it is not installed"
         )
 
     geodata = _import_saf_crri_geodata(filename)
@@ -1706,7 +1726,9 @@ def import_dwd_hdf5(filename, qty="RATE", **kwargs):
         )
 
     if qty not in ["ACRR", "DBZH", "RATE"]:
-        raise ValueError("unknown quantity %s: the available options are 'ACRR', 'DBZH' and 'RATE'")
+        raise ValueError(
+            "unknown quantity %s: the available options are 'ACRR', 'DBZH' and 'RATE'"
+        )
 
     # Open file
     f = h5py.File(filename, "r")
@@ -1812,7 +1834,8 @@ def import_dwd_hdf5(filename, qty="RATE", **kwargs):
         "%Y%m%d%H%M%S",
     )
     enddate = datetime.datetime.strptime(
-        file_content["dataset1"]["what"]["enddate"] + file_content["dataset1"]["what"]["endtime"],
+        file_content["dataset1"]["what"]["enddate"]
+        + file_content["dataset1"]["what"]["endtime"],
         "%Y%m%d%H%M%S",
     )
     accutime = (enddate - startdate).total_seconds() / 60.0
@@ -1876,7 +1899,8 @@ def _read_hdf5_cont(f, d):
                 # Handle empty group with attributes
                 d[key] = {attr: value.attrs[attr] for attr in value.attrs}
                 d[key] = {
-                    k: (v.decode() if isinstance(v, np.bytes_) else v) for k, v in d[key].items()
+                    k: (v.decode() if isinstance(v, np.bytes_) else v)
+                    for k, v in d[key].items()
                 }
 
         else:

--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -161,9 +161,7 @@ def _check_coords_range(selected_range, coordinate, full_range):
 
     if not isinstance(selected_range, (list, tuple)):
         if len(selected_range) != 2:
-            raise ValueError(
-                f"The {coordinate} range must be None or a two-element tuple or list"
-            )
+            raise ValueError(f"The {coordinate} range must be None or a two-element tuple or list")
 
         selected_range = list(selected_range)  # Make mutable
 
@@ -809,15 +807,11 @@ def import_knmi_hdf5(
 
     if not H5PY_IMPORTED:
         raise MissingOptionalDependency(
-            "h5py package is required to import "
-            "KNMI's radar datasets "
-            "but it is not installed"
+            "h5py package is required to import " "KNMI's radar datasets " "but it is not installed"
         )
 
     if qty not in ["ACRR", "DBZH"]:
-        raise ValueError(
-            "unknown quantity %s: the available options are 'ACRR' and 'DBZH' "
-        )
+        raise ValueError("unknown quantity %s: the available options are 'ACRR' and 'DBZH' ")
 
     ####
     # Precipitation fields
@@ -1078,9 +1072,7 @@ def import_mch_hdf5(filename, qty="RATE", **kwargs):
         )
 
     if qty not in ["ACRR", "DBZH", "RATE"]:
-        raise ValueError(
-            "unknown quantity %s: the available options are 'ACRR', 'DBZH' and 'RATE'"
-        )
+        raise ValueError("unknown quantity %s: the available options are 'ACRR', 'DBZH' and 'RATE'")
 
     f = h5py.File(filename, "r")
 
@@ -1092,9 +1084,7 @@ def import_mch_hdf5(filename, qty="RATE", **kwargs):
             what_grp_found = False
             # check if the "what" group is in the "dataset" group
             if "what" in list(dsg[1].keys()):
-                qty_, gain, offset, nodata, undetect = _read_mch_hdf5_what_group(
-                    dsg[1]["what"]
-                )
+                qty_, gain, offset, nodata, undetect = _read_mch_hdf5_what_group(dsg[1]["what"])
                 what_grp_found = True
 
             for dg in dsg[1].items():
@@ -1327,9 +1317,7 @@ def import_odim_hdf5(filename, qty="RATE", **kwargs):
         )
 
     if qty not in ["ACRR", "DBZH", "RATE"]:
-        raise ValueError(
-            "unknown quantity %s: the available options are 'ACRR', 'DBZH' and 'RATE'"
-        )
+        raise ValueError("unknown quantity %s: the available options are 'ACRR', 'DBZH' and 'RATE'")
 
     f = h5py.File(filename, "r")
 
@@ -1391,9 +1379,7 @@ def import_odim_hdf5(filename, qty="RATE", **kwargs):
                             quality[mask] = arr[mask]
                             quality[~mask] = np.nan
                     if quality is None:
-                        for dgg in dg[
-                            1
-                        ].items():  # da qui  ----------------------------
+                        for dgg in dg[1].items():  # da qui  ----------------------------
                             if dgg[0][0:7] == "quality":
                                 quality_keys = list(dgg[1].keys())
                                 if "what" in quality_keys:
@@ -1411,9 +1397,7 @@ def import_odim_hdf5(filename, qty="RATE", **kwargs):
                                     mask = np.logical_and(~mask_u, ~mask_n)
                                     quality = np.empty(arr.shape)  # , dtype=float)
                                     quality[mask] = arr[mask] * gain + offset
-                                    quality[~mask] = (
-                                        np.nan
-                                    )  # a qui -----------------------------
+                                    quality[~mask] = np.nan  # a qui -----------------------------
 
     if precip is None:
         raise IOError("requested quantity %s not found" % qty)
@@ -1464,10 +1448,7 @@ def import_odim_hdf5(filename, qty="RATE", **kwargs):
     if "xscale" in where.attrs.keys() and "yscale" in where.attrs.keys():
         xpixelsize = where.attrs["xscale"]
         ypixelsize = where.attrs["yscale"]
-    elif (
-        "xscale" in dataset1["where"].attrs.keys()
-        and "yscale" in dataset1["where"].attrs.keys()
-    ):
+    elif "xscale" in dataset1["where"].attrs.keys() and "yscale" in dataset1["where"].attrs.keys():
         where = dataset1["where"]
         xpixelsize = where.attrs["xscale"]
         ypixelsize = where.attrs["yscale"]
@@ -1564,8 +1545,7 @@ def import_saf_crri(filename, extent=None, **kwargs):
     """
     if not NETCDF4_IMPORTED:
         raise MissingOptionalDependency(
-            "netCDF4 package is required to import CRRI SAF products "
-            "but it is not installed"
+            "netCDF4 package is required to import CRRI SAF products " "but it is not installed"
         )
 
     geodata = _import_saf_crri_geodata(filename)
@@ -1726,9 +1706,7 @@ def import_dwd_hdf5(filename, qty="RATE", **kwargs):
         )
 
     if qty not in ["ACRR", "DBZH", "RATE"]:
-        raise ValueError(
-            "unknown quantity %s: the available options are 'ACRR', 'DBZH' and 'RATE'"
-        )
+        raise ValueError("unknown quantity %s: the available options are 'ACRR', 'DBZH' and 'RATE'")
 
     # Open file
     f = h5py.File(filename, "r")
@@ -1834,8 +1812,7 @@ def import_dwd_hdf5(filename, qty="RATE", **kwargs):
         "%Y%m%d%H%M%S",
     )
     enddate = datetime.datetime.strptime(
-        file_content["dataset1"]["what"]["enddate"]
-        + file_content["dataset1"]["what"]["endtime"],
+        file_content["dataset1"]["what"]["enddate"] + file_content["dataset1"]["what"]["endtime"],
         "%Y%m%d%H%M%S",
     )
     accutime = (enddate - startdate).total_seconds() / 60.0
@@ -1899,8 +1876,7 @@ def _read_hdf5_cont(f, d):
                 # Handle empty group with attributes
                 d[key] = {attr: value.attrs[attr] for attr in value.attrs}
                 d[key] = {
-                    k: (v.decode() if type(v) == np.bytes_ else v)
-                    for k, v in d[key].items()
+                    k: (v.decode() if isinstance(v, np.bytes_) else v) for k, v in d[key].items()
                 }
 
         else:

--- a/pysteps/io/interface.py
+++ b/pysteps/io/interface.py
@@ -20,17 +20,17 @@ from pprint import pprint
 
 _importer_methods = dict(
     bom_rf3=importers.import_bom_rf3,
+    dwd_hdf5=importers.import_dwd_hdf5,
+    dwd_radolan=importers.import_dwd_radolan,
     fmi_geotiff=importers.import_fmi_geotiff,
     fmi_pgm=importers.import_fmi_pgm,
+    knmi_hdf5=importers.import_knmi_hdf5,
     mch_gif=importers.import_mch_gif,
     mch_hdf5=importers.import_mch_hdf5,
     mch_metranet=importers.import_mch_metranet,
     mrms_grib=importers.import_mrms_grib,
     odim_hdf5=importers.import_odim_hdf5,
     opera_hdf5=importers.import_opera_hdf5,
-    knmi_hdf5=importers.import_knmi_hdf5,
-    dwd_hdf5=importers.import_dwd_hdf5,
-    dwd_radolan=importers.import_dwd_radolan,
     saf_crri=importers.import_saf_crri,
 )
 
@@ -57,9 +57,7 @@ def discover_importers():
     # Backward compatibility with previous entry point 'pysteps.plugins.importers' next to 'pysteps.plugins.importer'
     for entry_point in list(
         pkg_resources.iter_entry_points(group="pysteps.plugins.importer", name=None)
-    ) + list(
-        pkg_resources.iter_entry_points(group="pysteps.plugins.importers", name=None)
-    ):
+    ) + list(pkg_resources.iter_entry_points(group="pysteps.plugins.importers", name=None)):
         _importer = entry_point.load()
 
         importer_function_name = _importer.__name__
@@ -90,25 +88,16 @@ def importers_info():
     """Print all the available importers."""
 
     # Importers available in the `io.importers` module
-    available_importers = [
-        attr for attr in dir(importers) if attr.startswith("import_")
-    ]
+    available_importers = [attr for attr in dir(importers) if attr.startswith("import_")]
 
     print("\nImporters available in the pysteps.io.importers module")
     pprint(available_importers)
 
     # Importers declared in the pysteps.io.get_method interface
-    importers_in_the_interface = [
-        f.__name__ for f in interface._importer_methods.values()
-    ]
+    importers_in_the_interface = [f.__name__ for f in interface._importer_methods.values()]
 
     print("\nImporters available in the pysteps.io.get_method interface")
-    pprint(
-        [
-            (short_name, f.__name__)
-            for short_name, f in interface._importer_methods.items()
-        ]
-    )
+    pprint([(short_name, f.__name__) for short_name, f in interface._importer_methods.items()])
 
     # Let's use sets to find out if there are importers present in the importer module
     # but not declared in the interface, and viceversa.

--- a/pysteps/io/interface.py
+++ b/pysteps/io/interface.py
@@ -29,6 +29,8 @@ _importer_methods = dict(
     odim_hdf5=importers.import_odim_hdf5,
     opera_hdf5=importers.import_opera_hdf5,
     knmi_hdf5=importers.import_knmi_hdf5,
+    dwd_hdf5=importers.import_dwd_hdf5,
+    dwd_radolan=importers.import_dwd_radolan,
     saf_crri=importers.import_saf_crri,
 )
 

--- a/pysteps/io/interface.py
+++ b/pysteps/io/interface.py
@@ -57,7 +57,9 @@ def discover_importers():
     # Backward compatibility with previous entry point 'pysteps.plugins.importers' next to 'pysteps.plugins.importer'
     for entry_point in list(
         pkg_resources.iter_entry_points(group="pysteps.plugins.importer", name=None)
-    ) + list(pkg_resources.iter_entry_points(group="pysteps.plugins.importers", name=None)):
+    ) + list(
+        pkg_resources.iter_entry_points(group="pysteps.plugins.importers", name=None)
+    ):
         _importer = entry_point.load()
 
         importer_function_name = _importer.__name__
@@ -88,16 +90,25 @@ def importers_info():
     """Print all the available importers."""
 
     # Importers available in the `io.importers` module
-    available_importers = [attr for attr in dir(importers) if attr.startswith("import_")]
+    available_importers = [
+        attr for attr in dir(importers) if attr.startswith("import_")
+    ]
 
     print("\nImporters available in the pysteps.io.importers module")
     pprint(available_importers)
 
     # Importers declared in the pysteps.io.get_method interface
-    importers_in_the_interface = [f.__name__ for f in interface._importer_methods.values()]
+    importers_in_the_interface = [
+        f.__name__ for f in interface._importer_methods.values()
+    ]
 
     print("\nImporters available in the pysteps.io.get_method interface")
-    pprint([(short_name, f.__name__) for short_name, f in interface._importer_methods.items()])
+    pprint(
+        [
+            (short_name, f.__name__)
+            for short_name, f in interface._importer_methods.items()
+        ]
+    )
 
     # Let's use sets to find out if there are importers present in the importer module
     # but not declared in the interface, and viceversa.

--- a/pysteps/pystepsrc
+++ b/pysteps/pystepsrc
@@ -25,7 +25,7 @@
             }
         },
         "dwd": {
-            "root_path": "./radar/dwd",
+            "root_path": "./radar/dwd/RY",
             "path_fmt": "%Y/%m/%d",
             "fn_pattern": "%Y%m%d_%H%M_RY",
             "fn_ext": "h5",

--- a/pysteps/pystepsrc
+++ b/pysteps/pystepsrc
@@ -110,6 +110,17 @@
                 "gzipped": true
             }
         },
+        "dwd": {
+            "root_path": "./radar/dwd",
+            "path_fmt": "%Y/%m/%d",
+            "fn_pattern": "%Y%m%d_%H%M_RY",
+            "fn_ext": "h5",
+            "importer": "dwd_hdf5",
+            "timestep": 5,
+            "importer_kwargs": {
+                "qty": "RATE"
+            }
+        },
         "bom_nwp": {
             "root_path": "./nwp/bom",
             "path_fmt": "%Y/%m/%d",
@@ -142,6 +153,19 @@
             "importer_kwargs": {
                 "gzipped": true
             }
+        },
+        "dwd_nwp": {
+            "root_path": "./nwp/dwd",
+            "path_fmt": "%Y/%m/%d",
+            "fn_ext": ".grib2",
+            "fn_pattern": "%Y%m%d_%H%M_PR_GSP_060_120",
+            "importer": "dwd_nwp",
+            "timestep": 5,
+            "importer_kwargs": {
+                "varname": "PR_GSP",
+                "grid_file_path": "./aux/grid_files/dwd/icon/R19B07/icon_grid_0047_R19B07_L.nc"
+            }
+            
         }
     }
 }

--- a/pysteps/pystepsrc
+++ b/pysteps/pystepsrc
@@ -24,6 +24,17 @@
                 "gzipped": true
             }
         },
+        "dwd": {
+            "root_path": "./radar/dwd",
+            "path_fmt": "%Y/%m/%d",
+            "fn_pattern": "%Y%m%d_%H%M_RY",
+            "fn_ext": "h5",
+            "importer": "dwd_hdf5",
+            "timestep": 5,
+            "importer_kwargs": {
+                "qty": "RATE"
+            }
+        },
         "fmi": {
             "root_path": "./radar/fmi/pgm",
             "path_fmt": "%Y%m%d",
@@ -110,17 +121,6 @@
                 "gzipped": true
             }
         },
-        "dwd": {
-            "root_path": "./radar/dwd",
-            "path_fmt": "%Y/%m/%d",
-            "fn_pattern": "%Y%m%d_%H%M_RY",
-            "fn_ext": "h5",
-            "importer": "dwd_hdf5",
-            "timestep": 5,
-            "importer_kwargs": {
-                "qty": "RATE"
-            }
-        },
         "bom_nwp": {
             "root_path": "./nwp/bom",
             "path_fmt": "%Y/%m/%d",
@@ -128,28 +128,6 @@
             "fn_ext": "nc",
             "importer": "bom_nwp",
             "timestep": 10,
-            "importer_kwargs": {
-                "gzipped": true
-            }
-        },
-        "rmi_nwp": {
-            "root_path": "./nwp/rmi",
-            "path_fmt": "%Y/%m/%d",
-            "fn_pattern": "ao13_%Y%m%d%H_native_5min",
-            "fn_ext": "nc",
-            "importer": "rmi_nwp",
-            "timestep": 5,
-            "importer_kwargs": {
-                "gzipped": true
-            }
-        },
-        "knmi_nwp": {
-            "root_path": "./nwp/knmi",
-            "path_fmt": "%Y/%m/%d",
-            "fn_pattern": "%Y%m%d_%H00_Pforecast_Harmonie",
-            "fn_ext": "nc",
-            "importer": "knmi_nwp",
-            "timestep": 60,
             "importer_kwargs": {
                 "gzipped": true
             }
@@ -166,6 +144,28 @@
                 "grid_file_path": "./aux/grid_files/dwd/icon/R19B07/icon_grid_0047_R19B07_L.nc"
             }
             
+        },
+        "knmi_nwp": {
+            "root_path": "./nwp/knmi",
+            "path_fmt": "%Y/%m/%d",
+            "fn_pattern": "%Y%m%d_%H00_Pforecast_Harmonie",
+            "fn_ext": "nc",
+            "importer": "knmi_nwp",
+            "timestep": 60,
+            "importer_kwargs": {
+                "gzipped": true
+            }
+        },
+        "rmi_nwp": {
+            "root_path": "./nwp/rmi",
+            "path_fmt": "%Y/%m/%d",
+            "fn_pattern": "ao13_%Y%m%d%H_native_5min",
+            "fn_ext": "nc",
+            "importer": "rmi_nwp",
+            "timestep": 5,
+            "importer_kwargs": {
+                "gzipped": true
+            }
         }
     }
 }

--- a/pysteps/tests/helpers.py
+++ b/pysteps/tests/helpers.py
@@ -19,6 +19,7 @@ _reference_dates["bom"] = datetime(2018, 6, 16, 10, 0)
 _reference_dates["fmi"] = datetime(2016, 9, 28, 16, 0)
 _reference_dates["knmi"] = datetime(2010, 8, 26, 0, 0)
 _reference_dates["mch"] = datetime(2015, 5, 15, 16, 30)
+_reference_dates["dwd"] = datetime(2025, 6, 4, 17, 0)
 _reference_dates["opera"] = datetime(2018, 8, 24, 18, 0)
 _reference_dates["saf"] = datetime(2018, 6, 1, 7, 0)
 _reference_dates["mrms"] = datetime(2019, 6, 10, 0, 0)
@@ -49,6 +50,9 @@ def get_precipitation_fields(
 
     Source: mch
     Reference time: 2015/05/15 1630 UTC
+
+    Source: dwd
+    Reference time: 2025/06/04 1700 UTC
 
     Source: opera
     Reference time: 2018/08/24 1800 UTC
@@ -117,6 +121,9 @@ def get_precipitation_fields(
 
     if source == "mch":
         pytest.importorskip("PIL")
+
+    if source == "dwd":
+        pytest.importorskip("h5py")
 
     if source == "opera":
         pytest.importorskip("h5py")

--- a/pysteps/tests/test_io_dwd_hdf5.py
+++ b/pysteps/tests/test_io_dwd_hdf5.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import os
-
 import pytest
 
 import pysteps

--- a/pysteps/tests/test_io_dwd_hdf5.py
+++ b/pysteps/tests/test_io_dwd_hdf5.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+
+import os
+
+import pytest
+
+import pysteps
+from pysteps.tests.helpers import smart_assert
+
+pytest.importorskip("h5py")
+
+# Test for RADOLAN RY product
+
+root_path = pysteps.rcparams.data_sources["dwd"]["root_path"]
+
+filename = os.path.join(root_path, "RY", "2025", "06", "04", "20250604_1700_RY.h5")
+precip_ry, _, metadata_ry = pysteps.io.import_dwd_hdf5(filename, qty="RATE")
+
+
+def test_io_import_dwd_hdf5_ry_shape():
+    """Test the importer DWD HDF5."""
+    assert precip_ry.shape == (1200, 1100)
+
+
+# Test_metadata
+# Expected projection definition
+expected_proj = (
+    "+proj=stere +lat_0=90 +lat_ts=60 "
+    "'+lon_0=10 +a=6378137 +b=6356752.3142451802"
+    "+no_defs +x_0=543196.83521776402 "
+    "+y_0=3622588.8619310018 +units=m"
+)
+
+# List of (variable,expected,tolerance) tuples
+test_ry_attrs = [
+    ("projection", expected_proj, None),
+    ("ll_lon", 3.566994635, 1e-10),
+    ("ll_lat", 45.69642538, 1e-10),
+    ("ur_lon", 18.73161645, 1e-10),
+    ("ur_lat", 55.84543856, 1e-10),
+    ("x1", -500.0, 1e-6),
+    ("y1", -1199500.0, 1e-10),
+    ("x2", 1099500.0, 1e-10),
+    ("y2", 500.0, 1e-6),
+    ("xpixelsize", 1000.0, 1e-10),
+    ("xpixelsize", 1000.0, 1e-10),
+    ("cartesian_unit", "m", None),
+    ("yorigin", "upper", None),
+    ("institution", "ORG:78,CTY:616,CMT:Deutscher Wetterdienst radolan@dwd.de", None),
+    ("accutime", 5.0, 1e-10),
+    ("unit", "mm/h", None),
+    ("transform", None, None),
+    ("zerovalue", 0.0, 1e-10),
+    ("threshold", 0.12, 1e-10),
+]
+
+
+@pytest.mark.parametrize("variable, expected, tolerance", test_ry_attrs)
+def test_io_import_opera_hdf5_odyssey_dataset_attrs(variable, expected, tolerance):
+    """Test the importer OPERA HDF5."""
+    smart_assert(metadata_ry[variable], expected, tolerance)

--- a/pysteps/tests/test_io_dwd_hdf5.py
+++ b/pysteps/tests/test_io_dwd_hdf5.py
@@ -5,16 +5,21 @@ import os
 import pytest
 
 import pysteps
-from pysteps.tests.helpers import smart_assert
+from pysteps.tests.helpers import smart_assert, get_precipitation_fields
 
 pytest.importorskip("h5py")
 
 # Test for RADOLAN RY product
 
-root_path = pysteps.rcparams.data_sources["dwd"]["root_path"]
-
-filename = os.path.join(root_path, "RY", "2025", "06", "04", "20250604_1700_RY.h5")
-precip_ry, _, metadata_ry = pysteps.io.import_dwd_hdf5(filename, qty="RATE")
+precip_ry, metadata_ry = get_precipitation_fields(
+    num_prev_files=0,
+    num_next_files=0,
+    return_raw=False,
+    metadata=True,
+    source="dwd",
+    log_transform=False,
+    importer_kwargs=dict(qty="RATE"),
+)
 
 
 def test_io_import_dwd_hdf5_ry_shape():
@@ -26,7 +31,7 @@ def test_io_import_dwd_hdf5_ry_shape():
 # Expected projection definition
 expected_proj = (
     "+proj=stere +lat_0=90 +lat_ts=60 "
-    "'+lon_0=10 +a=6378137 +b=6356752.3142451802"
+    "+lon_0=10 +a=6378137 +b=6356752.3142451802 "
     "+no_defs +x_0=543196.83521776402 "
     "+y_0=3622588.8619310018 +units=m"
 )
@@ -39,8 +44,8 @@ test_ry_attrs = [
     ("ur_lon", 18.73161645, 1e-10),
     ("ur_lat", 55.84543856, 1e-10),
     ("x1", -500.0, 1e-6),
-    ("y1", -1199500.0, 1e-10),
-    ("x2", 1099500.0, 1e-10),
+    ("y1", -1199500.0, 1e-6),
+    ("x2", 1099500.0, 1e-6),
     ("y2", 500.0, 1e-6),
     ("xpixelsize", 1000.0, 1e-10),
     ("xpixelsize", 1000.0, 1e-10),
@@ -50,12 +55,12 @@ test_ry_attrs = [
     ("accutime", 5.0, 1e-10),
     ("unit", "mm/h", None),
     ("transform", None, None),
-    ("zerovalue", 0.0, 1e-10),
-    ("threshold", 0.12, 1e-10),
+    ("zerovalue", 0.0, 1e-6),
+    ("threshold", 0.12, 1e-6),
 ]
 
 
 @pytest.mark.parametrize("variable, expected, tolerance", test_ry_attrs)
-def test_io_import_opera_hdf5_odyssey_dataset_attrs(variable, expected, tolerance):
+def test_io_import_dwd_hdf5_ry_metadata(variable, expected, tolerance):
     """Test the importer OPERA HDF5."""
     smart_assert(metadata_ry[variable], expected, tolerance)

--- a/pysteps/tests/test_utils_reprojection.py
+++ b/pysteps/tests/test_utils_reprojection.py
@@ -5,8 +5,11 @@ import numpy as np
 import pytest
 import pysteps
 from pysteps.utils import reprojection as rpj
+import pysteps_nwp_importers
 
 pytest.importorskip("rasterio")
+pytest.importorskip("pyproj")
+# pytest.importorskip("pysteps_nwp_importers")
 
 root_path_radar = pysteps.rcparams.data_sources["rmi"]["root_path"]
 
@@ -109,4 +112,67 @@ def test_utils_reproject_grids(
 
     assert (
         metadata_reproj["projection"] == metadata_dst["projection"]
-    ), "projection is different than destionation projection"
+    ), "projection is different than destination projection"
+
+
+root_path_radar = pysteps.rcparams.data_sources["dwd"]["root_path"]
+root_path_nwp = pysteps.rcparams.data_sources["dwd_nwp"]["root_path"]
+
+filename_radar = os.path.join(
+    root_path_radar, "RY", "2025", "06", "04", "20250604_1700_RY.h5"
+)
+_, _, metadata_dst = pysteps.io.import_dwd_hdf5(filename_radar, qty="RATE")
+
+filename_nwp = os.path.join(
+    root_path_nwp, "2025", "06", "04", "20250604_1600_PR_GSP_060_120.grib2"
+)
+kwargs = {
+    "varname": "PR_GSP",
+    "grid_file_path": "./aux/grid_files/dwd/icon/R19B07/icon_grid_0047_R19B07_L.nc",
+}
+array_src, _, metadata_src = pysteps_nwp_importers.importer_dwd_nwp.import_dwd_nwp(
+    filename_nwp, **kwargs
+)
+
+# Since output of NWP importer is based on xarray and the restructure function is
+# rewritten for np.ndarray, there's is some improvisation
+metadata_src["clon"] = array_src["longitude"].values
+metadata_src["clat"] = array_src["latitude"].values
+array_src = array_src.values
+
+restructure_arg_names = ("array_src", "metadata_src", "metadata_dst")
+restructure_arg_values = [(array_src, metadata_src, metadata_dst)]
+
+
+@pytest.mark.parametrize(restructure_arg_names, restructure_arg_values)
+def test_utils_unstructured2regular(array_src, metadata_src, metadata_dst):
+    # Run unstructured2regular
+    array_rprj, metadata_rprj = rpj.unstructured2regular(
+        array_src, metadata_src, metadata_dst
+    )
+
+    # The tests
+    assert (
+        array_rprj.shape[0] == array_src.shape[0]
+    ), "Time dimension has not the same length as source"
+    assert (
+        array_rprj.shape[1] == array_src.shape[0],
+        "Ensemble member dimension has not the same length as source",
+    )
+
+    assert (
+        metadata_rprj["x1"] == metadata_dst["x1"]
+    ), "x-value lower left corner is not equal to radar composite"
+    assert (
+        metadata_rprj["x2"] == metadata_dst["x2"]
+    ), "x-value upper right corner is not equal to radar composite"
+    assert (
+        metadata_rprj["y1"] == metadata_dst["y1"]
+    ), "y-value lower left corner is not equal to radar composite"
+    assert (
+        metadata_rprj["y2"] == metadata_dst["y2"]
+    ), "y-value upper right corner is not equal to radar composite"
+
+    assert (
+        metadata_rprj["projection"] == metadata_dst["projection"]
+    ), "projection is different than destination projection"

--- a/pysteps/tests/test_utils_reprojection.py
+++ b/pysteps/tests/test_utils_reprojection.py
@@ -118,10 +118,14 @@ def test_utils_reproject_grids(
 root_path_radar = pysteps.rcparams.data_sources["dwd"]["root_path"]
 root_path_nwp = pysteps.rcparams.data_sources["dwd_nwp"]["root_path"]
 
-filename_radar = os.path.join(root_path_radar, "RY", "2025", "06", "04", "20250604_1700_RY.h5")
+filename_radar = os.path.join(
+    root_path_radar, "RY", "2025", "06", "04", "20250604_1700_RY.h5"
+)
 _, _, metadata_dst = pysteps.io.import_dwd_hdf5(filename_radar, qty="RATE")
 
-filename_nwp = os.path.join(root_path_nwp, "2025", "06", "04", "20250604_1600_PR_GSP_060_120.grib2")
+filename_nwp = os.path.join(
+    root_path_nwp, "2025", "06", "04", "20250604_1600_PR_GSP_060_120.grib2"
+)
 kwargs = {
     "varname": "PR_GSP",
     "grid_file_path": "./aux/grid_files/dwd/icon/R19B07/icon_grid_0047_R19B07_L.nc",
@@ -143,7 +147,9 @@ restructure_arg_values = [(array_src, metadata_src, metadata_dst)]
 @pytest.mark.parametrize(restructure_arg_names, restructure_arg_values)
 def test_utils_unstructured2regular(array_src, metadata_src, metadata_dst):
     # Run unstructured2regular
-    array_rprj, metadata_rprj = rpj.unstructured2regular(array_src, metadata_src, metadata_dst)
+    array_rprj, metadata_rprj = rpj.unstructured2regular(
+        array_src, metadata_src, metadata_dst
+    )
 
     # The tests
     assert (

--- a/pysteps/tests/test_utils_reprojection.py
+++ b/pysteps/tests/test_utils_reprojection.py
@@ -118,14 +118,10 @@ def test_utils_reproject_grids(
 root_path_radar = pysteps.rcparams.data_sources["dwd"]["root_path"]
 root_path_nwp = pysteps.rcparams.data_sources["dwd_nwp"]["root_path"]
 
-filename_radar = os.path.join(
-    root_path_radar, "RY", "2025", "06", "04", "20250604_1700_RY.h5"
-)
+filename_radar = os.path.join(root_path_radar, "RY", "2025", "06", "04", "20250604_1700_RY.h5")
 _, _, metadata_dst = pysteps.io.import_dwd_hdf5(filename_radar, qty="RATE")
 
-filename_nwp = os.path.join(
-    root_path_nwp, "2025", "06", "04", "20250604_1600_PR_GSP_060_120.grib2"
-)
+filename_nwp = os.path.join(root_path_nwp, "2025", "06", "04", "20250604_1600_PR_GSP_060_120.grib2")
 kwargs = {
     "varname": "PR_GSP",
     "grid_file_path": "./aux/grid_files/dwd/icon/R19B07/icon_grid_0047_R19B07_L.nc",
@@ -147,18 +143,15 @@ restructure_arg_values = [(array_src, metadata_src, metadata_dst)]
 @pytest.mark.parametrize(restructure_arg_names, restructure_arg_values)
 def test_utils_unstructured2regular(array_src, metadata_src, metadata_dst):
     # Run unstructured2regular
-    array_rprj, metadata_rprj = rpj.unstructured2regular(
-        array_src, metadata_src, metadata_dst
-    )
+    array_rprj, metadata_rprj = rpj.unstructured2regular(array_src, metadata_src, metadata_dst)
 
     # The tests
     assert (
         array_rprj.shape[0] == array_src.shape[0]
     ), "Time dimension has not the same length as source"
     assert (
-        array_rprj.shape[1] == array_src.shape[0],
-        "Ensemble member dimension has not the same length as source",
-    )
+        array_rprj.shape[1] == array_src.shape[0]
+    ), "Ensemble member dimension has not the same length as source"
 
     assert (
         metadata_rprj["x1"] == metadata_dst["x1"]

--- a/pysteps/utils/reprojection.py
+++ b/pysteps/utils/reprojection.py
@@ -15,7 +15,6 @@ from pysteps.exceptions import MissingOptionalDependency
 from scipy.interpolate import griddata
 
 import numpy as np
-import xarray as xr
 
 try:
     from rasterio import Affine as A
@@ -66,8 +65,7 @@ def reproject_grids(src_array, dst_array, metadata_src, metadata_dst):
 
     if not RASTERIO_IMPORTED:
         raise MissingOptionalDependency(
-            "rasterio package is required for the reprojection module, but it is "
-            "not installed"
+            "rasterio package is required for the reprojection module, but it is " "not installed"
         )
 
     # Extract the grid info from src_array
@@ -167,8 +165,7 @@ def unstructured2regular(src_array, metadata_src, metadata_dst):
 
     if not PYPROJ_IMPORTED:
         raise MissingOptionalDependency(
-            "pyproj package is required to reproject DWD's NWP data"
-            "but it is not installed"
+            "pyproj package is required to reproject DWD's NWP data" "but it is not installed"
         )
 
     if not "clon" in metadata_src.keys():
@@ -208,11 +205,7 @@ def unstructured2regular(src_array, metadata_src, metadata_dst):
     P_out = np.array((xx_dst.flatten(), yy_dst.flatten())).T
 
     # Nearest neighbor interpolation of x-y pairs
-    ic_out = (
-        griddata(P_in, ic_in.flatten(), P_out, method="nearest")
-        .reshape(s_out)
-        .astype(int)
-    )
+    ic_out = griddata(P_in, ic_in.flatten(), P_out, method="nearest").reshape(s_out).astype(int)
 
     # Apply interpolation on all time steps and ensemble members
     r_rprj = np.array(

--- a/pysteps/utils/reprojection.py
+++ b/pysteps/utils/reprojection.py
@@ -65,7 +65,8 @@ def reproject_grids(src_array, dst_array, metadata_src, metadata_dst):
 
     if not RASTERIO_IMPORTED:
         raise MissingOptionalDependency(
-            "rasterio package is required for the reprojection module, but it is " "not installed"
+            "rasterio package is required for the reprojection module, but it is "
+            "not installed"
         )
 
     # Extract the grid info from src_array
@@ -165,7 +166,8 @@ def unstructured2regular(src_array, metadata_src, metadata_dst):
 
     if not PYPROJ_IMPORTED:
         raise MissingOptionalDependency(
-            "pyproj package is required to reproject DWD's NWP data" "but it is not installed"
+            "pyproj package is required to reproject DWD's NWP data"
+            "but it is not installed"
         )
 
     if not "clon" in metadata_src.keys():
@@ -205,7 +207,11 @@ def unstructured2regular(src_array, metadata_src, metadata_dst):
     P_out = np.array((xx_dst.flatten(), yy_dst.flatten())).T
 
     # Nearest neighbor interpolation of x-y pairs
-    ic_out = griddata(P_in, ic_in.flatten(), P_out, method="nearest").reshape(s_out).astype(int)
+    ic_out = (
+        griddata(P_in, ic_in.flatten(), P_out, method="nearest")
+        .reshape(s_out)
+        .astype(int)
+    )
 
     # Apply interpolation on all time steps and ensemble members
     r_rprj = np.array(

--- a/pysteps/utils/reprojection.py
+++ b/pysteps/utils/reprojection.py
@@ -12,8 +12,10 @@ input field to a destination field.
     reproject_grids
 """
 from pysteps.exceptions import MissingOptionalDependency
+from scipy.interpolate import griddata
 
 import numpy as np
+import xarray as xr
 
 try:
     from rasterio import Affine as A
@@ -22,6 +24,13 @@ try:
     RASTERIO_IMPORTED = True
 except ImportError:
     RASTERIO_IMPORTED = False
+
+try:
+    import pyproj
+
+    PYPROJ_IMPORTED = True
+except ImportError:
+    PYPROJ_IMPORTED = False
 
 
 def reproject_grids(src_array, dst_array, metadata_src, metadata_dst):
@@ -118,3 +127,117 @@ def reproject_grids(src_array, dst_array, metadata_src, metadata_dst):
         metadata[key] = metadata_dst[key]
 
     return r_rprj, metadata
+
+
+def unstructured2regular(src_array, metadata_src, metadata_dst):
+    """
+    Reproject unstructured data onto a regular grid.
+
+    Parameters
+    ----------
+    src_array: xarray
+        xarray of shape (t, n_ens, ngridcells) containing a time
+        series of precipitation enesemble forecasts. These precipitation fields
+        will be reprojected.
+    metadata_src: dict
+        Metadata dictionary containing the projection, clon, clat, and ngridcells
+        and attributes of the src_array as described in the documentation of
+        :py:mod:`pysteps.io.importers`.
+    metadata_dst: dict
+        Metadata dictionary containing the projection, x- and ypixelsize, x1 and
+        y2 attributes of the dst_array.
+
+    Returns
+    -------
+    r_rprj: xarray
+        Three-dimensional array of shape (t, n_ens, x, y) containing the
+        precipitation fields of src_array, but reprojected to the domain
+        of dst_array.
+    metadata: dict
+        Metadata dictionary containing the projection, x- and ypixelsize, x1 and
+        y2 attributes of the reprojected src_array.
+    """
+
+    if not PYPROJ_IMPORTED:
+        raise MissingOptionalDependency(
+            "pyproj package is required to reproject DWD's NWP data"
+            "but it is not installed"
+        )
+
+    # Get number of grid cells
+    Nc = src_array["longitude"].shape[0]
+    ic_in = np.arange(Nc)
+
+    # Get cartesian coordinates of destination grid
+    x_dst = np.arange(
+        np.float32(metadata_dst["x1"]),
+        np.float32(metadata_dst["x2"]),
+        metadata_dst["xpixelsize"],
+    )
+
+    y_dst = np.arange(
+        np.float32(metadata_dst["y1"]),
+        np.float32(metadata_dst["y2"]),
+        metadata_dst["ypixelsize"],
+    )
+
+    if metadata_dst["yorigin"] == "upper":
+        y_dst = y_dst[::-1]
+    xx_dst, yy_dst = np.meshgrid(x_dst, y_dst)
+    s_out = yy_dst.shape
+    P_out = np.array((xx_dst.flatten(), yy_dst.flatten())).T
+
+    # Extract the grid info from src_array assuming the same projection of src and dst
+    pr = pyproj.Proj(metadata_dst["projection"])
+    x_src, y_src = pr(src_array["longitude"].values, src_array["latitude"].values)
+    P_in = np.stack((x_src, y_src)).T
+
+    ic_out = (
+        griddata(P_in, ic_in.flatten(), P_out, method="nearest")
+        .reshape(s_out)
+        .astype(int)
+    )
+
+    data_rprj = np.array(
+        [
+            [src_array[i, j].values[ic_out] for j in range(src_array.shape[1])]
+            for i in range(src_array.shape[0])
+        ]
+    )
+    dims = ["time", "ens_no", "south_north", "west_east"]
+    lon, lat = pr(xx_dst, yy_dst, inverse=True)
+    coords = {
+        "time": src_array["time"],
+        "ens_no": src_array["ens_no"],
+        "west_east": np.arange(0, len(x_dst), 1),
+        "south_north": np.arange(0, len(y_dst), 1),
+        "x": ("west_east", np.arange(0, len(x_dst), 1), {"units": "1"}),
+        "y": ("south_north", np.arange(0, len(y_dst), 1), {"units": "1"}),
+        "projection_x_coordinate": ("west_east", x_dst, {"units": "m"}),
+        "projection_y_coordinate": ("south_north", y_dst, {"units": "m"}),
+        "longitude": (
+            ["south_north", "west_east"],
+            lon,
+            {"units": "degrees_north"},
+        ),
+        "latitude": (["south_north", "west_east"], lat, {"units": "degrees_east"}),
+    }
+    xr_rprj = xr.DataArray(data=data_rprj, dims=dims, coords=coords)
+
+    # Update the metadata
+    metadata = metadata_src.copy()
+
+    for key in [
+        "projection",
+        "yorigin",
+        "xpixelsize",
+        "ypixelsize",
+        "x1",
+        "x2",
+        "y1",
+        "y2",
+        "cartesian_unit",
+    ]:
+        metadata[key] = metadata_dst[key]
+
+    return xr_rprj, metadata

--- a/pysteps/utils/reprojection.py
+++ b/pysteps/utils/reprojection.py
@@ -15,7 +15,6 @@ from pysteps.exceptions import MissingOptionalDependency
 from scipy.interpolate import griddata
 
 import numpy as np
-import xarray as xr
 
 try:
     from rasterio import Affine as A

--- a/pysteps/utils/reprojection.py
+++ b/pysteps/utils/reprojection.py
@@ -136,7 +136,7 @@ def unstructured2regular(src_array, metadata_src, metadata_dst):
 
     Parameters
     ----------
-    src_array: array-like
+    src_array: np.ndarray
         Three-dimensional array of shape (t, n_ens, n_gridcells) containing a
         time series of precipitation ensemble forecasts. These precipitation
         fields will be reprojected.
@@ -150,13 +150,19 @@ def unstructured2regular(src_array, metadata_src, metadata_dst):
 
     Returns
     -------
-    r_rprj: array-like
-        Four-dimensional array of shape (t, n_ens, x, y) containing the
-        precipitation fields of src_array, but reprojected to the domain
-        of dst_array.
-    metadata: dict
-        Metadata dictionary containing the projection, x- and ypixelsize, x1 and
-        y2 attributes of the reprojected src_array.
+    tuple
+        A tuple containing:
+        - r_rprj: np.ndarray
+            Four dimensional array of shape (t, n_ens, x, y) containing the
+            precipitation fields of src_array, but reprojected to the grid
+            of dst_array.
+        - metadata: dict
+            Dictionary containing geospatial metadat such as:
+            - 'projection' : PROJ.4 string defining the stereographic projection.
+            - 'xpixelsize', 'ypixelsize': Pixel size in meters.
+            - 'x1', 'y1': Carthesian coordinates of the lower-left corner.
+            - 'x2', 'y2': Carthesian coordinates of the upper-right corner.
+            - 'cartesian_unit': Unit of the coordinate system (meters).
     """
 
     if not PYPROJ_IMPORTED:
@@ -193,7 +199,7 @@ def unstructured2regular(src_array, metadata_src, metadata_dst):
     xx_dst, yy_dst = np.meshgrid(x_dst, y_dst)
     s_out = yy_dst.shape
 
-    # Extract the grid info from src_array assuming the same projection of src and dst
+    # Extract the grid info of src_array assuming the same projection of src and dst
     pr = pyproj.Proj(metadata_dst["projection"])
     x_src, y_src = pr(metadata_src["clon"], metadata_src["clat"])
 

--- a/pysteps/utils/reprojection.py
+++ b/pysteps/utils/reprojection.py
@@ -12,7 +12,6 @@ input field to a destination field.
     reproject_grids
 """
 from pysteps.exceptions import MissingOptionalDependency
-from scipy.interpolate import griddata
 
 import numpy as np
 
@@ -23,13 +22,6 @@ try:
     RASTERIO_IMPORTED = True
 except ImportError:
     RASTERIO_IMPORTED = False
-
-try:
-    import pyproj
-
-    PYPROJ_IMPORTED = True
-except ImportError:
-    PYPROJ_IMPORTED = False
 
 
 def reproject_grids(src_array, dst_array, metadata_src, metadata_dst):
@@ -110,118 +102,6 @@ def reproject_grids(src_array, dst_array, metadata_src, metadata_dst):
         )
 
     # Update the metadata
-    metadata = metadata_src.copy()
-
-    for key in [
-        "projection",
-        "yorigin",
-        "xpixelsize",
-        "ypixelsize",
-        "x1",
-        "x2",
-        "y1",
-        "y2",
-        "cartesian_unit",
-    ]:
-        metadata[key] = metadata_dst[key]
-
-    return r_rprj, metadata
-
-
-def unstructured2regular(src_array, metadata_src, metadata_dst):
-    """
-    Reproject unstructured data onto a regular grid on the assumption that
-    both src data and dst grid have the same projection.
-
-    Parameters
-    ----------
-    src_array: np.ndarray
-        Three-dimensional array of shape (t, n_ens, n_gridcells) containing a
-        time series of precipitation ensemble forecasts. These precipitation
-        fields will be reprojected.
-    metadata_src: dict
-        Metadata dictionary containing the projection, clon, clat, and ngridcells
-        and attributes of the src_array as described in the documentation of
-        :py:mod:`pysteps.io.importers`.
-    metadata_dst: dict
-        Metadata dictionary containing the projection, x- and ypixelsize, x1 and
-        y2 attributes of the dst_array.
-
-    Returns
-    -------
-    tuple
-        A tuple containing:
-        - r_rprj: np.ndarray
-            Four dimensional array of shape (t, n_ens, x, y) containing the
-            precipitation fields of src_array, but reprojected to the grid
-            of dst_array.
-        - metadata: dict
-            Dictionary containing geospatial metadat such as:
-            - 'projection' : PROJ.4 string defining the stereographic projection.
-            - 'xpixelsize', 'ypixelsize': Pixel size in meters.
-            - 'x1', 'y1': Carthesian coordinates of the lower-left corner.
-            - 'x2', 'y2': Carthesian coordinates of the upper-right corner.
-            - 'cartesian_unit': Unit of the coordinate system (meters).
-    """
-
-    if not PYPROJ_IMPORTED:
-        raise MissingOptionalDependency(
-            "pyproj package is required to reproject DWD's NWP data"
-            "but it is not installed"
-        )
-
-    if not "clon" in metadata_src.keys():
-        raise KeyError("Center longitude (clon) is missing in metadata_src")
-    if not "clat" in metadata_src.keys():
-        raise KeyError("Center latitude (clat) is missing in metadata_src")
-
-    # Get number of grid cells
-    Nc = metadata_src["clon"].shape[0]
-    ic_in = np.arange(Nc)
-
-    # Get cartesian coordinates of destination grid
-    x_dst = np.arange(
-        np.float32(metadata_dst["x1"]),
-        np.float32(metadata_dst["x2"]),
-        metadata_dst["xpixelsize"],
-    )
-
-    y_dst = np.arange(
-        np.float32(metadata_dst["y1"]),
-        np.float32(metadata_dst["y2"]),
-        metadata_dst["ypixelsize"],
-    )
-
-    # Create destination grid
-    if metadata_dst["yorigin"] == "upper":
-        y_dst = y_dst[::-1]
-    xx_dst, yy_dst = np.meshgrid(x_dst, y_dst)
-    s_out = yy_dst.shape
-
-    # Extract the grid info of src_array assuming the same projection of src and dst
-    pr = pyproj.Proj(metadata_dst["projection"])
-    x_src, y_src = pr(metadata_src["clon"], metadata_src["clat"])
-
-    # Create array of x-y pairs for interpolation
-    P_in = np.stack((x_src, y_src)).T
-    P_out = np.array((xx_dst.flatten(), yy_dst.flatten())).T
-
-    # Nearest neighbor interpolation of x-y pairs
-    ic_out = (
-        griddata(P_in, ic_in.flatten(), P_out, method="nearest")
-        .reshape(s_out)
-        .astype(int)
-    )
-
-    # Apply interpolation on all time steps and ensemble members
-    r_rprj = np.array(
-        [
-            [src_array[i, j][ic_out] for j in range(src_array.shape[1])]
-            for i in range(src_array.shape[0])
-        ]
-    )
-
-    # Update the src metadata
     metadata = metadata_src.copy()
 
     for key in [


### PR DESCRIPTION
Implementation of an importer for DWD radar data products and a reprojection onto a regular grid. These are necessary to test the implementation of the reduced-space EnKF combination approach (Nerini et al., 2019) and to compare the results with the already existing code base that uses DWD data.