### PR TITLE
Fix external nowcast only zeros

### DIFF
--- a/pysteps/blending/steps.py
+++ b/pysteps/blending/steps.py
@@ -3152,7 +3152,7 @@ class StepsBlendingNowcaster:
         # areas with the "..._mod_only" blended forecasts, consisting
         # of the NWP and noise components.
         nan_indices = np.isnan(worker_state.final_blended_forecast_recomposed)
-        if self.__config.smooth_radar_mask_range != 0:
+        if self.__config.smooth_radar_mask_range != 0 and np.any(nan_indices):
             # Compute the smooth dilated mask
             new_mask = blending.utils.compute_smooth_dilated_mask(
                 nan_indices,


### PR DESCRIPTION
I thought I fixed this in https://github.com/pySTEPS/pysteps/pull/546, but I realized now that an external nowcast does not necessarily have to have nan's at the edge (especially in our usecase where we run the external nowcast on a larger domain to explicitly prevent this).

This should not be an issue if it were not for the bug where, if there are no nan's anywhere in the domain, the code that is supposed to fill this part with values from nwp will simply set the entire domain to 0.

The simple fix is to not try to fill in the nan's when there are no nan's anywhere in the domain.