### PR TITLE
Add smooth_radar_mask functionality from steps blending to pca_kalman_filter_blending

### DIFF
--- a/pysteps/blending/pca_ens_kalman_filter.py
+++ b/pysteps/blending/pca_ens_kalman_filter.py
@@ -708,7 +708,7 @@ class ForecastModel:
         # forecast outside the radar domain. Therefore, fill these
         # areas with NWP, if requested.
         nan_mask = np.isnan(self.__forecast_state.nwc_prediction[self.__ens_member])
-        self.__forecast_state.nwc_prediction[self.__ens_member][nan_mask] = nwp
+        self.__forecast_state.nwc_prediction[self.__ens_member][nan_mask] = nwp[nan_mask]
         # For a smoother transition at the edge, we can slowly dilute the nowcast
         # component into NWP at the edges
         if self.__forecast_state.config.smooth_radar_mask_range != 0:

--- a/pysteps/blending/pca_ens_kalman_filter.py
+++ b/pysteps/blending/pca_ens_kalman_filter.py
@@ -694,7 +694,6 @@ class ForecastModel:
             self.__forecast_state.params.extrapolation_kwargs[
                 "map_coordinates_mode"
             ] = "constant"
-            self.__nwp_for_filling = nwp
         self.__advect()
 
         # The extrapolation components are NaN outside the advected
@@ -786,15 +785,16 @@ class ForecastModel:
             displacement_previous=self.__previous_displacement,
             **self.__forecast_state.params.extrapolation_kwargs,
         )
-        self.__forecast_state.params.domain_mask = (
-            self.__forecast_state.params.extrapolation_method(
-                self.__forecast_state.params.domain_mask,
-                self.__velocity,
-                [1],
-                interp_order=1,
-                outval=True,
-            )[0]
-        )
+        if self.__forecast_state.config.smooth_radar_mask_range > 0:
+            self.__forecast_state.params.domain_mask = (
+                self.__forecast_state.params.extrapolation_method(
+                    self.__forecast_state.params.domain_mask,
+                    self.__velocity,
+                    [1],
+                    interp_order=1,
+                    outval=True,
+                )[0]
+            )
 
         # Get the difference of the previous displacement field.
         self.__previous_displacement -= displacement_tmp

--- a/pysteps/blending/pca_ens_kalman_filter.py
+++ b/pysteps/blending/pca_ens_kalman_filter.py
@@ -718,6 +718,7 @@ class ForecastModel:
                 nan_mask,
                 max_padding_size_in_px=self.__forecast_state.config.smooth_radar_mask_range,
             )
+            new_mask = np.nan_to_num(new_mask, nan=0)
 
             # Ensure mask values are between 0 and 1
             mask_model = np.clip(new_mask, 0, 1)

--- a/pysteps/blending/pca_ens_kalman_filter.py
+++ b/pysteps/blending/pca_ens_kalman_filter.py
@@ -1389,10 +1389,8 @@ class EnKFCombinationNowcaster:
         self.__params.extrapolation_kwargs["return_displacement"] = True
         is_correction_timestep = False
 
-        [
+        for j in range(self.__config.n_ens_members):
             self.FC_Models[j].set_nwp_data_for_filling(self.__nwp_precip[j, 0])
-            for j in range(self.__config.n_ens_members)
-        ]
 
         for t, fc_leadtime in enumerate(self.__forecast_leadtimes):
             if self.__config.measure_time:

--- a/pysteps/blending/pca_ens_kalman_filter.py
+++ b/pysteps/blending/pca_ens_kalman_filter.py
@@ -755,8 +755,8 @@ class ForecastModel:
                 self.__forecast_state.nwc_prediction[self.__ens_member]
             )
 
-        # Set no data area
-        self.__set_no_data()
+            # Set no data area
+            self.__set_no_data()
 
     # Call spatial decomposition function and compute an adjusted standard deviation of
     # each spatial scale at timesteps where NWP information is incorporated.

--- a/pysteps/blending/pca_ens_kalman_filter.py
+++ b/pysteps/blending/pca_ens_kalman_filter.py
@@ -708,14 +708,16 @@ class ForecastModel:
         # forecast outside the radar domain. Therefore, fill these
         # areas with NWP, if requested.
         nan_mask = np.isnan(self.__forecast_state.nwc_prediction[self.__ens_member])
