### PR TITLE
fix only zeros when using external nowcast

### DIFF
--- a/pysteps/blending/steps.py
+++ b/pysteps/blending/steps.py
@@ -450,6 +450,15 @@ class StepsBlendingNowcaster:
         # Store inputs
         self.__precip = precip
         self.__precip_nowcast = precip_nowcast
+        if precip_nowcast is not None:
+            # Save the original NaN mask before replacement, so it can be
+            # restored for probability matching in the external_nowcast path.
+            # The NaN replacement is needed for cascade decomposition (FFT),
+            # but probability matching needs the NaN domain mask to exclude
+            # out-of-domain pixels from the CDF matching.
+            self.__precip_nowcast_nan_mask = ~np.isfinite(self.__precip_nowcast)
+        else:
+            self.__precip_nowcast_nan_mask = None
         self.__precip_models = precip_models
         self.__velocity = velocity
         self.__velocity_models = velocity_models
@@ -668,6 +677,19 @@ class StepsBlendingNowcaster:
                     if t_sub > 0:
                         self.__blend_cascades(t_sub, j, worker_state)
                         self.__recompose_cascade_to_rainfall_field(j, worker_state)
+                        # For external_nowcast: restore NaN outside the radar
+                        # domain in the recomposed field and the model-only
+                        # field so the post-processing (smooth radar mask, NaN
+                        # filling, incremental mask, CDF matching) works the
+                        # same as the standard STEPS path.
+                        if (
+                            self.__config.nowcasting_method == "external_nowcast"
+                            and self.__precip_nowcast_nan_mask is not None
+                        ):
+                            nan_mask_t = self.__precip_nowcast_nan_mask[j][t]
+                            worker_state.final_blended_forecast_recomposed[
+                                nan_mask_t
+                            ] = np.nan
                         final_blended_forecast_single_member = (
                             self.__post_process_output(
                                 j,
@@ -2682,10 +2704,14 @@ class StepsBlendingNowcaster:
                     precip_extrapolated_decomp.copy()
                 )
 
-            # Also update the probability matching fields
-            precip_extrapolated = self.__precip_nowcast[j][t][:, :]
+            # Also update the probability matching fields.
+            # Restore the original NaN mask so that CDF probability matching
+            # correctly excludes out-of-domain pixels (NaN was replaced with
+            # nanmin for cascade decomposition in __prepare_radar_and_NWP_fields).
+            precip_extrapolated = self.__precip_nowcast[j][t][:, :].copy()
+            precip_extrapolated[self.__precip_nowcast_nan_mask[j][t]] = np.nan
             worker_state.precip_extrapolated_probability_matching.append(
-                precip_extrapolated.copy()
+                precip_extrapolated
             )
 
             # Stack it for the output


### PR DESCRIPTION
When using the new external nowcast solution I ran into an issue where the output would contain only 0 (or -15 dBZ). I debugged this issue and this change seems to fix it and also should be in line with what the "normal" steps blending does. The output also looks OK.

@Joep1999 Maybe you can also take a look at this? You do not seem to be a member so you cannot approve, but you can leave comments I believe.