### PR TITLE
Fix TypeError when timesteps list has a gap in blending.steps.forecast

### DIFF
--- a/pysteps/blending/steps.py
+++ b/pysteps/blending/steps.py
@@ -711,9 +711,9 @@ class StepsBlendingNowcaster:
                             )
                         )
 
-                    final_blended_forecast_all_members_one_timestep[j] = (
-                        final_blended_forecast_single_member
-                    )
+                final_blended_forecast_all_members_one_timestep[j] = (
+                    final_blended_forecast_single_member
+                )
 
             dask_worker_collection = []
 

--- a/pysteps/tests/test_blending_steps.py
+++ b/pysteps/tests/test_blending_steps.py
@@ -17,6 +17,10 @@ steps_arg_values = [
     (1, 3, 4, 8,'steps', None, "mean", False, "spn", True, 4, False, False, 0, True, None, None, None),
     (1, 3, 4, 8,'steps', None, "cdf", False, "spn", True, 4, False, False, 0, False, None, None, None),
     (1, [1, 2, 3], 4, 8,'steps', None, "cdf", False, "spn", True, 4, False, False, 0, False, None, None, None),
+    # Regression test for a gap in the timesteps list (e.g. [1, 3] skips 2): this used to raise
+    # "TypeError: 'NoneType' object is not iterable" because the bin for the skipped step never
+    # got a value written to final_blended_forecast_all_members_one_timestep.
+    (1, [1, 3], 4, 8,'steps', None, "cdf", False, "spn", True, 4, False, False, 0, False, None, None, None),
     (1, 3, 4, 8,'steps', "incremental", "cdf", False, "spn", True, 4, False, False, 0, False, None, None, None),
     (1, 3, 4, 6,'steps', "incremental", "cdf", False, "bps", True, 4, False, False, 0, False, None, None, None),
     (1, 3, 4, 6,'steps', "incremental", "cdf", False, "bps", False, 4, False, False, 0, False, None, None, None),


### PR DESCRIPTION
### Problem
Calling `pysteps.blending.steps.forecast()` with a sparse `timesteps` list that has a gap (e.g. `[1, 3]`, skipping `2`) raises:

    TypeError: 'NoneType' object is not iterable

at `self.__state.final_blended_forecast[j].extend(...)` inside `__blended_nowcast_main_loop`.

### Root cause
In `StepsBlendingNowcaster.__blended_nowcast_main_loop`, `worker(j)` builds `final_blended_forecast_single_member` inside `for t_sub in self.__state.subtimesteps:`, but the line that stores it into `final_blended_forecast_all_members_one_timestep[j]` is indented one level too deep — inside that same `for` loop instead of after it:

    for t_sub in self.__state.subtimesteps:
        if t_sub > 0:
            ...
            final_blended_forecast_single_member = (
                self.__post_process_output(...)
            )

        final_blended_forecast_all_members_one_timestep[j] = (   # <- inside the for loop
            final_blended_forecast_single_member
        )

When a requested `timesteps` list has a gap, `nowcast_utils.binned_timesteps` produces an empty bin for the skipped native step, so `self.__state.subtimesteps == []` at that outer step. The `for t_sub in []:` loop body then never runs, so the assignment never happens, and `final_blended_forecast_all_members_one_timestep[j]` is left at its initial value of `None`. That later gets passed to `.extend(None)`.

Note the two existing list-`timesteps` cases in `test_blending_steps.py` don't actually exercise this: `[1, 2, 3]` has no gap, and the other `[1, 3]` case uses `zero_radar=True, zero_nwp=True`, which takes an early-exit shortcut that skips the main loop entirely.

### Fix
Dedent the assignment one level so it runs once per ensemble member after the `subtimesteps` loop finishes, regardless of whether that loop ran zero, one, or more iterations — matching the intent of "whatever this member produced at this outer step, even if that's nothing."

### Testing
- Added a regression test: `timesteps=[1, 3]` with non-zero radar/NWP precipitation (the two existing conditions needed to hit this bug at once).
- Reproduced the crash directly against the pre-fix code, confirmed the fix resolves it with no other behavior change.
- Full `pysteps/tests/test_blending_steps.py` suite: 59 passed (58 existing + 1 new).
- `black --check` passes with no formatting changes needed.