### PR TITLE
Add complevel argument to netcdf exporter + tests

### DIFF
--- a/pysteps/io/exporters.py
+++ b/pysteps/io/exporters.py
@@ -381,6 +381,7 @@ def initialize_forecast_exporter_netcdf(
     fill_value=None,
     scale_factor=None,
     offset=None,
+    complevel=9,
     **kwargs,
 ):
     """
@@ -429,6 +430,9 @@ def initialize_forecast_exporter_netcdf(
     offset: float, optional
         The offset to offset the data as: store_value = scale_factor *
         precipitation_value + offset. Defaults to None.
+    complevel: int, optional
+        Compression level for zlib compression, between 1 (fastest, least
+        compression) and 9 (slowest, most compression). Defaults to 9.
 
     Other Parameters
     ----------------
@@ -612,7 +616,7 @@ def initialize_forecast_exporter_netcdf(
             dimensions=("ens_number", "time", "y", "x"),
             compression="zlib",
             zlib=True,
-            complevel=9,
+            complevel=complevel,
             fill_value=fill_value,
         )
     else:
@@ -622,7 +626,7 @@ def initialize_forecast_exporter_netcdf(
             dimensions=("time", "y", "x"),
             compression="zlib",
             zlib=True,
-            complevel=9,
+            complevel=complevel,
             fill_value=fill_value,
         )
 

--- a/pysteps/io/exporters.py
+++ b/pysteps/io/exporters.py
@@ -431,8 +431,9 @@ def initialize_forecast_exporter_netcdf(
         The offset to offset the data as: store_value = scale_factor *
         precipitation_value + offset. Defaults to None.
     complevel: int, optional
-        Compression level for zlib compression, between 1 (fastest, least
-        compression) and 9 (slowest, most compression). Defaults to 9.
+        Compression level for zlib compression, ranging from 0 (no
+        compression) to 9 (slowest, most compression). Higher values
+        reduce file size but increase write time. Defaults to 9.
 
     Other Parameters
     ----------------

--- a/pysteps/tests/test_exporters.py
+++ b/pysteps/tests/test_exporters.py
@@ -30,7 +30,7 @@ exporter_arg_names = (
 
 exporter_arg_values = [
     (1, None, np.float32, None, None, None, 3, 1),
-    (1, None, np.float32, None, None, None, 3, None),
+    (1, None, np.float32, None, None, None, 3, 0),
     (1, None, np.float32, None, None, None, 3, 0),
     (1, "timestep", np.float32, 65535, None, None, 3, 9),
     (2, None, np.float32, 65535, None, None, 3, 2),
@@ -105,6 +105,7 @@ def test_io_export_netcdf_one_member_one_time_step(
             fill_value=fill_value,
             scale_factor=scale_factor,
             offset=offset,
+            complevel=complevel,
         )
 
         if n_ens_members > 1:

--- a/pysteps/tests/test_exporters.py
+++ b/pysteps/tests/test_exporters.py
@@ -25,16 +25,19 @@ exporter_arg_names = (
     "scale_factor",
     "offset",
     "n_timesteps",
+    "complevel",
 )
 
 exporter_arg_values = [
-    (1, None, np.float32, None, None, None, 3),
-    (1, "timestep", np.float32, 65535, None, None, 3),
-    (2, None, np.float32, 65535, None, None, 3),
-    (2, None, np.float32, 65535, None, None, [1, 2, 4]),
-    (2, "timestep", np.float32, None, None, None, 3),
-    (2, "timestep", np.float32, None, None, None, [1, 2, 4]),
-    (2, "member", np.float64, None, 0.01, 1.0, 3),
+    (1, None, np.float32, None, None, None, 3, 1),
+    (1, None, np.float32, None, None, None, 3, None),
+    (1, None, np.float32, None, None, None, 3, 6),
+    (1, "timestep", np.float32, 65535, None, None, 3, 9),
+    (2, None, np.float32, 65535, None, None, 3, 2),
+    (2, None, np.float32, 65535, None, None, [1, 2, 4], 2),
+    (2, "timestep", np.float32, None, None, None, 3, 2),
+    (2, "timestep", np.float32, None, None, None, [1, 2, 4], 2),
+    (2, "member", np.float64, None, 0.01, 1.0, 3, 2),
 ]
 
 
@@ -58,7 +61,14 @@ def test_get_geotiff_filename():
 
 @pytest.mark.parametrize(exporter_arg_names, exporter_arg_values)
 def test_io_export_netcdf_one_member_one_time_step(
-    n_ens_members, incremental, datatype, fill_value, scale_factor, offset, n_timesteps
+    n_ens_members,
+    incremental,
+    datatype,
+    fill_value,
+    scale_factor,
+    offset,
+    n_timesteps,
+    complevel,
 ):
     """
     Test the export netcdf.

--- a/pysteps/tests/test_exporters.py
+++ b/pysteps/tests/test_exporters.py
@@ -31,7 +31,7 @@ exporter_arg_names = (
 exporter_arg_values = [
     (1, None, np.float32, None, None, None, 3, 1),
     (1, None, np.float32, None, None, None, 3, 0),
-    (1, None, np.float32, None, None, None, 3, 0),
+    (1, None, np.float32, None, None, None, 3, 6),
     (1, "timestep", np.float32, 65535, None, None, 3, 9),
     (2, None, np.float32, 65535, None, None, 3, 2),
     (2, None, np.float32, 65535, None, None, [1, 2, 4], 2),

--- a/pysteps/tests/test_exporters.py
+++ b/pysteps/tests/test_exporters.py
@@ -31,7 +31,7 @@ exporter_arg_names = (
 exporter_arg_values = [
     (1, None, np.float32, None, None, None, 3, 1),
     (1, None, np.float32, None, None, None, 3, None),
-    (1, None, np.float32, None, None, None, 3, 6),
+    (1, None, np.float32, None, None, None, 3, 0),
     (1, "timestep", np.float32, 65535, None, None, 3, 9),
     (2, None, np.float32, 65535, None, None, 3, 2),
     (2, None, np.float32, 65535, None, None, [1, 2, 4], 2),


### PR DESCRIPTION
As pointed out by @larsbonnefoy, setting this to a lower value significantly speeds up netcdf writing.


