### PR TITLE
fix issue with linear blending

### DIFF
--- a/pysteps/blending/linear_blending.py
+++ b/pysteps/blending/linear_blending.py
@@ -21,9 +21,10 @@ Implementation of the linear blending and saliency-based blending between nowcas
 """
 
 import numpy as np
+from scipy.stats import rankdata
+
 from pysteps import nowcasts
 from pysteps.utils import conversion
-from scipy.stats import rankdata
 
 
 def forecast(
@@ -105,10 +106,6 @@ def forecast(
     if nowcast_kwargs is None:
         nowcast_kwargs = dict()
 
-    # Ensure that only the most recent precip timestep is used
-    if len(precip.shape) == 3:
-        precip = precip[-1, :, :]
-
     # First calculate the number of needed timesteps (up to end_blending) for the nowcast
     # to ensure that the nowcast calculation time is limited.
     timesteps_nowcast = int(end_blending / timestep)
@@ -184,10 +181,10 @@ def forecast(
                     precip_nowcast = np.repeat(precip_nowcast, repeats, axis=0)
 
         # Check if dimensions are correct
-        assert (
-            precip_nwp.shape[-2:] == precip_nowcast.shape[-2:]
-        ), "The x and y dimensions of precip_nowcast and precip_nwp need to be identical: dimension of precip_nwp = {} and dimension of precip_nowcast = {}".format(
-            precip_nwp.shape[-2:], precip_nowcast.shape[-2:]
+        assert precip_nwp.shape[-2:] == precip_nowcast.shape[-2:], (
+            "The x and y dimensions of precip_nowcast and precip_nwp need to be identical: dimension of precip_nwp = {} and dimension of precip_nowcast = {}".format(
+                precip_nwp.shape[-2:], precip_nowcast.shape[-2:]
+            )
         )
 
         # Ensure we are not working with nans in the bleding.

--- a/pysteps/blending/linear_blending.py
+++ b/pysteps/blending/linear_blending.py
@@ -109,6 +109,7 @@ def forecast(
     # First calculate the number of needed timesteps (up to end_blending) for the nowcast
     # to ensure that the nowcast calculation time is limited.
     timesteps_nowcast = int(end_blending / timestep)
+    timesteps_nowcast = min(timesteps, timesteps_nowcast)
 
     nowcast_method_func = nowcasts.get_method(nowcast_method)
 

--- a/pysteps/blending/linear_blending.py
+++ b/pysteps/blending/linear_blending.py
@@ -182,10 +182,10 @@ def forecast(
                     precip_nowcast = np.repeat(precip_nowcast, repeats, axis=0)
 
         # Check if dimensions are correct
-        assert precip_nwp.shape[-2:] == precip_nowcast.shape[-2:], (
-            "The x and y dimensions of precip_nowcast and precip_nwp need to be identical: dimension of precip_nwp = {} and dimension of precip_nowcast = {}".format(
-                precip_nwp.shape[-2:], precip_nowcast.shape[-2:]
-            )
+        assert (
+            precip_nwp.shape[-2:] == precip_nowcast.shape[-2:]
+        ), "The x and y dimensions of precip_nowcast and precip_nwp need to be identical: dimension of precip_nwp = {} and dimension of precip_nowcast = {}".format(
+            precip_nwp.shape[-2:], precip_nowcast.shape[-2:]
         )
 
         # Ensure we are not working with nans in the bleding.

--- a/pysteps/tests/test_blending_linear_blending.py
+++ b/pysteps/tests/test_blending_linear_blending.py
@@ -185,21 +185,21 @@ def test_linear_blending(
     # entirely constant
 
     # Assert that the control time step is in the range of the forecasted time steps
-    assert controltime <= (n_timesteps * timestep), (
-        "Control time needs to be within reach of forecasts, controltime = {} and n_timesteps = {}".format(
-            controltime, n_timesteps
-        )
+    assert controltime <= (
+        n_timesteps * timestep
+    ), "Control time needs to be within reach of forecasts, controltime = {} and n_timesteps = {}".format(
+        controltime, n_timesteps
     )
 
     # Assert that the start time of the blending comes before the end time of the blending
-    assert start_blending < end_blending, (
-        "Start time of blending needs to be smaller than end time of blending"
-    )
+    assert (
+        start_blending < end_blending
+    ), "Start time of blending needs to be smaller than end time of blending"
 
     # Assert that the control time is a multiple of the time step
-    assert not controltime % timestep, (
-        "Control time needs to be a multiple of the time step"
-    )
+    assert (
+        not controltime % timestep
+    ), "Control time needs to be a multiple of the time step"
 
     # Initialise dummy NWP data
     if n_models == 0:
@@ -255,20 +255,16 @@ def test_linear_blending(
             n_timesteps,
             200,
             200,
-        ), (
-            "The shape of the blended array does not have the expected value. The shape is {}".format(
-                r_blended.shape
-            )
+        ), "The shape of the blended array does not have the expected value. The shape is {}".format(
+            r_blended.shape
         )
     else:
         assert r_blended.shape == (
             n_timesteps,
             200,
             200,
-        ), (
-            "The shape of the blended array does not have the expected value. The shape is {}".format(
-                r_blended.shape
-            )
+        ), "The shape of the blended array does not have the expected value. The shape is {}".format(
+            r_blended.shape
         )
 
     # Assert that the blended field at the control time step is equal to
@@ -313,8 +309,6 @@ def test_salient_weight(
     assert ws.shape == (
         200,
         200,
-    ), (
-        "The shape of the ranked salience array does not have the expected value. The shape is {}".format(
-            ws.shape
-        )
+    ), "The shape of the ranked salience array does not have the expected value. The shape is {}".format(
+        ws.shape
     )

--- a/pysteps/tests/test_blending_linear_blending.py
+++ b/pysteps/tests/test_blending_linear_blending.py
@@ -2,8 +2,9 @@
 
 import numpy as np
 import pytest
-from pysteps.blending.linear_blending import forecast, _get_ranked_salience, _get_ws
 from numpy.testing import assert_array_almost_equal
+
+from pysteps.blending.linear_blending import _get_ranked_salience, _get_ws, forecast
 from pysteps.utils import transformation
 
 # Test function arguments
@@ -184,21 +185,21 @@ def test_linear_blending(
     # entirely constant
 
     # Assert that the control time step is in the range of the forecasted time steps
-    assert controltime <= (
-        n_timesteps * timestep
-    ), "Control time needs to be within reach of forecasts, controltime = {} and n_timesteps = {}".format(
-        controltime, n_timesteps
+    assert controltime <= (n_timesteps * timestep), (
+        "Control time needs to be within reach of forecasts, controltime = {} and n_timesteps = {}".format(
+            controltime, n_timesteps
+        )
     )
 
     # Assert that the start time of the blending comes before the end time of the blending
-    assert (
-        start_blending < end_blending
-    ), "Start time of blending needs to be smaller than end time of blending"
+    assert start_blending < end_blending, (
+        "Start time of blending needs to be smaller than end time of blending"
+    )
 
     # Assert that the control time is a multiple of the time step
-    assert (
-        not controltime % timestep
-    ), "Control time needs to be a multiple of the time step"
+    assert not controltime % timestep, (
+        "Control time needs to be a multiple of the time step"
+    )
 
     # Initialise dummy NWP data
     if n_models == 0:
@@ -226,6 +227,10 @@ def test_linear_blending(
     r_input, _ = transformation.dB_transform(
         r_input, None, threshold=0.1, zerovalue=-15.0
     )
+    if len(r_input.shape) == 3:
+        r_input = (
+            r_input[-1] if nowcast_method in ["extrapolation", "eulerian"] else r_input
+        )
 
     # Calculate the blended field
     r_blended = forecast(
@@ -250,16 +255,20 @@ def test_linear_blending(
             n_timesteps,
             200,
             200,
-        ), "The shape of the blended array does not have the expected value. The shape is {}".format(
-            r_blended.shape
+        ), (
+            "The shape of the blended array does not have the expected value. The shape is {}".format(
+                r_blended.shape
+            )
         )
     else:
         assert r_blended.shape == (
             n_timesteps,
             200,
             200,
-        ), "The shape of the blended array does not have the expected value. The shape is {}".format(
-            r_blended.shape
+        ), (
+            "The shape of the blended array does not have the expected value. The shape is {}".format(
+                r_blended.shape
+            )
         )
 
     # Assert that the blended field at the control time step is equal to
@@ -304,6 +313,8 @@ def test_salient_weight(
     assert ws.shape == (
         200,
         200,
-    ), "The shape of the ranked salience array does not have the expected value. The shape is {}".format(
-        ws.shape
+    ), (
+        "The shape of the ranked salience array does not have the expected value. The shape is {}".format(
+            ws.shape
+        )
     )

--- a/pysteps/tests/test_blending_linear_blending.py
+++ b/pysteps/tests/test_blending_linear_blending.py
@@ -229,7 +229,16 @@ def test_linear_blending(
     )
     if len(r_input.shape) == 3:
         r_input = (
-            r_input[-1] if nowcast_method in ["extrapolation", "eulerian"] else r_input
+            r_input[-1]
+            if nowcast_method
+            in [
+                "extrapolation",
+                "eulerian",
+                "lagrangian",
+                "lagrangian_probability",
+                "probability",
+            ]
+            else r_input
         )
 
     # Calculate the blended field

--- a/pysteps/tests/test_blending_linear_blending.py
+++ b/pysteps/tests/test_blending_linear_blending.py
@@ -284,6 +284,96 @@ def test_linear_blending(
             )
 
 
+def test_linear_blending_ar_nowcast_3d_precip():
+    """Regression test: AR-based nowcast methods (e.g. sprog) require several past
+    precipitation fields (shape (ar_order + 1, m, n)) rather than a single 2D field.
+    forecast() used to always collapse a 3D precip input down to its last frame,
+    which broke these methods. This test checks that a 3D precip stack is passed
+    through to the nowcast method unmodified."""
+
+    np.random.seed(42)
+
+    timestep = 5
+    n_timesteps = 5
+
+    r_input = np.random.rand(3, 32, 32) * 5.0
+    r_input, _ = transformation.dB_transform(
+        r_input, None, threshold=0.1, zerovalue=-15.0
+    )
+    velocity = np.zeros((2, 32, 32))
+    r_nwp = np.random.rand(n_timesteps, 32, 32) * 5.0
+
+    r_blended = forecast(
+        r_input,
+        dict({"unit": "mm/h", "transform": "dB"}),
+        velocity,
+        n_timesteps,
+        timestep,
+        "sprog",
+        r_nwp,
+        dict({"unit": "mm/h", "transform": None}),
+        start_blending=10,
+        end_blending=20,
+        nowcast_kwargs=dict(n_cascade_levels=4, precip_thr=-10.0),
+    )
+
+    assert r_blended.shape == (
+        n_timesteps,
+        32,
+        32,
+    ), "The shape of the blended array does not have the expected value. The shape is {}".format(
+        r_blended.shape
+    )
+    assert np.all(
+        np.isfinite(r_blended)
+    ), "The blended array contains non-finite values"
+
+
+def test_linear_blending_timesteps_nowcast_clamp():
+    """Regression test: when end_blending / timestep exceeds the requested number of
+    timesteps, the nowcast used to be computed for more timesteps than precip_nwp
+    (and thus precip_blended) has. Combined with fill_nwp and NaNs in the nowcast,
+    this caused a shape mismatch when filling in the NWP data. timesteps_nowcast is
+    now clamped to timesteps to prevent this."""
+
+    timestep = 5
+    n_timesteps = 5
+
+    r_input = np.random.rand(32, 32) * 5.0
+    r_input, _ = transformation.dB_transform(
+        r_input, None, threshold=0.1, zerovalue=-15.0
+    )
+    r_input[0, 0] = np.nan
+    velocity = np.zeros((2, 32, 32))
+    r_nwp = np.random.rand(n_timesteps, 32, 32) * 5.0
+
+    # end_blending / timestep = 10, which is larger than n_timesteps = 5
+    r_blended = forecast(
+        r_input,
+        dict({"unit": "mm/h", "transform": "dB"}),
+        velocity,
+        n_timesteps,
+        timestep,
+        "eulerian",
+        r_nwp,
+        dict({"unit": "mm/h", "transform": None}),
+        start_blending=10,
+        end_blending=50,
+        fill_nwp=True,
+    )
+
+    assert r_blended.shape == (
+        n_timesteps,
+        32,
+        32,
+    ), "The shape of the blended array does not have the expected value. The shape is {}".format(
+        r_blended.shape
+    )
+    assert np.all(
+        np.isfinite(r_blended)
+    ), "The blended array contains non-finite values after filling with NWP data"
+
+
 ranked_salience_values = [
     (np.ones((200, 200)), np.ones((200, 200)), 0.9),
     (np.zeros((200, 200)), np.random.rand(200, 200), 0.7),


### PR DESCRIPTION
The pysteps short courses use the linear blending method, but it seems to be broken. The radar precip should just be passed to the nowcast method as is, since a nowcast method like steps expects all 3 timesteps to be there. If you want to run this with an extrapolation nowcast you should only pass the last timestep, just like you do when you call the extrapolation nowcast directly.