### PR TITLE
fix: issue with example code

### DIFF
--- a/pysteps/blending/steps.py
+++ b/pysteps/blending/steps.py
@@ -457,15 +457,6 @@ class StepsBlendingNowcaster:
             # but probability matching needs the NaN domain mask to exclude
             # out-of-domain pixels from the CDF matching.
             self.__precip_nowcast_nan_mask = ~np.isfinite(self.__precip_nowcast)
-            if (
-                self.__precip_nowcast_nan_mask.shape[0] == 1
-                and steps_blending_config.n_ens_members != 1
-            ):
-                self.__precip_nowcast_nan_mask = np.repeat(
-                    self.__precip_nowcast_nan_mask,
-                    steps_blending_config.n_ens_members,
-                    axis=0,
-                )
         else:
             self.__precip_nowcast_nan_mask = None
         self.__precip_models = precip_models
@@ -1915,6 +1906,11 @@ class StepsBlendingNowcaster:
                     )
                     self.__precip_nowcast = np.repeat(
                         self.__precip_nowcast,
+                        repeats,
+                        axis=0,
+                    )
+                    self.__precip_nowcast_nan_mask = np.repeat(
+                        self.__precip_nowcast_nan_mask,
                         repeats,
                         axis=0,
                     )

--- a/pysteps/blending/steps.py
+++ b/pysteps/blending/steps.py
@@ -457,6 +457,15 @@ class StepsBlendingNowcaster:
             # but probability matching needs the NaN domain mask to exclude
             # out-of-domain pixels from the CDF matching.
             self.__precip_nowcast_nan_mask = ~np.isfinite(self.__precip_nowcast)
+            if (
+                self.__precip_nowcast_nan_mask.shape[0] == 1
+                and steps_blending_config.n_ens_members != 1
+            ):
+                self.__precip_nowcast_nan_mask = np.repeat(
+                    self.__precip_nowcast_nan_mask,
+                    steps_blending_config.n_ens_members,
+                    axis=0,
+                )
         else:
             self.__precip_nowcast_nan_mask = None
         self.__precip_models = precip_models


### PR DESCRIPTION
Fixes #548 

Looks like if you pass it a nowcast with only a single member the nan mask will not have the correct shape at the time it is used. This is because a single member gets repeated to match the number of members expected. Now the same happens for the nan mask.