### PR TITLE
Return xsize and ysize metadata from the ODIMhdf5 reader

### DIFF
--- a/pysteps/io/importers.py
+++ b/pysteps/io/importers.py
@@ -37,6 +37,10 @@ The metadata dictionary contains the following recommended key-value pairs:
 +------------------+----------------------------------------------------------+
 |   ypixelsize     | grid resolution in y-direction                           |
 +------------------+----------------------------------------------------------+
+|    xsize         | grid size in x-direction                                 |
++------------------+----------------------------------------------------------+
+|    ysize         | grid size in y-direction                                 |
++------------------+----------------------------------------------------------+
 |   cartesian_unit | the physical unit of the cartesian x- and y-coordinates: |
 |                  | e.g. 'm' or 'km'                                         |
 +------------------+----------------------------------------------------------+
@@ -1474,7 +1478,21 @@ def import_odim_hdf5(filename, qty="RATE", **kwargs):
     else:
         xpixelsize = None
         ypixelsize = None
-
+        
+    if "xsize" in where.attrs.keys() and "ysize" in where.attrs.keys():
+        xsize = where.attrs["xsize"]
+        ysize = where.attrs["ysize"]
+    elif (
+        "xsize" in dataset1["where"].attrs.keys()
+        and "ysize" in dataset1["where"].attrs.keys()
+    ):
+        where = dataset1["where"]
+        xsize = where.attrs["xsize"]
+        ysize = where.attrs["ysize"]
+    else:
+        xsize = None
+        ysize = None
+        
     if qty == "ACRR":
         unit = "mm"
         transform = None


### PR DESCRIPTION
ODIMhdf5 reader has been missing xsize and ysize in the importing stage. I know it could be easily calculated from the x and y coordinates and the xpixelsize and ypixelsize, but why add the calculation when the variables are present already in the metadata.