-        self.__forecast_state.nwc_prediction[self.__ens_member][nan_mask] = nwp[nan_mask]
+        self.__forecast_state.nwc_prediction[self.__ens_member][nan_mask] = nwp[
+            nan_mask
+        ]
         # For a smoother transition at the edge, we can slowly dilute the nowcast
         # component into NWP at the edges
         if self.__forecast_state.config.smooth_radar_mask_range != 0:
-            nan_mask = np.isnan(self.__forecast_state.nwc_prediction[self.__ens_member])
+            # nan_mask = np.isnan(self.__forecast_state.nwc_prediction[self.__ens_member])
             # Compute the smooth dilated mask
             new_mask = blending.utils.compute_smooth_dilated_mask(
-                nan_mask,
+                self.__forecast_state.params.domain_mask,
                 max_padding_size_in_px=self.__forecast_state.config.smooth_radar_mask_range,
             )
             new_mask = np.nan_to_num(new_mask, nan=0)

--- a/pysteps/tests/test_blending_pca_ens_kalman_filter.py
+++ b/pysteps/tests/test_blending_pca_ens_kalman_filter.py
@@ -10,37 +10,39 @@ from pysteps import blending, motion, utils
 # fmt: off
 pca_enkf_arg_values = [
     # Standard setting
-    (20,30,0,-60,False,False,5,5,0.05,0.01,"ssft","masked_enkf",True,None,1.0,"ensemble",False,False),
+    (20,30,0,-60,False,False,5,5,0.05,0.01,"ssft","masked_enkf",True,None,1.0,"ensemble",False,False,0),
+    # Smooth radar mask
+    (20,30,0,-60,False,False,5,5,0.05,0.01,"ssft","masked_enkf",True,None,1.0,"ensemble",False,False,20),
     # Coarser NWP temporal resolution
-    (20,30,0,-60,False,False,5,15,0.05,0.01,"ssft","masked_enkf",True,None,1.0,"ensemble",False,False),
+    (20,30,0,-60,False,False,5,15,0.05,0.01,"ssft","masked_enkf",True,None,1.0,"ensemble",False,False,0),
     # Coarser Obs temporal resolution
-    (20,30,0,-60,False,False,10,5,0.05,0.01,"ssft","masked_enkf",True,None,1.0,"ensemble",False,False),
+    (20,30,0,-60,False,False,10,5,0.05,0.01,"ssft","masked_enkf",True,None,1.0,"ensemble",False,False,0),
     # Larger shift of the NWP init
-    (20,30,0,-30,False,False,5,5,0.05,0.01,"ssft","masked_enkf",True,None,1.0,"ensemble",False,False),
+    (20,30,0,-30,False,False,5,5,0.05,0.01,"ssft","masked_enkf",True,None,1.0,"ensemble",False,False,0),
     # Zero rain case in observation
-    (20,30,0,-60,True,False,5,5,0.05,0.01,"ssft","masked_enkf",True,None,1.0,"ensemble",False,False),
+    (20,30,0,-60,True,False,5,5,0.05,0.01,"ssft","masked_enkf",True,None,1.0,"ensemble",False,False,0),
     # Zero rain case in NWP
-    (20,30,0,-60,False,True,5,5,0.05,0.01,"ssft","masked_enkf",True,None,1.0,"ensemble",False,False),
+    (20,30,0,-60,False,True,5,5,0.05,0.01,"ssft","masked_enkf",True,None,1.0,"ensemble",False,False,0),
     # Zero rain in both
-    (20,30,0,-60,True,True,5,5,0.05,0.01,"ssft","masked_enkf",True,None,1.0,"ensemble",False,False),
+    (20,30,0,-60,True,True,5,5,0.05,0.01,"ssft","masked_enkf",True,None,1.0,"ensemble",False,False,0),
     # Accumulated sampling probability
-    (20,30,0,-60,False,False,5,5,0.05,0.01,"ssft","masked_enkf",True,None,1.0,"ensemble",True,False),
+    (20,30,0,-60,False,False,5,5,0.05,0.01,"ssft","masked_enkf",True,None,1.0,"ensemble",True,False,0),
     # Use full NWP weight
-    (20,30,0,-60,False,False,5,5,0.05,0.01,"ssft","masked_enkf",True,None,1.0,"ensemble",False,True),
+    (20,30,0,-60,False,False,5,5,0.05,0.01,"ssft","masked_enkf",True,None,1.0,"ensemble",False,True,0),
     # Both
-    (20,30,0,-60,False,False,5,5,0.05,0.01,"ssft","masked_enkf",True,None,1.0,"ensemble",True,True),
+    (20,30,0,-60,False,False,5,5,0.05,0.01,"ssft","masked_enkf",True,None,1.0,"ensemble",True,True,0),
     # Explained variance as sampling probability source
-    (20,30,0,-60,False,False,5,5,0.05,0.01,"ssft","masked_enkf",True,None,1.0,"explained_var",False,False),
+    (20,30,0,-60,False,False,5,5,0.05,0.01,"ssft","masked_enkf",True,None,1.0,"explained_var",False,False,0),
     # No combination
-    (20,30,0,-60,False,False,5,5,0.05,0.01,"ssft","masked_enkf",False,None,1.0,"ensemble",False,False),
+    (20,30,0,-60,False,False,5,5,0.05,0.01,"ssft","masked_enkf",False,None,1.0,"ensemble",False,False,0),
     # Standard deviation adjustment
-    (20,30,0,-60,False,False,5,5,0.05,0.01,"ssft","masked_enkf",True,"auto",1.0,"ensemble",False,False),
+    (20,30,0,-60,False,False,5,5,0.05,0.01,"ssft","masked_enkf",True,"auto",1.0,"ensemble",False,False,0),
     # Other number of ensemble members
-    (10,30,0,-60,False,False,5,5,0.05,0.01,"ssft","masked_enkf",True,None,1.0,"ensemble",False,False),
+    (10,30,0,-60,False,False,5,5,0.05,0.01,"ssft","masked_enkf",True,None,1.0,"ensemble",False,False,0),
     # Other forecast length
-    (20,35,0,-60,False,False,5,5,0.05,0.01,"ssft","masked_enkf",True,None,1.0,"ensemble",False,False),
+    (20,35,0,-60,False,False,5,5,0.05,0.01,"ssft","masked_enkf",True,None,1.0,"ensemble",False,False,0),
     # Other noise method
-    (20,30,0,-60,False,False,5,5,0.05,0.01,"nonparametric","masked_enkf",True,None,1.0,"ensemble",False,False),]
+    (20,30,0,-60,False,False,5,5,0.05,0.01,"nonparametric","masked_enkf",True,None,1.0,"ensemble",False,False,0),]
 # fmt: on
 
 pca_enkf_arg_names = (
@@ -62,6 +64,7 @@ pca_enkf_arg_names = (
     "sampling_prob_source",
     "use_accum_sampling_prob",
     "ensure_full_nwp_weight",
+    "smooth_radar_mask_range",
 )
 
 
@@ -85,6 +88,7 @@ def test_pca_enkf_combination(
     sampling_prob_source,
     use_accum_sampling_prob,
     ensure_full_nwp_weight,
+    smooth_radar_mask_range,
 ):
     pytest.importorskip("sklearn")
 
@@ -221,6 +225,7 @@ def test_pca_enkf_combination(
         issuetime=forecast_init,
         n_ens_members=n_ens_members,
         precip_mask_dilation=1,
+        smooth_radar_mask_range=smooth_radar_mask_range,
         n_cascade_levels=6,
         precip_thr=metadata["threshold"],
         norain_thr=norain_thr,


### PR DESCRIPTION
The current reduced-space ensemble kalman filter blending is working well in our test setup at KNMI. However, we notice some edge artefacts sometimes in the forecast, especially for the first lead times where the nowcast is dominant, e.g. (I believe this was the probability of >0.1mm/h rainfall for all members):

<img width="395" height="352" alt="image" src="https://github.com/user-attachments/assets/df3f5e3d-aeab-47b1-aaf7-8b4efc1acfb4" />

What we think happens is that the transition nowcast - NWP at the edge of the radar domain can be sharp and because the advection step is now all the way at the end of the forecast (probability matching and the Kalman filter correction are before it), you also get discontinuities in the nowcast rainfall if a field is right at the edge of the domain. The `smooth_radar_mask_range` option that we have already implemented in the STEPS blending procedure might be a solution. This PR implements this option in the pca_kalman_filter_blending code.

@m-rempel, I couldn't add you as a reviewer, but maybe good if you have a look at it as well. :)
