### PR TITLE
Probabilistic versions of FSS and spatial contingency metrics

### DIFF
--- a/pysteps/verification/detcatscores.py
+++ b/pysteps/verification/detcatscores.py
@@ -18,7 +18,7 @@ forecasts.
 
 import collections
 import numpy as np
-from pfss.pysteps.verification.spatialscores import smooth_fields, normalize_forecast_obs
+from pysteps.verification.spatialscores import smooth_fields, normalize_forecast_obs
 
 def det_cat_fct(pred, obs, thr, scores="", axis=None):
     """

--- a/pysteps/verification/spatialscores.py
+++ b/pysteps/verification/spatialscores.py
@@ -677,7 +677,7 @@ def fss_compute(fss):
     return 1.0 - numer / denom
 
 
-def fss_ens(fcst, obs, thr, scales, version='fss'):
+def fss_ens(fcst, obs, thr, scales, version='fss', mask_obs=False):
     """
     Compute Fractions Skill Score (FSS) for ensemble or deterministic forecasts
     across multiple thresholds and spatial scales.

--- a/pysteps/verification/spatialscores.py
+++ b/pysteps/verification/spatialscores.py
@@ -677,7 +677,7 @@ def fss_compute(fss):
     return 1.0 - numer / denom
 
 
-def fss_ens(fcst, obs, thr, scales, version='fss', mask_obs=False):
+def fss_ens(fcst, obs, thr, scales, version='fss'):
     """
     Compute Fractions Skill Score (FSS) for ensemble or deterministic forecasts
     across multiple thresholds and spatial scales.


### PR DESCRIPTION
Added probabilistic versions of FSS (pfss, avfss and agfss) and spatial contingency scores (POD,FAR, ETS, ...) to be able to compute scores for ensemble forecasts for multiple window sizes, thresholds, and timesteps.

FSS versions reference:
Necker, T., Wolfgruber, L., Kugler, L., Weissmann, M., Dorninger, M. & Serafin, S. (2024) The fractions skill score for ensemble forecast verification. Quarterly Journal of the Royal Meteorological Society, 150(764), 4457–4477. Available from: https://doi.org/10.1002/qj.4824